### PR TITLE
Update lang.php

### DIFF
--- a/web/includes/lang.php
+++ b/web/includes/lang.php
@@ -43,4 +43,18 @@ function loadLanguage( $prefix="" )
 if ( $langFile = loadLanguage() )
     require_once( $langFile );
 
+
+//
+// Date and time formats fallback, if not set up by the language file already
+//
+defined("DATE_FMT_CONSOLE_LONG") or define("DATE_FMT_CONSOLE_LONG", "D jS M, g:ia");		// This is the main console date/time, date() or strftime() format
+defined("DATE_FMT_CONSOLE_SHORT") or define( "DATE_FMT_CONSOLE_SHORT", "%H:%M" );		// This is the xHTML console date/time, date() or strftime() format
+
+defined("STRF_FMT_DATETIME") or define( "STRF_FMT_DATETIME", "%c" );				// Strftime locale aware format for dates with times
+defined("STRF_FMT_DATE") or define( "STRF_FMT_DATE", "%x" );					// Strftime locale aware format for dates without times
+defined("STRF_FMT_TIME") or define( "STRF_FMT_TIME", "%X" );					// Strftime locale aware format for times without dates
+
+defined("STRF_FMT_DATETIME_SHORT") or define( "STRF_FMT_DATETIME_SHORT", "%y/%m/%d %H:%M:%S" );	// Strftime shorter format for dates with time, not locale aware
+defined("STRF_FMT_DATETIME_SHORTER") or define( "STRF_FMT_DATETIME_SHORTER", "%m/%d %H:%M:%S" );// Strftime shorter format for dates with time, not locale aware, used where space is tight
+
 ?>


### PR DESCRIPTION
Add the ability to set up the Date and time formats by the language files, according to that language's regionals.
The patch allows to set up a global default, in case the language file doesn't contain the date and time definitions.

Here we look if the constants are already defined or not, if they are not, define them to the original defaults.
