### PR TITLE
Fix reload loop on switching skins

### DIFF
--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -87,7 +87,7 @@ if($tab == 'skins') {
 	if (isset($_GET['skin-choice'])) {
 		setcookie('zmSkin',$_GET['skin-choice']);
 		//header("Location: index.php?view=options&tab=skins&reset_parent=1");
-		echo '<script type="text/javascript">window.opener.location.reload();window.location.reload();</script>';
+		echo "<script type=\"text/javascript\">window.opener.location.reload();window.location.href=\"{$_SERVER['PHP_SELF']}?view={$view}&tab={$tab}\"</script>";
 	}
 
 ?>

--- a/web/skins/flat/views/options.php
+++ b/web/skins/flat/views/options.php
@@ -87,7 +87,7 @@ if($tab == 'skins') {
 	if (isset($_GET['skin-choice'])) {
 		setcookie('zmSkin',$_GET['skin-choice']);
 		//header("Location: index.php?view=options&tab=skins&reset_parent=1");
-		echo '<script type="text/javascript">window.opener.location.reload();window.location.reload();</script>';
+		echo "<script type=\"text/javascript\">window.opener.location.reload();window.location.href=\"{$_SERVER['PHP_SELF']}?view={$view}&tab={$tab}\"</script>";
 	}
 
 ?>


### PR DESCRIPTION
Fix for this issue: 
When selecting a new skin in options/display and clicking "SAVE", the options and console windows go into a reload loop, the options window has to be closed to recover.

Partial fix for #378. put in a seperate request because its a self contained bug fix.
