### PR TITLE
Fix marker-out-of-bounds crash when defining zone points

### DIFF
--- a/src/zm_zone.cpp
+++ b/src/zm_zone.cpp
@@ -956,12 +956,16 @@ int Zone::Load( Monitor *monitor, Zone **&zones )
 
 		Debug( 5, "Parsing polygon %s", Coords );
 		Polygon polygon;
-		if ( !ParsePolygonString( Coords, polygon ) )
-			Panic( "Unable to parse polygon string '%s' for zone %d/%s for monitor %s", Coords, Id, Name, monitor->Name() );
+		if ( !ParsePolygonString( Coords, polygon ) ) {
+			Error( "Unable to parse polygon string '%s' for zone %d/%s for monitor %s, ignoring", Coords, Id, Name, monitor->Name() );
+            continue;
+        }
 
 		if ( polygon.LoX() < 0 || polygon.HiX() >= (int)monitor->Width() 
-           || polygon.LoY() < 0 || polygon.HiY() >= (int)monitor->Height() )
-			Panic( "Zone %d/%s for monitor %s extends outside of image dimensions, %d, %d, %d, %d", Id, Name, monitor->Name(), polygon.LoX(), polygon.LoY(), polygon.HiX(), polygon.HiY() );
+           || polygon.LoY() < 0 || polygon.HiY() >= (int)monitor->Height() ) {
+			Error( "Zone %d/%s for monitor %s extends outside of image dimensions, (%d,%d), (%d,%d), ignoring", Id, Name, monitor->Name(), polygon.LoX(), polygon.LoY(), polygon.HiX(), polygon.HiY() );
+            continue;
+        }
 
 		if ( false && !strcmp( Units, "Percent" ) )
 		{

--- a/web/skins/classic/views/css/zone.css
+++ b/web/skins/classic/views/css/zone.css
@@ -33,9 +33,13 @@
     position: relative;
 }
 
+/* NB: The size of the imageFrame determines the area within which the markers
+ * may be moved.  When adjusting the padding and margins of the imageFrame and
+ * the DIVs within it, test that the markers behave sensibly when dragged to
+ * the extreme edges of the imageFrame. */
 #imageFrame {
     position: relative;
-    padding: 0 6px 6px 0; /* Double margin of points below */
+    padding: 0 3px 3px 0; /* Compensate for negative margins in the markers just below. */
 }
 
 #imageFrame div {

--- a/web/skins/classic/views/js/zone.js
+++ b/web/skins/classic/views/js/zone.js
@@ -255,30 +255,13 @@ function applyZoneUnits()
 
 function limitRange( field, minValue, maxValue )
 {
-    if ( parseInt(field.value) < parseInt(minValue) )
-    {
-        field.value = minValue;
-    }
-    else if ( parseInt(field.value) > parseInt(maxValue) )
-    {
-        field.value = maxValue;
-    }
+    field.value = constrainValue( parseInt(field.value), parseInt(minValue), parseInt(maxValue) );
 }
 
 function limitFilter( field )
 {
-    var minValue = 3;
-    var maxValue = 15;
-
     field.value = (Math.floor((field.value-1)/2)*2) + 1;
-    if ( parseInt(field.value) < minValue )
-    {
-        field.value = minValue;
-    }
-    if ( parseInt(field.value) > maxValue )
-    {
-        field.value = maxValue;
-    }
+    field.value = constrainValue(parseInt(field.value), 3, 15);
 }
 
 function limitArea( field )
@@ -352,11 +335,22 @@ function fixActivePoint( index )
     updateZoneImage();
 }
 
+function constrainValue( value, loVal, hiVal )
+{
+    if ( value < loVal ) {
+        return loVal;
+    }
+    if ( value > hiVal ) {
+        return hiVal;
+    }
+    return value;
+}
+
 function updateActivePoint( index )
 {
     var point = $('point'+index);
-    var x = point.getStyle( 'left' ).toInt();
-    var y = point.getStyle( 'top' ).toInt();
+    var x = constrainValue( point.getStyle( 'left' ).toInt(), 0, maxX );
+    var y = constrainValue( point.getStyle( 'top' ).toInt(), 0, maxY );
 
     $('newZone[Points]['+index+'][x]').value = x;
     $('newZone[Points]['+index+'][y]').value = y;
@@ -387,10 +381,7 @@ function delPoint( index )
 
 function limitPointValue( point, loVal, hiVal )
 {
-    if ( point.value < loVal )
-        point.value = 0;
-    else if ( point.value > hiVal )
-        point.value = hiVal;
+    point.value = constrainValue(point.value, loVal, hiVal)
 }
 
 function updateX( index )


### PR DESCRIPTION
In the zone definition view, I can drag markers up to 3 pixels beyond the right and bottom edges of the image.  These values are accepted without validation and cause the zma process to crash loop.

"Zone 9/New for monitor Living extends outside of image dimensions, 0, 0, 642, 482"

This change:
1. Fixes the CSS problem that allowed me to drag elements beyond the bounds of the image
2. Fixes the Javascript so that it will validate drag-based coordinate inputs in case the CSS regresses
3. Reclassifies this situation from Panic -> Error, since there is a reasonable recovery path here (ignore the zone) that is better than crashing.
