### PR TITLE
Delete PATH_BUILD and TIME_BUILD from zm.conf and fix ZM_DB_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,9 +418,7 @@ message(STATUS "Using web group: ${ZM_WEB_GROUP}")
 set(ZM_PID "${ZM_RUNDIR}/zm.pid")
 set(ZM_CONFIG "/${CMAKE_INSTALL_SYSCONFDIR}/zm.conf")
 set(VERSION "${zoneminder_VERSION}")
-set(PATH_BUILD "${PROJECT_SOURCE_DIR}")
 set(PKGDATADIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/zoneminder")
-set(TIME_BUILD "1000000") # Don't have a solution for this one yet
 set(BINDIR "${CMAKE_INSTALL_FULL_BINDIR}")
 set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 set(SYSCONFDIR "/${CMAKE_INSTALL_SYSCONFDIR}")
@@ -428,6 +426,7 @@ set(WEB_PREFIX "${ZM_WEBDIR}")
 set(CGI_PREFIX "${ZM_CGIDIR}")
 set(WEB_USER "${ZM_WEB_USER}")
 set(WEB_GROUP "${ZM_WEB_GROUP}")
+set(ZM_DB_TYPE "mysql")
 set(EXTRA_PERL_LIB "use lib '${ZM_PERL_USE_PATH}';")
 
 # Reassign some variables if a target distro has been specified

--- a/configure.ac
+++ b/configure.ac
@@ -6,10 +6,6 @@ AC_CONFIG_HEADERS(config.h)
 
 AC_SUBST([AM_CXXFLAGS], [-D__STDC_CONSTANT_MACROS])
 
-PATH_BUILD=`pwd`
-AC_SUBST(PATH_BUILD)
-TIME_BUILD=`date +'%s'`
-AC_SUBST(TIME_BUILD)
 AC_SUBST(VERSION)
 
 AC_ARG_VAR(ZM_DB_HOST,[Hostname where ZoneMinder database located, default localhost])
@@ -22,6 +18,9 @@ AC_ARG_VAR(ZM_RUNDIR,[Location of transient process files, default /var/run/zm])
 AC_ARG_VAR(ZM_TMPDIR,[Location of temporary files, default /tmp/zm])
 AC_ARG_VAR(ZM_LOGDIR,[Location of generated log files, default /var/log/zm])
 
+if test "$ZM_DB_TYPE" == ""; then
+	AC_SUBST(ZM_DB_HOST,[mysql])
+fi
 if test "$ZM_DB_HOST" == ""; then
 	AC_SUBST(ZM_DB_HOST,[localhost])
 fi

--- a/zm.conf.in
+++ b/zm.conf.in
@@ -9,12 +9,6 @@
 # or installations.
 #
 
-# Path to build directory
-ZM_PATH_BUILD=@PATH_BUILD@
-
-# Build time, used to record when to trigger various checks
-ZM_TIME_BUILD=@TIME_BUILD@
-
 # Path to installed data directory, used mostly for finding DB upgrade scripts
 ZM_PATH_DATA=@PKGDATADIR@
 
@@ -37,7 +31,7 @@ ZM_PATH_CGI=@CGI_PREFIX@
 ZM_WEB_USER=@WEB_USER@
 ZM_WEB_GROUP=@WEB_GROUP@
 
-# ZoneMinder database type: so far only mysql is supported
+# ZoneMinder database type
 ZM_DB_TYPE=@ZM_DB_TYPE@
 
 # ZoneMinder database hostname or ip address


### PR DESCRIPTION
I can't see any reason why we still need PATH_BUILD and TIME_BUILD.
This pull request also sets up ZM_DB_TYPE default to be mysql for now.
