### PR TITLE
Fix checkJsonError messages

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2225,10 +2225,11 @@ function isVector ( &$array )
     return( true );
 }
 
-function checkJsonError()
+function checkJsonError($value)
 {
     if ( function_exists('json_last_error') )
     {
+        $value = var_export($value,true);
         switch( json_last_error() )
         {
             case JSON_ERROR_DEPTH :
@@ -2252,7 +2253,7 @@ function jsonEncode( &$value )
     if ( function_exists('json_encode') )
     {
         $string = json_encode( $value );
-        checkJsonError();
+        checkJsonError($value);
         return( $string );
     }
 
@@ -2293,7 +2294,7 @@ function jsonDecode( $value )
     if ( function_exists('json_decode') )
     {
         $object = json_decode( $value, true );
-        checkJsonError();
+        checkJsonError($value);
         return( $object );
     }
 


### PR DESCRIPTION
The $value string was not set inside checkJsonError, so it was not possible to see the data which caused the error
