### PR TITLE
Enclose value of the Notes attribute with quotes.

### DIFF
--- a/web/skins/classic/includes/timeline_functions.php
+++ b/web/skins/classic/includes/timeline_functions.php
@@ -228,6 +228,7 @@ function parseFilterToTree( $filter )
                         case 'MonitorName':
                         case 'Name':
                         case 'Cause':
+                        case 'Notes':
                             $value = "'$value'";
                             break;
                         case 'DateTime':


### PR DESCRIPTION
Also enclose Notes attribute with quotes when using timeline from a filter.  See issue #291.
