### PR TITLE
Update zmupdate.pl.in

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -967,19 +967,9 @@ if ( $version )
     }
 	if ( $cascade || $version lt "1.26.0" )
 	{
-		my $sth = $dbh->prepare_cached( 'select * from Monitors LIMIT 0,1' );
-		die "Error: " . $dbh->errstr . "\n" unless ($sth);
-		die "Error: " . $sth->errstr . "\n" unless ($sth->execute);
-
-		my $columns = $sth->{'NAME'};
-		if ( ! grep(/^Colours$/, @$columns ) ) {
-			$dbh->do(q{alter table Monitors add column `Colours` tinyint(3) unsigned NOT NULL default '1' after `Height`;});
-		} # end if
-		if ( ! grep(/^Deinterlacing$/, @$columns ) ) {
-			$dbh->do(q{alter table Monitors add column `Deinterlacing` INT unsigned NOT NULL default '0' after `Orientation`;});
-		} # end if
-		$sth->finish();
-		$cascade = !undef;
+        # Patch the database
+        patchDB( $dbh, "1.26.0" );
+        $cascade = !undef;
 	}
     if ( $cascade )
     {


### PR DESCRIPTION
Discovered an issue testing a database upgrade from 1.24.4 to 1.26.0.  The 1.26 upgrade would ignore supplied credentials and would only run with the default zmuser credentials.  This caused the upgrade to fail because zmuser does not have the ALTER dB permission.  

Further investigation revealed the patchDB() function, which appears to do all the hard work for us.  I'm not a Perl expert, but if I understand correctly the block of code that @connortechnology recently wrote can be replaced by a call to PatchDB as shown.  The PatchDB function will make use of --user & --pass if they are supplied. Note that this commit depends on commit 29ec57f. 
