### PR TITLE
Fixed issue DateTime handling in filter queries that broke timeline view...

### DIFF
--- a/web/skins/classic/includes/timeline_functions.php
+++ b/web/skins/classic/includes/timeline_functions.php
@@ -232,7 +232,7 @@ function parseFilterToTree( $filter )
                             $value = "'$value'";
                             break;
                         case 'DateTime':
-                            $value = strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) );
+                            $value = "'".strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) )."'";
                             break;
                         case 'Date':
                             $value = "to_days( '".strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) )."' )";

--- a/web/skins/flat/includes/timeline_functions.php
+++ b/web/skins/flat/includes/timeline_functions.php
@@ -232,7 +232,7 @@ function parseFilterToTree( $filter )
                             $value = "'$value'";
                             break;
                         case 'DateTime':
-                            $value = strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) );
+                            $value = "'".strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) )."'";
                             break;
                         case 'Date':
                             $value = "to_days( '".strftime( STRF_FMT_DATETIME_DB, strtotime( $value ) )."' )";


### PR DESCRIPTION
After updating my ZoneMinder installation to the lastest Git version, the timeline view became broken.  I would only get a screen with a error message about a DB query not returning any records.  The steps to reproduce are (in both the classic skin and in the flat skin):

*Go to the Zoneminder Console page.  
*Click on any of the links under the 'Hour','Day','Week',Month' columns to go to the Events view.  
*When in Events view opens up, click on "Show TimeLine" link.
*The Timeline window will open to an error message instead of the Timeline view.

The issue was the parseFilterToTree function wasn't wrapping DateTime values with quotes, cause the resulting DB query to fail.
