### PR TITLE
Fixes 520 travis build ffmpeg failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev 2>&1 > /dev/null 
 install:
-  - git clone --depth=10 --branch=master git://source.ffmpeg.org/ffmpeg.git 
+  - git clone -b n2.4.1 --depth=1 git://source.ffmpeg.org/ffmpeg.git
   - cd ffmpeg
-  - git checkout tags/n2.4 
   - ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx --enable-libvorbis --enable-libtheora 
   - make -j `grep processor /proc/cpuinfo|wc -l` 
   - sudo make install 


### PR DESCRIPTION
Current Travis YML was grabbing ffmpeg master branch to build, resulting in build failures based on ffmpeg changes. This pull changes the clone to get the tagged release number from ffmpeg instead. This does mean the project will need to manage the version of ffmpeg that is tested against, but that is probably not a bad thing. Will mean end users can be told ZoneMinder version x works with ffmpeg version y.
