### PR TITLE
Update rules

### DIFF
--- a/distros/debian/rules
+++ b/distros/debian/rules
@@ -74,4 +74,4 @@ override_dh_auto_test:
 
 .PHONY: override_dh_strip
 override_dh_strip:
-        dh_strip --dbg-package=zoneminder-dbg
+	dh_strip --dbg-package=zoneminder-dbg


### PR DESCRIPTION
There was a missing tab-indent. So dpkg-buildpackage under debian didnt work:

Error:
debian/rules:77: **\* missing separator.  Stop.
