### PR TITLE
Re-Add ZM_PATH_DATA

### DIFF
--- a/zm.conf.in
+++ b/zm.conf.in
@@ -12,8 +12,11 @@
 # Current version of ZoneMinder
 ZM_VERSION=@VERSION@
 
-# Path to build directory, used mostly for finding DB upgrade scripts
+# Path to build directory
 ZM_PATH_BUILD=@PATH_BUILD@
+
+# Path to installed data directory, used mostly for finding DB upgrade scripts
+ZM_PATH_DATA=@PKGDATADIR@
 
 # Build time, used to record when to trigger various checks
 ZM_TIME_BUILD=@TIME_BUILD@


### PR DESCRIPTION
@connortechnology
I'm not sure if you've noticed my previous attempts to point this out, so I'm creating a pull request.

Since merging pull request https://github.com/ZoneMinder/ZoneMinder/pull/200 zmupdate no longer uses ZM_PATH_BUILD as the default folder for sql files.  Instead, it uses ZM_PATH_DATA.  Please refer to the description in pull request #200 for details.
