### PR TITLE
Update watch.php

### DIFF
--- a/web/skins/mobile/views/watch.php
+++ b/web/skins/mobile/views/watch.php
@@ -24,7 +24,7 @@ if ( !canView( 'Stream' ) )
     return;
 }
 
-$sql = "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id = '".dbEscape($_REQUEST['mid'])."'";
+$sql = "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id = ".dbEscape($_REQUEST['mid']);
 $monitor = dbFetchOne( $sql );
 
 $showPtzControls = ( ZM_OPT_CONTROL && $monitor['Controllable'] && canView( 'Control' ) );


### PR DESCRIPTION
Somehow the dbEscape($_REQUEST['mid']) returns the index enclosed in quotes. So I got a lot of erros like:

 [SQL-ERR dbFetchOne no result, statement was 'select C._, M._ from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id = ''5''']

Removing the quotes made it work for me...
