### PR TITLE
fix eyezm authentication issue

### DIFF
--- a/web/skins/xml/skin.php
+++ b/web/skins/xml/skin.php
@@ -28,7 +28,7 @@ foreach ( getSkinIncludes( 'includes/functions.php' ) as $includeFile )
     require_once $includeFile;
 
 if ( empty($view) )
-	$view = isset($user)?'console':'login';
+     $view = 'console';
 
 if ( !isset($user) && ZM_OPT_USE_AUTH && ZM_AUTH_TYPE == "remote" && !empty( $_SERVER['REMOTE_USER']) )
 {


### PR DESCRIPTION
This pull request was taken from the forum:
http://www.zoneminder.com/forums/viewtopic.php?p=83665#p83665

I believe this issue with eyezm was created by previous attempts to fix remote authentication, which means this commit is related to these commits:
26be1bd041c5ff249dd3412c616df1923c0153c0
6e5d9272e03783683f9db1665e63e84cdc506a68

Please note that I have no way to test this change myself.
