### PR TITLE
do not quote column names in parse filter

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1406,7 +1406,7 @@ function parseFilter( &$filter, $saveToSession=false, $querySep='&amp;' )
                     case 'Cause':
                     case 'Notes':
                     case 'Archived':
-                        $filter['sql'] .= dbEscape('E.'.$filter['terms'][$i]['attr']);
+                        $filter['sql'] .= "E.".$filter['terms'][$i]['attr'];
                         break;
                     case 'DiskPercent':
                         $filter['sql'] .= getDiskPercent();


### PR DESCRIPTION
As described in issue #364, event counters on the console are not displayed because changes in php db handling cause dbEscape function to emit  single quotes around the argument to be escaped. This doesn't work for column names.
Since the colum names to be added to the sql are already known to be OK (selected in switch statement) we can drop the dbEscape for the column name.
