### PR TITLE
Enclose value of the Notes attribute with quotes.

### DIFF
--- a/web/skins/classic/includes/timeline_functions.php
+++ b/web/skins/classic/includes/timeline_functions.php
@@ -242,6 +242,9 @@ function parseFilterToTree( $filter )
                         case 'Weekday':
                             $value = "weekday( '".strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) )."' )";
                             break;
+                        case 'Notes':
+                            $value = "'".$value."'";
+                            break;
                     }
                     $valueList[] = $value;
                 }


### PR DESCRIPTION
Fix SQL-ERR using Timeline after executing Filter matching on string with whitespace.  See issue #291.
