### PR TITLE
Reduce window size to exclude task bar area

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -71,6 +71,23 @@ var popupSizes = {
 
 var popupOptions = "resizable,scrollbars,status=no";
 
+function checkSize() {
+    if (window.outerHeight) {
+        var w = window.outerWidth;
+        var prevW = w;
+        var h = window.outerHeight;
+        var prevH = h;
+        if (h > screen.availHeight)
+            h  = screen.availHeight;
+        if (w > screen.availWidth)
+            w  = screen.availWidth;
+        if (w != prevW || h != prevH)
+            window.resizeTo(w,h);
+    }
+}
+
+window.addEvent( 'domready', checkSize);
+
 // Deprecated
 function newWindow( url, name, width, height )
 {

--- a/web/skins/flat/js/skin.js
+++ b/web/skins/flat/js/skin.js
@@ -71,6 +71,23 @@ var popupSizes = {
 
 var popupOptions = "resizable,scrollbars,status=no";
 
+function checkSize() {
+    if (window.outerHeight) {
+        var w = window.outerWidth;
+        var prevW = w;
+        var h = window.outerHeight;
+        var prevH = h;
+        if (h > screen.availHeight)
+            h  = screen.availHeight;
+        if (w > screen.availWidth)
+            w  = screen.availWidth;
+        if (w != prevW || h != prevH)
+            window.resizeTo(w,h);
+    }
+}
+
+window.addEvent( 'domready', checkSize);
+
 // Deprecated
 function newWindow( url, name, width, height )
 {


### PR DESCRIPTION
Just as a base for discussion, not sure where such functionality should be best placed:

When openig windows for zone definition or event frames for HD cameras where the image size is larger than current screen resolution, the windows extend under the task bar area.
Controls on the lower edge of the window (Add new zone, next frame...) are now hard to reach: The window must be manually resized and moved (or maximized) to get at these controls.

On browsers where a window.outerHeight Property is available, it's possible to resize the windows so they fit in the available screen area (i.e, Screen height - task bar height). For me this makes working with HD cameras much easier.

Works in Current Chrome, Firefox and IE11. Doesn't work for IE<11
