### PR TITLE
Update FI9821W_Y2k.pm

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
@@ -109,7 +109,7 @@ sub printMsg
 }
 
 sub sendCmd
-{ 
+{
     my $self = shift;
     my $cmd = shift;
     my $result = undef;
@@ -135,13 +135,13 @@ sub reset
    my $cmd = "setOSDSetting%26isEnableTimeStamp%3D0%26isEnableDevName%3D1%26dispPos%3D0%26isEnabledOSDMask%3D0";
    $self->sendCmd( $cmd );
    # Setup For Stream=0 Resolution=720p Bandwith=4M FPS=30 KeyFrameInterval/GOP=100 VBR=ON
-   my $cmd = "setVideoStreamParam%26streamType%3D0%26resolution%3D0%26bitRate%3D4194304%26frameRate%3D30%26GOP%3D100%26isVBR%3D1";
+   $cmd = "setVideoStreamParam%26streamType%3D0%26resolution%3D0%26bitRate%3D4194304%26frameRate%3D30%26GOP%3D100%26isVBR%3D1";
    $self->sendCmd( $cmd );
    # Setup For Infrared AUTO
-   my $cmd = "setInfraLedConfig%26Mode%3D1";
+   $cmd = "setInfraLedConfig%26Mode%3D1";
    $self->sendCmd( $cmd );
    # Reset image settings
-   my $cmd = "resetImageSetting";
+   $cmd = "resetImageSetting";
    $self->sendCmd( $cmd );
 }
 
@@ -150,10 +150,10 @@ sub moveStop
    my $self = shift;
    Debug( "Move Stop" );
         my $cmd = "ptzStopRun";
-   $self->sendCmd( $cmd );      
-        my $cmd = "setDevName%26devName%3D.";
+   $self->sendCmd( $cmd );
+        $cmd = "setDevName%26devName%3D.";
         $self->sendCmd( $cmd );
-   my $cmd = "setOSDSetting%26isEnableDevName%3D1";
+   $cmd = "setOSDSetting%26isEnableDevName%3D1";
    $self->sendCmd( $cmd );
 }
 
@@ -184,7 +184,7 @@ sub moveConUp
     if ( $tiltspeed < 0 ) {
             $tiltspeed = 0;
                 }
-    Debug( "Move Up" );   
+    Debug( "Move Up" );
     if ( $osd eq "on" )
    {
     my $cmd = "setDevName%26devName%3DMove Up $tiltspeed";
@@ -192,7 +192,7 @@ sub moveConUp
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveUp";
+    $cmd = "ptzMoveUp";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -219,7 +219,7 @@ sub moveConDown
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveDown";
+    $cmd = "ptzMoveDown";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -244,7 +244,7 @@ sub moveConLeft
         }
     my $cmd = "setPTZSpeed%26speed%3D$panspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveLeft";
+    $cmd = "ptzMoveLeft";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -272,7 +272,7 @@ sub moveConRight
         }
     my $cmd = "setPTZSpeed%26speed%3D$panspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveRight";
+    $cmd = "ptzMoveRight";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -299,7 +299,7 @@ sub moveConUpLeft
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveTopLeft";
+    $cmd = "ptzMoveTopLeft";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -326,7 +326,7 @@ sub moveConUpRight
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveTopRight";
+    $cmd = "ptzMoveTopRight";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -353,7 +353,7 @@ sub moveConDownLeft
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveBottomLeft";
+    $cmd = "ptzMoveBottomLeft";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -380,7 +380,7 @@ sub moveConDownRight
         }
     my $cmd = "setPTZSpeed%26speed%3D$tiltspeed";
     $self->sendCmd( $cmd );
-    my $cmd = "ptzMoveBottomRight";
+    $cmd = "ptzMoveBottomRight";
     $self->sendCmd( $cmd );
     $self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
@@ -396,7 +396,7 @@ sub zoomConTele
         }
     my $cmd = "setInfraLedConfig%26mode%3D1";
     $self->sendCmd( $cmd );
-    my $cmd = "openInfraLed";
+    $cmd = "openInfraLed";
     $self->sendCmd( $cmd );
 }
 
@@ -411,7 +411,7 @@ sub zoomConWide
         }
     my $cmd = "setInfraLedConfig%26mode%3D1";
     $self->sendCmd( $cmd );
-    my $cmd = "closeInfraLed";
+    $cmd = "closeInfraLed";
     $self->sendCmd( $cmd );
 }
 
@@ -425,7 +425,7 @@ sub wake
          $self->sendCmd( $cmd );
         }
     my $cmd = "setInfraLedConfig%26mode%3D0";
-    $self->sendCmd( $cmd );       
+    $self->sendCmd( $cmd );
 }
 
 sub focusConNear
@@ -445,7 +445,7 @@ sub focusConNear
    {
          my $cmd = "setDevName%26devName%3DSharpness $speed";
          $self->sendCmd( $cmd );
-         my $cmd = "setOSDSetting%26isEnableDevName%3D1";
+         $cmd = "setOSDSetting%26isEnableDevName%3D1";
     $self->sendCmd( $cmd );
         }
     my $cmd = "setSharpness%26sharpness%3D$speed";
@@ -668,7 +668,7 @@ sub presetSet
                                     my $cmd = "setDevName%26devName%3DSet Preset $preset";
                                        $self->sendCmd( $cmd );
                       }
-                                                  my $cmd = "ptzAddPresetPoint%26name%3D$preset";
+                                                  $cmd = "ptzAddPresetPoint%26name%3D$preset";
                                                   $self->sendCmd( $cmd );
                         }
 }
@@ -687,7 +687,7 @@ sub presetGoto
                       }
                    my $cmd = "setPTZSpeed%26speed%3D0";
                         $self->sendCmd( $cmd );
-                        my $cmd = "ptzGotoPresetPoint%26name%3D$preset";
+                        $cmd = "ptzGotoPresetPoint%26name%3D$preset";
                         $self->sendCmd( $cmd );
                        }
 }
@@ -744,3 +744,4 @@ at your option, any later version of Perl 5 you may have available.
 
 
 =cut
+


### PR DESCRIPTION
Fixed this issue:
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 138.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 141.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 144.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 154.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 156.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 195.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 222.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 247.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 275.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 302.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 329.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 356.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 383.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 399.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 414.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 448.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 671.
"my" variable $cmd masks earlier declaration in same scope at FI9821W_Y2k.pm line 690.
