### PR TITLE
Fix for Issue #88 - ZMS crashing

### DIFF
--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -196,7 +196,7 @@ User *zmLoadAuthUser( const char *auth, bool use_remote_addr )
 
 		char auth_key[512] = "";
 		char auth_md5[32+1] = "";
-      size_t md5len = 32;
+      size_t md5len = 16;
       unsigned char md5sum[md5len];
 
 		time_t now = time( 0 );


### PR DESCRIPTION
Previously, systems without gnutls were computing auth_md5 to be twice the size of what it was defined to be, thus causing zms to crash. The for loop at line 227 builds auth_md5 by looping every "2j", which means the upper limit (md5len) should be half the desired size of auth_md5.
