### PR TITLE
Update zmupdate.pl.in to give option to convert to InnoDB tables

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -454,6 +454,35 @@ if ( $version )
         }
     }
 
+    sub toInnoDB
+    {
+	my $dbh = shift;
+	my $sql = "SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_schema='zm' AND engine = 'MyISAM'";
+	my $sth = $dbh->prepare_cached( $sql ) or die( "Can't prepare '$sql': ".$dbh->errstr() );
+	my $res = $sth->execute() or die( "Can't execute: ".$sth->errstr() );
+
+	my @dbTables;
+		while( my $dbTable = $sth->fetchrow() )
+		{
+	        push( @dbTables, $dbTable );
+        	}
+	$sth->finish();
+
+	if (@dbTables)
+	{
+		print "\nConverting MyISAM tables to InnoDB. Please wait.\n";
+	    	foreach (@dbTables)
+			{
+			my $sql = "ALTER TABLE $_ ENGINE = InnoDB";
+			my $sth = $dbh->prepare_cached( $sql ) or die( "Can't prepare '$sql': ".$dbh->errstr() );
+			my $res = $sth->execute() or die( "Can't execute: ".$sth->errstr() );
+			}
+	        $sth->finish();
+	} else {
+		print "\nNo MyISAM tables found. Skipping...\n";
+	}
+    }
+
     print( "\nUpgrading database to version ".ZM_VERSION."\n" );
 
     # Update config first of all
@@ -984,6 +1013,16 @@ if ( $version )
 			$dbh->do(q{alter table Monitors add column `Deinterlacing` INT unsigned NOT NULL default '0' after `Orientation`;});
 		} # end if
 		$sth->finish();
+
+		print( "\nPrevious versions of ZoneMinder used the MyISAM database engine.\nHowever, the recommended database engine is InnoDB.\n");
+		print( "\nHint: InnoDB tables are much less likely to be corrupted during an unclean shutdown.\n\nPress 'y' to convert your tables to InnoDB or 'n' to skip : ");
+        	my $response = <STDIN>;
+        	chomp( $response );
+        	if ( $response =~ /^[yY]$/ )
+        	{
+        	    toInnoDB($dbh);
+        	}
+
 		$cascade = !undef;
 	}
     if ( $cascade )


### PR DESCRIPTION
When upgrading the zoneminder database to 1.26, this proposed change will ask the user to convert existing MyISAM tables over InnoDB.  It first scans for existing MyISAM tables and will skip over any tables that are already converted to InnoDB.

I've tested this on (a copy of) a production database server and have verified it doesn't alter existing tables from a different schema.

And I'm done messing with the zmupdate script. I promise.
I understand if this change is considered outside the scope of a current bug fix release.
