### PR TITLE
Fix window sizes and input field sizes for flat skin

### DIFF
--- a/web/skins/flat/css/skin.css
+++ b/web/skins/flat/css/skin.css
@@ -97,7 +97,7 @@ input,textarea,select,button {
     color: #333333;
 }
 
-input[type=text], input[type=password], textarea {
+input[type=text], input[type=password], textarea, select {
     padding: 1px;
 }
 
@@ -432,7 +432,7 @@ th.table-th-sort-rev span.table-th-sort-span {
 }
 
 #content table input[type=submit], #content table input[type=button], #content table button {
-    margin-top: 0;
+    margin-top: 1px;
 }
 
 #contentButtons {

--- a/web/skins/flat/js/skin.js
+++ b/web/skins/flat/js/skin.js
@@ -24,7 +24,7 @@
 
 // Javascript window sizes
 var popupSizes = {
-    'bandwidth':    { 'width': 260, 'height': 130 },
+    'bandwidth':    { 'width': 280, 'height': 160 },
     'console':      { 'width': 750, 'height': 312 },
     'control':      { 'width': 380, 'height': 480 },
     'controlcaps':  { 'width': 780, 'height': 320 },
@@ -34,33 +34,33 @@ var popupSizes = {
     'devices':      { 'width': 400, 'height': 240 },
     'donate':       { 'width': 500, 'height': 280 },
     'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 200, minHeight: 540 },
-    'eventdetail':  { 'width': 400, 'height': 220 },
-    'events':       { 'width': 760, 'height': 480 },
+    'eventdetail':  { 'width': 560, 'height': 290 },
+    'events':       { 'width': 1020, 'height': 480 },
     'export':       { 'width': 400, 'height': 340 },
-    'filter':       { 'width': 720, 'height': 360 },
+    'filter':       { 'width': 740, 'height': 390 },
     'filtersave':   { 'width': 560, 'height': 160 },
     'frame':        { 'addWidth': 32, 'minWidth': 384, 'addHeight': 100 },
     'frames':       { 'width': 500, 'height': 300 },
-    'function':     { 'width': 248, 'height': 92 },
+    'function':     { 'width': 248, 'height': 130 },
     'group':        { 'width': 360, 'height': 180 },
     'groups':       { 'width': 460, 'height': 220 },
     'image':        { 'addWidth': 48, 'addHeight': 80 },
     'log':          { 'width': 980, 'height': 720 },
     'login':        { 'width': 720, 'height': 480 },
     'logout':       { 'width': 240, 'height': 100 },
-    'monitor':      { 'width': 480, 'height': 364 },
-    'monitorpreset':{ 'width': 400, 'height': 200 },
+    'monitor':      { 'width': 500, 'height': 620 },
+    'monitorpreset':{ 'width': 400, 'height': 250 },
     'monitorprobe': { 'width': 500, 'height': 240 },
     'monitorselect':{ 'width': 160, 'height': 200 },
     'montage':      { 'width': -1, 'height': -1 },
     'optionhelp':   { 'width': 400, 'height': 320 },
-    'options':      { 'width': 1300, 'height': 620 },
+    'options':      { 'width': 1370, 'height': 620 },
     'preset':       { 'width': 300, 'height': 120 },
     'settings':     { 'width': 200, 'height': 225 },
     'state':        { 'width': 400, 'height': 154 },
     'stats':        { 'width': 740, 'height': 200 },
     'timeline':     { 'width': 760, 'height': 540 },
-    'user':         { 'width': 320, 'height': 420 },
+    'user':         { 'width': 340, 'height': 680 },
     'version':      { 'width': 440, 'height': 160 },
     'video':        { 'width': 420, 'height': 360 },
     'videoview':    { 'addWidth': 48, 'addHeight': 80 },
@@ -146,6 +146,7 @@ function createPopup( url, name, tag, width, height )
     if ( popupSize.height > 0 )
         popupDimensions += ",height="+popupSize.height;
     var popup = window.open( url, name, popupOptions+popupDimensions );
+    popup.focus();
 }
 
 function createEventPopup( eventId, eventFilter, width, height )

--- a/web/skins/flat/views/filter.php
+++ b/web/skins/flat/views/filter.php
@@ -194,14 +194,14 @@ for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['term
         {
 ?>
               <td><?= buildSelect( "filter[terms][$i][op]", $opTypes ); ?></td>
-              <td><input name="filter[terms][<?= $i ?>][val]" id="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?validHtmlStr($_REQUEST['filter']['terms'][$i]['val']):'' ?>"/><?php if ( $hasCal ) { ?><script type="text/javascript">Calendar.setup( { inputField: "filter[terms][<?= $i ?>][val]", ifFormat: "%Y-%m-%d %H:%M", showsTime: true, timeFormat: "24", showOthers: true, weekNumbers: false });</script><?php } ?></td>
+              <td><input type="text" name="filter[terms][<?= $i ?>][val]" id="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?validHtmlStr($_REQUEST['filter']['terms'][$i]['val']):'' ?>"/><?php if ( $hasCal ) { ?><script type="text/javascript">Calendar.setup( { inputField: "filter[terms][<?= $i ?>][val]", ifFormat: "%Y-%m-%d %H:%M", showsTime: true, timeFormat: "24", showOthers: true, weekNumbers: false });</script><?php } ?></td>
 <?php
         }
         elseif ( $_REQUEST['filter']['terms'][$i]['attr'] == "Date" )
         {
 ?>
               <td><?= buildSelect( "filter[terms][$i][op]", $opTypes ); ?></td>
-              <td><input name="filter[terms][<?= $i ?>][val]" id="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?validHtmlStr($_REQUEST['filter']['terms'][$i]['val']):'' ?>"/><?php if ( $hasCal ) { ?><script type="text/javascript">Calendar.setup( { inputField: "filter[terms][<?= $i ?>][val]", ifFormat: "%Y-%m-%d", showOthers: true, weekNumbers: false });</script><?php } ?></td>
+              <td><input type="text" name="filter[terms][<?= $i ?>][val]" id="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?validHtmlStr($_REQUEST['filter']['terms'][$i]['val']):'' ?>"/><?php if ( $hasCal ) { ?><script type="text/javascript">Calendar.setup( { inputField: "filter[terms][<?= $i ?>][val]", ifFormat: "%Y-%m-%d", showOthers: true, weekNumbers: false });</script><?php } ?></td>
 <?php
         }
         elseif ( $_REQUEST['filter']['terms'][$i]['attr'] == "Weekday" )
@@ -230,7 +230,7 @@ for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['term
         {
 ?>
               <td><?= buildSelect( "filter[terms][$i][op]", $opTypes ); ?></td>
-              <td><input name="filter[terms][<?= $i ?>][val]" value="<?= $_REQUEST['filter']['terms'][$i]['val'] ?>"/></td>
+              <td><input type="text" name="filter[terms][<?= $i ?>][val]" value="<?= $_REQUEST['filter']['terms'][$i]['val'] ?>"/></td>
 <?php
         }
     }
@@ -238,7 +238,7 @@ for ( $i = 0; isset($_REQUEST['filter']) && $i < count($_REQUEST['filter']['term
     {
 ?>
               <td><?= buildSelect( "filter[terms][$i][op]", $opTypes ); ?></td>
-              <td><input name="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?$_REQUEST['filter']['terms'][$i]['val']:'' ?>"/></td>
+              <td><input type="text" name="filter[terms][<?= $i ?>][val]" value="<?= isset($_REQUEST['filter']['terms'][$i]['val'])?$_REQUEST['filter']['terms'][$i]['val']:'' ?>"/></td>
 <?php
     }
 ?>

--- a/web/skins/flat/views/js/zone.js
+++ b/web/skins/flat/views/js/zone.js
@@ -448,13 +448,13 @@ function drawZonePoints()
         cell.inject( row );
 
         cell = new Element( 'td' );
-        var input = new Element( 'input', { 'id': 'newZone[Points]['+i+'][x]', 'name': 'newZone[Points]['+i+'][x]', 'value': zone['Points'][i].x, 'size': 5 } );
+        var input = new Element( 'input', { 'type': 'text', 'id': 'newZone[Points]['+i+'][x]', 'name': 'newZone[Points]['+i+'][x]', 'value': zone['Points'][i].x, 'size': 5 } );
         input.addEvent( 'change', updateX.pass( i ) );
         input.inject( cell );
         cell.inject( row );
 
         cell = new Element( 'td' );
-        input = new Element( 'input', { 'id': 'newZone[Points]['+i+'][y]', 'name': 'newZone[Points]['+i+'][y]', 'value': zone['Points'][i].y, 'size': 5 } );
+        input = new Element( 'input', { 'type': 'text', 'id': 'newZone[Points]['+i+'][y]', 'name': 'newZone[Points]['+i+'][y]', 'value': zone['Points'][i].y, 'size': 5 } );
         input.addEvent( 'change', updateY.pass( i ) );
         input.inject( cell );
         cell.inject( row );

--- a/web/skins/flat/views/zone.php
+++ b/web/skins/flat/views/zone.php
@@ -247,8 +247,8 @@ for ( $i = 0; $i < $pointCols; $i++ )
 ?>
                       <tr id="row<?= $j ?>" onmouseover="highlightOn( <?= $j ?> )" onmouseout="highlightOff( <?= $j ?> )" onclick="setActivePoint( <?= $j ?> )">
                         <td><?= $j+1 ?></td>
-                        <td><input name="newZone[Points][<?= $j ?>][x]" id="newZone[Points][<?= $j ?>][x]" size="5" value="<?= $newZone['Points'][$j]['x'] ?>" onchange="updateX( this, <?= $j ?> )"<?php if ( canEdit( 'Monitors' ) ) { ?> disabled="disabled"<?php } ?>/></td>
-                        <td><input name="newZone[Points][<?= $j ?>][y]" id="newZone[Points][<?= $j ?>][y]" size="5" value="<?= $newZone['Points'][$j]['y'] ?>" onchange="updateY( this, <?= $j ?> )"<?php if ( canEdit( 'Monitors' ) ) { ?> disabled="disabled"<?php } ?>/></td>
+                        <td><input type="text" name="newZone[Points][<?= $j ?>][x]" id="newZone[Points][<?= $j ?>][x]" size="5" value="<?= $newZone['Points'][$j]['x'] ?>" onchange="updateX( this, <?= $j ?> )"<?php if ( canEdit( 'Monitors' ) ) { ?> disabled="disabled"<?php } ?>/></td>
+                        <td><input type="text" name="newZone[Points][<?= $j ?>][y]" id="newZone[Points][<?= $j ?>][y]" size="5" value="<?= $newZone['Points'][$j]['y'] ?>" onchange="updateY( this, <?= $j ?> )"<?php if ( canEdit( 'Monitors' ) ) { ?> disabled="disabled"<?php } ?>/></td>
                         <td><a href="#" onclick="addPoint( this, <?= $j ?> ); return( false );">+</a><?php if ( count($newZone['Points']) > 3 ) { ?>&nbsp;<a id="delete<?= $j ?>" href="#" onclick="delPoint( this, <?= $j ?> ); return(false);">&ndash;</a><?php } ?>&nbsp;<a id="cancel<?= $j ?>" href="#" onclick="unsetActivePoint( <?= $j ?> ); return( false );">X</a></td>
                       </tr>
 <?php


### PR DESCRIPTION
Fixes layout issues mentioned in #378:
- change sizes of popup windows to match space required by flat skin for bandwith, eventdetails, events, filter, function, monitor, monitorpreset, options and user popups
- add focus() call to createPopup function: if the popup is already open but hidden behind other windows, bring it to the front
- change padding of select lists from 10 to 1 pixel to match other input fields
- give buttons a 1px top margin to keep buttons from sticking together in filter window
  
  ![image](https://cloud.githubusercontent.com/assets/6896360/2677356/26726a74-c150-11e3-97f0-d69d26f293e2.png)
- fix input elements with missing type attribute - these were rendered like type="text" but with a 10px padding. (on filter and zone views)
