### PR TITLE
Disables non-POSIX warning when using gnu wildcard

### DIFF
--- a/db/Makefile.am
+++ b/db/Makefile.am
@@ -1,4 +1,4 @@
-AUTOMAKE_OPTIONS = gnu
+AUTOMAKE_OPTIONS = foreign
 
 zmdbdatadir = $(pkgdatadir)/db
 


### PR DESCRIPTION
From commit# e68fd9db914b446867564d5c3695e1e6fac0927f
The following warning could previously be seen when building zoneminder:

```
db/Makefile.am:13: wildcard zm_update-*.sql: non-POSIX variable name
db/Makefile.am:13: (probably a GNU make extension)
```

This request removes the warning.
