### PR TITLE
Fix 'Undefined index: filter' php warnings for filter view when

### DIFF
--- a/web/skins/classic/views/filter.php
+++ b/web/skins/classic/views/filter.php
@@ -160,7 +160,7 @@ xhtmlHeaders(__FILE__, $SLANG['EventFilter'] );
         <table id="fieldsTable" class="filterTable" cellspacing="0">
           <tbody>
 <?php
-for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
+for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['terms']); $i++ )
 {
 ?>
             <tr>

--- a/web/skins/classic/views/js/filter.js.php
+++ b/web/skins/classic/views/js/filter.js.php
@@ -1,9 +1,8 @@
 var deleteSavedFilterString = "<?= $SLANG['DeleteSavedFilter'] ?>";
-
 function validateForm( form )
 {
 <?php
-if ( count($_REQUEST['filter']['terms']) > 2 )
+if ( isset ($_REQUEST['filter']) && count($_REQUEST['filter']['terms']) > 2 )
 {
 ?>
     var bracket_count = 0;
@@ -27,7 +26,7 @@ for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
 }
 ?>
 <?php
-for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
+for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['terms']); $i++ )
 {
 ?>
     var val = form.elements['filter[terms][<?= $i ?>][val]'];

--- a/web/skins/flat/views/filter.php
+++ b/web/skins/flat/views/filter.php
@@ -160,7 +160,7 @@ xhtmlHeaders(__FILE__, $SLANG['EventFilter'] );
         <table id="fieldsTable" class="filterTable" cellspacing="0">
           <tbody>
 <?php
-for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
+for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['terms']); $i++ )
 {
 ?>
             <tr>

--- a/web/skins/flat/views/js/filter.js.php
+++ b/web/skins/flat/views/js/filter.js.php
@@ -3,7 +3,7 @@ var deleteSavedFilterString = "<?= $SLANG['DeleteSavedFilter'] ?>";
 function validateForm( form )
 {
 <?php
-if ( count($_REQUEST['filter']['terms']) > 2 )
+if ( isset ($_REQUEST['filter']) && count($_REQUEST['filter']['terms']) > 2 )
 {
 ?>
     var bracket_count = 0;
@@ -27,7 +27,7 @@ for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
 }
 ?>
 <?php
-for ( $i = 0; $i < count($_REQUEST['filter']['terms']); $i++ )
+for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['terms']); $i++ )
 {
 ?>
     var val = form.elements['filter[terms][<?= $i ?>][val]'];


### PR DESCRIPTION
 called without filter arguments. 
Opening the filter window from the generic/unfiltered event list will result in php warnings in the log. See issue #369. 
