### PR TITLE
Fix "Can't stat : No such file or directory" message

### DIFF
--- a/src/zmfix.cpp
+++ b/src/zmfix.cpp
@@ -166,7 +166,7 @@ int main( int argc, char *argv[] )
     // Yadda yadda
     mysql_free_result( result );
 
-    snprintf( sql, sizeof(sql), "select distinct ControlDevice from Monitors where not isnull(ControlDevice)" );
+    snprintf( sql, sizeof(sql), "select distinct ControlDevice from Monitors where not isEmpty(ControlDevice)" );
     if ( mysql_query( &dbconn, sql ) )
     {
         Error( "Can't run query: %s", mysql_error( &dbconn ) );


### PR DESCRIPTION
Many zoneminder systems have a "Can't stat : No such file or directory" in their logs each time zmfix is run. The problem was traced back to the sql query, which looked for a ControlDevice field that was not null.  However, the ControlDevice field is empty, rather than null, when there is no control device.
