### PR TITLE
Allow AUTH_TYPE remote to work

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -40,6 +40,12 @@ if ( ZM_OPT_USE_AUTH && ZM_AUTH_HASH_LOGINS && empty($user) && !empty($_REQUEST[
     }
 }
 
+if ( ZM_AUTH_TYPE == 'remote' && empty($user) && !empty($_SERVER['REMOTE_USER']) )
+{
+    userLogin($_SERVER['REMOTE_USER']);
+}
+
+
 if ( !empty($action) )
 {
     // General scope actions


### PR DESCRIPTION
Not sure what changed, but AUTH_TYPE=remote no longer worked for me in 1.26.4 but did work in 1.25.0, this fixed it.

Feel free to explain how AUTH_TYPE=remote should/used to work. My tracing led to the skins.php file that set a view and actions, but then nothing that followed it used the actions, so the actions variable was nulled in the page refresh. I can see that you can override the actions.php file in a skin, but that doesn't seem like the right place for Auth code.
