### PR TITLE
edit zmupdate function in init script

### DIFF
--- a/scripts/zm.in
+++ b/scripts/zm.in
@@ -81,8 +81,8 @@ zmstatus()
 
 zmupdate()
 {
-	if [ -x $ZM_PATH_BIN/zm_update ]; then
-		$ZM_PATH_BIN/zm_update -f
+	if [ -x $ZM_PATH_BIN/zmupdate.pl ]; then
+		$ZM_PATH_BIN/zmupdate.pl -f
 	fi
 }
 


### PR DESCRIPTION
Noticed the init script was looking for a zm_update, which doesn't exist.  My best guess is that this should be changed to zmupdate.pl. This causes zoneminder to reload its configuration from the database prior to startup. Thoughts?
