### PR TITLE
Fix prev button while in gapless mode.  All buttons tested and working.

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -877,6 +877,11 @@ void EventStream::processCommand( const CmdMsg *msg )
                 // Clear paused flag
                 paused = false;
             }
+
+	    // If we are in single event mode and at the last frame, replay the current event
+	    if ( (mode == MODE_SINGLE) && (curr_frame_id == event_data->frame_count) )
+		curr_frame_id = 1;
+
             replay_rate = ZM_RATE_BASE;
             break;
         }


### PR DESCRIPTION
I use Gapless mode almost exclusively.  Prior to this commit, pressing the previous button would cause zoneminder to load the last frame in the previous event.  Zoneminder would then immediately load the next event, which was the same event the user just watched.

This commit causes zoneminder to load the first frame in the previous event once the Prev button is pressed.  I've tested all the buttons to make sure none of them were adversely affected by this commit.

@barjac Any chance you could patch this into one of your builds and give this a second look?
