### PR TITLE
focus popup windows

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -146,6 +146,7 @@ function createPopup( url, name, tag, width, height )
     if ( popupSize.height > 0 )
         popupDimensions += ",height="+popupSize.height;
     var popup = window.open( url, name, popupOptions+popupDimensions );
+    popup.focus();
 }
 
 function createEventPopup( eventId, eventFilter, width, height )
@@ -156,6 +157,7 @@ function createEventPopup( eventId, eventFilter, width, height )
     var name = 'zmEvent';
     var popupSize = getPopupSize( 'event', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function createFramesPopup( eventId, width, height )
@@ -164,6 +166,7 @@ function createFramesPopup( eventId, width, height )
     var name = 'zmFrames';
     var popupSize = getPopupSize( 'frames', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function createFramePopup( eventId, frameId, width, height )
@@ -172,6 +175,7 @@ function createFramePopup( eventId, frameId, width, height )
     var name = 'zmFrame';
     var popupSize = getPopupSize( 'frame', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function windowToFront()

--- a/web/skins/flat/js/skin.js
+++ b/web/skins/flat/js/skin.js
@@ -157,6 +157,7 @@ function createEventPopup( eventId, eventFilter, width, height )
     var name = 'zmEvent';
     var popupSize = getPopupSize( 'event', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function createFramesPopup( eventId, width, height )
@@ -165,6 +166,7 @@ function createFramesPopup( eventId, width, height )
     var name = 'zmFrames';
     var popupSize = getPopupSize( 'frames', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function createFramePopup( eventId, frameId, width, height )
@@ -173,6 +175,7 @@ function createFramePopup( eventId, frameId, width, height )
     var name = 'zmFrame';
     var popupSize = getPopupSize( 'frame', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
+    popup.focus();
 }
 
 function windowToFront()


### PR DESCRIPTION
In flat skin, a call to popup.focus() after opening a popup window was added in #381. This should also be added to classic skin and extended to all the functions opening popup windows.
calling focus() after window.open makes sure the popup window is in the foreground in case the window already exists.
