### PR TITLE
Change comments for many Camera subclasses

### DIFF
--- a/src/zm_curl_camera.h
+++ b/src/zm_curl_camera.h
@@ -36,8 +36,8 @@
 #endif
 
 //
-// Class representing 'remote' cameras, i.e. those which are
-// accessed over a network connection.
+// Class representing 'curl' cameras, i.e. those which are
+// accessed using the curl library
 //
 class cURLCamera : public Camera
 {

--- a/src/zm_ffmpeg_camera.h
+++ b/src/zm_ffmpeg_camera.h
@@ -27,8 +27,8 @@
 #include "zm_ffmpeg.h"
 
 //
-// Class representing 'remote' cameras, i.e. those which are
-// accessed over a network connection.
+// Class representing 'ffmpeg' cameras, i.e. those which are
+// accessed using ffmpeg multimedia framework
 //
 class FfmpegCamera : public Camera
 {

--- a/src/zm_file_camera.h
+++ b/src/zm_file_camera.h
@@ -28,7 +28,7 @@
 
 //
 // Class representing 'file' cameras, i.e. those which are
-// accessed over a network connection.
+// accessed using a single file which contains the latest jpeg data
 //
 class FileCamera : public Camera
 {

--- a/src/zm_remote_camera_http.h
+++ b/src/zm_remote_camera_http.h
@@ -27,8 +27,8 @@
 #include "zm_utils.h"
 
 //
-// Class representing 'remote' cameras, i.e. those which are
-// accessed over a network connection.
+// Class representing 'http' cameras, i.e. those which are
+// accessed over a network connection using http
 //
 class RemoteCameraHttp : public RemoteCamera
 {

--- a/src/zm_remote_camera_rtsp.h
+++ b/src/zm_remote_camera_rtsp.h
@@ -28,8 +28,9 @@
 #include "zm_ffmpeg.h"
 
 //
-// Class representing 'remote' cameras, i.e. those which are
-// accessed over a network connection.
+// Class representing 'rtsp' cameras, i.e. those which are
+// accessed over a network connection using rtsp protocol
+// (Real Time Streaming Protocol)
 //
 class RemoteCameraRtsp : public RemoteCamera
 {


### PR DESCRIPTION
Have comments for Camera subclasses match the subclasses. When subclasses were copied, the comments were often left the same as the copied subclass.
