### PR TITLE
Update zmtrigger.pl.in

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -55,7 +55,7 @@ my @connections;
 push( @connections, ZoneMinder::Trigger::Connection->new( name=>"Chan1", channel=>ZoneMinder::Trigger::Channel::Inet->new( port=>6802 ), mode=>"rw" ) );
 push( @connections, ZoneMinder::Trigger::Connection->new( name=>"Chan2", channel=>ZoneMinder::Trigger::Channel::Unix->new( path=>$Config{ZM_PATH_SOCKS}.'/zmtrigger.sock' ), mode=>"rw" ) );
 #push( @connections, ZoneMinder::Trigger::Connection->new( name=>"Chan3", channel=>ZoneMinder::Trigger::Channel::File->new( path=>'/tmp/zmtrigger.out' ), mode=>"w" ) );
-push( @connections, ZoneMinder::Trigger::Connection->new( name=>"Chan4", channel=>ZoneMinder::Trigger::Channel::Serial->new( path=>'/dev/ttyS0' ), mode=>"rw" ) );
+#push( @connections, ZoneMinder::Trigger::Connection->new( name=>"Chan4", channel=>ZoneMinder::Trigger::Channel::Serial->new( path=>'/dev/ttyS0' ), mode=>"rw" ) );
 
 # ==========================================================================
 #


### PR DESCRIPTION
zmtrigger.pl should not open serial port #1 by default. There could be situations where other hardware etc. would be attached to the port that is not used by zoneminder. 

Better if this can be commented out by default and if a user needs serial access, he can enable it by removing the comment.

This line also gives an permissions error when running on Ubuntu which prevents zmtrigger to start. That error can probably be fixed by adding the zm user permission to the serial port. But the main issue is that if the program does not need access to the port, it should not open it.
