### PR TITLE
Change Prev Button functionality

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -1161,9 +1161,10 @@ void EventStream::checkEventLoaded()
                 loadEventData( event_id );
 
                 Debug( 2, "Current frame id = %d", curr_frame_id );
-                if ( curr_frame_id <= 0 )
-                    curr_frame_id = event_data->frame_count;
-                else
+//		When loading a new event, always set the current frame id to the first frame rather than the last
+//                if ( curr_frame_id <= 0 )
+//                    curr_frame_id = event_data->frame_count;
+//                else
                     curr_frame_id = 1;
                 Debug( 2, "New frame id = %d", curr_frame_id );
             }


### PR DESCRIPTION
When loading a new event, always set the current frame id to the first frame rather than the last
