### PR TITLE
Improve Chrome browser support & log streaming events

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -796,7 +796,15 @@ function getBrowser( &$browser, &$version )
         elseif ( preg_match( '/Chrome\/([0-9.]+)/', $_SERVER['HTTP_USER_AGENT'], $logVersion) )
         {
             $version = $logVersion[1];
-            $browser = 'chrome';
+            // Check for old version of Chrome with bug 5876
+            if ( $version < 7 )
+            {
+                $browser = 'oldchrome';
+            }
+            else
+            {
+                $browser = 'chrome';
+            }
         }
         elseif ( preg_match( '/Safari\/([0-9.]+)/', $_SERVER['HTTP_USER_AGENT'], $logVersion) )
         {
@@ -849,6 +857,13 @@ function isInternetExplorer()
     return( $browser == "ie" );
 }
 
+function isOldChrome()
+{
+    getBrowser( $browser, $version );
+
+    return( $browser == "oldchrome" );
+}
+
 function isChrome()
 {
     getBrowser( $browser, $version );
@@ -882,12 +897,17 @@ function canStreamIframe()
 
 function canStreamNative()
 {
-   // Chrome can display the stream, but then it blocks everything else (Chrome bug 5876)
-   return( ZM_WEB_CAN_STREAM == "yes" || ( ZM_WEB_CAN_STREAM == "auto" && (!isInternetExplorer() && !isChrome()) ) );
+   // Old versions of Chrome can display the stream, but then it blocks everything else (Chrome bug 5876)
+   return( ZM_WEB_CAN_STREAM == "yes" || ( ZM_WEB_CAN_STREAM == "auto" && (!isInternetExplorer() && !isOldChrome()) ) );
 }
 
 function canStreamApplet()
 {
+    if ( (ZM_OPT_CAMBOZOLA && !file_exists( ZM_PATH_WEB.'/'.ZM_PATH_CAMBOZOLA )) )
+    {
+        Warning ( "ZM_OPT_CAMBOZOLA is enabled, but the system cannot find ".ZM_PATH_WEB."/".ZM_PATH_CAMBOZOLA );
+    }
+
     return( (ZM_OPT_CAMBOZOLA && file_exists( ZM_PATH_WEB.'/'.ZM_PATH_CAMBOZOLA )) );
 }
 

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -55,6 +55,7 @@ else
 {
     $streamMode = "single";
     $streamSrc = getStreamSrc( array( "mode=".$streamMode, "monitor=".$monitor['Id'], "scale=".$scale ) );
+    Info( "The system has fallen back to single jpeg mode for streaming. Consider enabling Cambozola or upgrading the client browser.");
 }
 
 $showDvrControls = ( $streamMode == 'jpeg' && $monitor['StreamReplayBuffer'] != 0 );


### PR DESCRIPTION
Native streaming in Chrome was previously disabled due to Chrome bug 5876.  However that bug was fixed some time ago.  This commit enables native streaming for newer versions of Chrome that do not have this bug.

This commit also adds two new log events.  It adds a warning when OPT_CAMBOZOLA is enabled, but the system cannot find the cambozola.jar file.  Also, an informational event is created any-time the system has to fall back to single jpeg mode for streaming.  

These events are intended to aid in troubleshooting browser streaming issues.
