### PR TITLE
Updated cmake for the modern WebUI branch

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -1,11 +1,8 @@
 # CMakeLists.txt for the ZoneMinder web files
 
-# Process the tools/mootools subdirectory
-add_subdirectory(tools/mootools tools/mootools)
-
 # Create files from the .in files
-configure_file(includes/config.php.in ${CMAKE_CURRENT_SOURCE_DIR}/includes/config.php @ONLY)
+#configure_file(app/Config/config.php.in ${CMAKE_CURRENT_SOURCE_DIR}/app/Config/config.php @ONLY)
 
 # Install the web files
-install(DIRECTORY ajax css graphics includes js lang skins tools views DESTINATION "${ZM_WEBDIR}" PATTERN "*.in" EXCLUDE PATTERN "*Make*" EXCLUDE)
+install(DIRECTORY app lib DESTINATION "${ZM_WEBDIR}" PATTERN "*.in" EXCLUDE PATTERN "*Make*" EXCLUDE PATTERN "*cmake*" EXCLUDE)
 install(FILES index.php README.md DESTINATION "${ZM_WEBDIR}")


### PR DESCRIPTION
Updated the web/CMakeLists.txt file for the modern WebUI branch.

I could not find any config file in that directory that autotools/cmake should setup. You need something like include/config.php that has stuff like @ZM_DB_NAME@ and other important variables.
