### PR TITLE
Make zmpkg.pl check for more required directories other than just @ZM_TMPDIR@

### DIFF
--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -152,19 +152,32 @@ if ( $command =~ /^(?:start|restart)$/ )
             exit( -1 );
         }
 
-        # Recreate the temporary directory if it's been wiped
-        if ( !-e "@ZM_TMPDIR@" )
-        {
-            Debug( "Recreating temporary directory '@ZM_TMPDIR@'" );
-            mkdir( "@ZM_TMPDIR@", 0700 ) or Fatal( "Can't create missing temporary directory '@ZM_TMPDIR@': $!" );
-            my ( $runName ) = getpwuid( $> );
-            if ( $runName ne $Config{ZM_WEB_USER} )
-            {
-                # Not running as web user, so should be root in whch case chown the temporary directory
-                my ( $webName, $webPass, $webUid, $webGid ) = getpwnam( $Config{ZM_WEB_USER} ) or Fatal( "Can't get user details for web user '".$Config{ZM_WEB_USER}."': $!" );
-                chown( $webUid, $webGid, "@ZM_TMPDIR@" ) or Fatal( "Can't change ownership of temporary directory '@ZM_TMPDIR@' to '".$Config{ZM_WEB_USER}.":".$Config{ZM_WEB_GROUP}."': $!" );
-            }
-        }
+	my @zm_dirs_check = ('@ZM_TMPDIR@', $Config{ZM_PATH_SOCKS}, $Config{ZM_PATH_SWAP});
+	my @zm_dirs_missing;
+
+	# Check for some key directories for existance and recreate before we surrender root privileges
+	foreach (@zm_dirs_check)
+	{
+		Debug("Checking for $_");
+		push @zm_dirs_missing,$_ if (!-e $_ );
+	}
+
+	# Remove duplicates
+	my %temphash = map { $_, 1 } @zm_dirs_missing;
+	@zm_dirs_missing = keys %temphash;
+
+	foreach (@zm_dirs_missing)
+	{
+		Debug( "Recreating directory '$_'" );
+		mkdir( $_, 0700 ) or Fatal( "Can't create missing directory $_: $!" );
+		my ( $runName ) = getpwuid( $> );
+		if ( $runName ne $Config{ZM_WEB_USER} )
+		{
+                	# Not running as web user, so should be root in whch case chown the directory
+                	my ( $webName, $webPass, $webUid, $webGid ) = getpwnam( $Config{ZM_WEB_USER} ) or Fatal( "Can't get user details for web user '".$Config{ZM_WEB_USER}."': $!" );
+                	chown( $webUid, $webGid, $_ ) or Fatal( "Can't change ownership of directory $_ to '".$Config{ZM_WEB_USER}.":".$Config{ZM_WEB_GROUP}."': $!" );
+		}
+	}
 		zmMemTidy();
 		runCommand( "zmdc.pl startup" );
 


### PR DESCRIPTION
Prefaces:
- This may not be all that clean, but it's close and avoids repitition.
- My Perl fu may be bad; apologies, but I'm normally allergic to perl anyway ;)

I believe `zmpkg.pl` should do more thorough checking of vital directories, after I decided to move `ZM_PATH_SOCKS` and `ZM_PATH_SWAP` to Debian's `/run` (effectively making those `tmpfs`-based.)  It tends to currently assume that all configurable paths will be user-configured under a build-time macro -- that being `@ZM_TMPDIR@`.

I did find patches to distro-based scripts, like 11d0428a206d9173dedd3c2ad9bfbf21df29cf58, but I believe this is the wrong place to assure directories that are configurable within ZoneMinder actually exist.  I've also noticed that ZM leaves sockets and stuff from `ZM_PATH_SWAP` behind too upon shutdown, but that's for another day, maybe.
