### PR TITLE
Remove apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV DEBIAN_FRONTEND noninteractive
 # Resynchronize the package index files 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get upgrade -y
 
 # Install the prerequisites
 RUN apt-get install -y build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libpcre3 libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm subversion automake autoconf libjpeg-turbo8-dev libjpeg-turbo8 libtheora-dev libvorbis-dev libvpx-dev libx264-dev libmp4v2-dev ffmpeg git wget mysql-client apache2 php5 php5-mysql apache2-mpm-prefork libapache2-mod-php5 php5-cli openssh-server mysql-server libvlc-dev libvlc5 libvlccore-dev libvlccore5 vlc-data vlc libcurl4-openssl-dev


### PR DESCRIPTION
Convention is to avoid this if not needed, as there is no init 
system and some packages have to be held back. upgrade will 
sometimes break due to the state of ubuntu:latest

To see the official issue: dotcloud/docker#1724
To see workarounds: https://github.com/racker/docker-ubuntu-with-updates/blob/master/precise/Dockerfile
