### PR TITLE
Configure automatic reconnect

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -90,6 +90,7 @@ sub zmDbConnect( ;$ )
 		    $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}.";host=".$Config{ZM_DB_HOST}, $Config{ZM_DB_USER}, $Config{ZM_DB_PASS} );
         }
         $dbh->trace( 0 );
+        $dbh->{mysql_auto_reconnect} = 1;
 	}
 	return( $dbh );
 }


### PR DESCRIPTION
to mitigate disconnect errors when using zmaudit.pl use automatic reconnect.

---

i've come across this particular error when switching from mysql to mariadb.
still someone should check if this has negative impact somewhere (especially when locks or transactions are used in the perl scripts somewhere)
