### PR TITLE
Suppresses erroneous Corrupt Jpeg messages sent from the jpeg library

### DIFF
--- a/src/zm_jpeg.cpp
+++ b/src/zm_jpeg.cpp
@@ -59,7 +59,8 @@ void zm_jpeg_emit_message( j_common_ptr cinfo, int msg_level )
 		 */
 		if ( zmerr->pub.num_warnings == 0 || zmerr->pub.trace_level >= 3 )
 		{
-			(zmerr->pub.format_message)( cinfo, buffer ); 
+			(zmerr->pub.format_message)( cinfo, buffer );
+			if (!strstr(buffer, "Corrupt JPEG data:")) 
 			Warning( "%s", buffer );
 		}
 		/* Always count warnings in num_warnings. */


### PR DESCRIPTION
Certain Foscam cameras and their clones stream jpeg images that appear fine visually but have some kind of minor issue that causes the jpeg library to continually report a warning.  

Prior to this patch, Zoneminder would fill the log with events like this:
zmc_m1 10017 WAR Corrupt JPEG data: 1 extraneous bytes before marker 0xd9 zm_jpeg.cpp 63

This patch suppresses these warnings
