### PR TITLE
Update getBrowser() to match IE10

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -788,7 +788,7 @@ function getBrowser( &$browser, &$version )
     }
     else
     {
-        if ( preg_match( '/MSIE ([0-9].[0-9]{1,2})/', $_SERVER['HTTP_USER_AGENT'], $logVersion) )
+        if ( preg_match( '/MSIE (.*?);/', $_SERVER['HTTP_USER_AGENT'], $logVersion) )
         {
             $version = $logVersion[1];
             $browser = 'ie';


### PR DESCRIPTION
Updates the preg_match expression to match Internet Explorer 10. The previous pattern would not detect IE10, and hence zoneminder would not attempt to stream via Cambozola, which leaves IE10 users looking at a broken link.

NOTE: There is another file in the zoneminder source tree, AssetDispatcher.php, that also uses the same pattern match expression.  It is part of the Cake folder, which I am not familiar with.  Please advise if we should edit that file as well.
