### PR TITLE
Added preset/autostop/IR support to FI8908W, new module for all Foscam IP cameras

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
@@ -241,7 +241,7 @@ sub presetSet
 	my $params = shift;
 	my $preset = $self->getParam( $params, 'preset' );
 	Debug( "Set Preset $preset" );
-	my $cmdnum = 30 + ($preset*2);
+	my $cmdnum = 30 + (($preset-1)*2);
 	$self->sendCmd( 'decoder_control.cgi?command=$cmdnum&' );
 }
 
@@ -252,7 +252,7 @@ sub presetGoto
 	my $params = shift;
 	my $preset = $self->getParam( $params, 'preset' );
 	Debug( "Goto Preset $preset" );
-	my $cmdnum = 31 + ($preset*2);
+	my $cmdnum = 31 + (($preset-1)*2);
 	$self->sendCmd( 'decoder_control.cgi?command=$cmdnum&' );
 }
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
@@ -3,6 +3,7 @@
 # ZoneMinder Foscam FI8908W / FI8918W IP Control Protocol Module, $Date$, $Revision$
 # Copyright (C) 2001-2008 Philip Coombes
 # Modified for use with Foscam FI8908W IP Camera by Dave Harris
+# Modified to add preset, autostop, and IR on/off support by Daniel Rich
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -141,6 +142,7 @@ sub moveConUp
 	my $self = shift;
 	Debug( "Move Up" );
 	$self->sendCmd( 'decoder_control.cgi?command=0&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Down Arrow
@@ -149,6 +151,7 @@ sub moveConDown
 	my $self = shift;
 	Debug( "Move Down" );
 	$self->sendCmd( 'decoder_control.cgi?command=2&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Left Arrow
@@ -157,6 +160,7 @@ sub moveConLeft
 	my $self = shift;
 	Debug( "Move Left" );
 	$self->sendCmd( 'decoder_control.cgi?command=6&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Right Arrow
@@ -165,6 +169,7 @@ sub moveConRight
 	my $self = shift;
 	Debug( "Move Right" );
 	$self->sendCmd( 'decoder_control.cgi?command=4&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Diagonally Up Right Arrow
@@ -173,6 +178,7 @@ sub moveConUpRight
 	my $self = shift;
 	Debug( "Move Diagonally Up Right" );
 	$self->sendCmd( 'decoder_control.cgi?command=90&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Diagonally Down Right Arrow
@@ -181,6 +187,7 @@ sub moveConDownRight
 	my $self = shift;
 	Debug( "Move Diagonally Down Right" );
 	$self->sendCmd( 'decoder_control.cgi?command=92&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Diagonally Up Left Arrow
@@ -189,6 +196,7 @@ sub moveConUpLeft
 	my $self = shift;
 	Debug( "Move Diagonally Up Left" );
 	$self->sendCmd( 'decoder_control.cgi?command=91&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Diagonally Down Left Arrow
@@ -197,6 +205,7 @@ sub moveConDownLeft
 	my $self = shift;
 	Debug( "Move Diagonally Down Left" );
 	$self->sendCmd( 'decoder_control.cgi?command=93&' );
+	$self->autoStop( $self->{Monitor}->{AutoStopTimeout} );
 }
 
 #Stop
@@ -206,6 +215,16 @@ sub moveStop
 	Debug( "Move Stop" );
 	$self->sendCmd( 'decoder_control.cgi?command=1&' );
 }
+sub autoStop
+{
+	my $self = shift;
+	my $autostop = shift;
+	Debug( "Auto Stop" );
+	if ( $autostop ) {
+		usleep( $autostop );
+		$self->sendCmd( 'decoder_control.cgi?command=1&' );
+	}
+}
 
 #Move Camera to Home Position
 sub presetHome
@@ -213,6 +232,44 @@ sub presetHome
 	my $self = shift;
 	Debug( "Home Preset" );
 	$self->sendCmd( 'decoder_control.cgi?command=25&' );
+}
+
+#Set preset position
+sub presetSet
+{
+	my $self = shift;
+	my $params = shift;
+	my $preset = $self->getParam( $params, 'preset' );
+	Debug( "Set Preset $preset" );
+	my $cmdnum = 30 + ($preset*2);
+	$self->sendCmd( 'decoder_control.cgi?command=$cmdnum&' );
+}
+
+#Goto preset position
+sub presetGoto
+{
+	my $self = shift;
+	my $params = shift;
+	my $preset = $self->getParam( $params, 'preset' );
+	Debug( "Goto Preset $preset" );
+	my $cmdnum = 31 + ($preset*2);
+	$self->sendCmd( 'decoder_control.cgi?command=$cmdnum&' );
+}
+
+#Turn IR off
+sub sleep
+{
+	my $self = shift;
+	Debug( "IR Off" );
+	$self->sendCmd( 'decoder_control.cgi?command=94&' );
+}
+
+#Turn IR on
+sub wake
+{
+	my $self = shift;
+	Debug( "IR On" );
+	$self->sendCmd( 'decoder_control.cgi?command=95&' );
 }
 
 1;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FoscamIPCam.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FoscamIPCam.pm
@@ -1,0 +1,258 @@
+# ==========================================================================
+#
+# ZoneMinder Foscam IP Camera Control Protocol Module, $Date$, $Revision$
+# Copyright (C) 2001-2008 Philip Coombes
+# Modified for use with Foscam FI8908W IP Camera by Dave Harris
+# Modified to add preset, autostop, and IR on/off support by Daniel Rich
+# Converted into a general Foscam IP Camera module with zoom, iris, and focus
+#	Added handling for inverted cameras
+#	by Daniel Rich
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# ==========================================================================
+#
+package ZoneMinder::Control::FoscamIPCam;
+
+use 5.006;
+use strict;
+use warnings;
+
+require ZoneMinder::Base;
+require ZoneMinder::Control;
+
+our @ISA = qw(ZoneMinder::Control);
+
+# ==========================================================================
+#
+# Foscam IP Camera Control Protocol
+#
+# The Foscam IP Camera protocol is described at:
+#    http://www.foscam.es/descarga/ipcam_cgi_sdk.pdf
+#
+# ==========================================================================
+
+use ZoneMinder::Logger qw(:all);
+use ZoneMinder::Config qw(:all);
+
+use Time::HiRes qw( usleep );
+
+sub new
+{ 
+	my $class = shift;
+	my $id = shift;
+	my $self = ZoneMinder::Control->new( $id );
+	bless( $self, $class );
+	srand( time() );
+	return $self;
+}
+
+our %FoscamCommands = (
+	'moveConUp'        => 0,
+	'moveStop'         => 1,
+	'moveConDown'      => 2,
+	'moveConLeft'      => 6,	# left/right reversed from the spec
+	'moveConRight'     => 4,	# left/right reversed from the spec
+	'moveConUpLeft'    => 91,	# left/right reversed from the spec
+	'moveConUpRight'   => 90,	# left/right reversed from the spec
+	'moveConDownLeft'  => 93,	# left/right reversed from the spec
+	'moveConDownRight' => 92,	# left/right reversed from the spec
+	'irisConClose'     => 8,
+	'irisConOpen'      => 10,
+	'irisStop'         => 9,
+	'focusConNear'     => 12,
+	'focusConFar'      => 14,
+	'focusStop'        => 15,
+	'zoomConTele'      => 16,
+	'zoomConWide'      => 18,
+	'zoomStop'         => 17,
+	'presetSet'        => 30,
+	'presetGoto'       => 31,
+	'sleep'            => 94,	# IR off
+	'wake'             => 95,	# IR on
+);
+
+our $AUTOLOAD;
+
+sub AUTOLOAD
+{
+	my $self = shift;
+	my $class = ref($self) || croak( "$self not object" );
+	my $name = $AUTOLOAD;
+	$name =~ s/.*://;
+	if ( exists($self->{$name}) )
+	{
+		return( $self->{$name} );
+	}
+	elsif ( defined($FoscamCommands{$name}) )
+	{
+		return( $self->handleCommand($name) );
+	}
+	Fatal( "Can't access $name member of object of class $class" );
+}
+
+sub open
+{
+	my $self = shift;
+
+	$self->loadMonitor();
+
+	use LWP::UserAgent;
+	$self->{ua} = LWP::UserAgent->new;
+	$self->{ua}->agent( "ZoneMinder Control Agent/".ZoneMinder::Base::ZM_VERSION );
+
+	$self->{state} = 'open';
+}
+
+sub close
+{ 
+	my $self = shift;
+	$self->{state} = 'closed';
+}
+
+sub printMsg
+{
+	my $self = shift;
+	my $msg = shift;
+	my $msg_len = length($msg);
+
+	Debug( $msg."[".$msg_len."]" );
+}
+
+sub sendCmd
+{
+	my $self = shift;
+	my $cmd = shift;
+	my $result = undef;
+
+	my ($user, $password) = split /:/, $self->{Monitor}->{ControlDevice};
+
+	if ( !defined $password ) {
+		# If value of "Control device" does not consist of two parts, then only password is given and we fallback to default user:
+		$password = $user;
+		$user = 'admin';
+	}
+
+	$cmd .= "user=$user&pwd=$password";
+
+	printMsg( $cmd, "Tx" );
+
+	my $req = HTTP::Request->new( GET=>"http://".$self->{Monitor}->{ControlAddress}."/$cmd" );
+	my $res = $self->{ua}->request($req);
+
+	if ( $res->is_success )
+	{
+		$result = !undef;
+	}
+	else
+	{
+		Error( "Error check failed: '".$res->status_line()."' for URL ".$req->uri() );
+	}
+
+	return( $result );
+}
+
+sub reset
+{
+	my $self = shift;
+	Debug( "Camera Reset" );
+	$self->sendCmd( 'reboot.cgi?' );
+}
+
+# General Foscam command handler
+sub handleCommand
+{
+	my $self = shift;
+	my $command = shift;
+
+	# Inverted camera, flip left/right, up/down move commands
+	if ( $self->{Monitor}->{Orientation} == 180 and $command =~ /^move/ )
+	{
+		if ($command =~ /Up/)
+		{
+			$command  =~ s/Up/Down/;
+		}
+		else 
+		{
+			$command  =~ s/Down/Up/;
+		}
+		if ($command =~ /Left/)
+		{
+			$command  =~ s/Left/Right/;
+		}
+		else 
+		{
+			$command  =~ s/Right/Left/;
+		}
+	}
+	Debug( $command );
+	$self->sendCmd( 'decoder_control.cgi?command='. $FoscamCommands{$command} .'&' );
+	if ( $self->{Monitor}->{AutoStopTimeout} )
+	{
+		usleep( $self->{Monitor}->{AutoStopTimeout} );
+		my $stopCmd = $command;	# Figure out stop command from 
+		$stopCmd =~ s/[A-Z].*$/Stop/;	#   base of current command
+		if ( defined $FoscamCommands{$stopCmd} )
+		{
+			Debug( 'Autostop triggered' );
+			$self->sendCmd( 'decoder_control.cgi?command='. $FoscamCommands{$stopCmd} .'&' );
+		}
+	}
+}
+
+#Move Camera to Home Position
+sub presetHome
+{
+	my $self = shift;
+	Debug( "Home Preset" );
+	$self->sendCmd( 'decoder_control.cgi?command=25&' );
+}
+
+#Set preset position
+sub presetSet
+{
+	my $self = shift;
+	my $params = shift;
+	my $preset = $self->getParam( $params, 'preset' );
+	Debug( "Set Preset $preset" );
+	my $cmdnum = $FoscamCommands{'presetSet'} + (($preset-1)*2);
+	$self->sendCmd( 'decoder_control.cgi?command='. $cmdnum. '&' );
+}
+
+#Goto preset position
+sub presetGoto
+{
+	my $self = shift;
+	my $params = shift;
+	my $preset = $self->getParam( $params, 'preset' );
+	Debug( "Goto Preset $preset" );
+	my $cmdnum = $FoscamCommands{'presetGoto'} + (($preset-1)*2);
+	$self->sendCmd( 'decoder_control.cgi?command='. $cmdnum. '&' );
+}
+
+1;
+
+__END__
+=pod
+
+=head1 DESCRIPTION
+
+This module contains the implementation of the Foscam IP camera control
+protocol.
+
+The module uses "Control Device" value to retrieve user and password. User and password should
+be separated by colon, e.g. user:password. If colon is not provided, then "admin" is used
+as a fallback value for the user.
+=cut


### PR DESCRIPTION
The update to FI8908W.pm adds support for presets, autostop, and IR on/off support. This fixes a bug in the pull request I submitted the other day.

This pull request also contains a new file, FoscamIPCam.pm. This is an all-purpose Foscam module that should work for any camera supporting the commands at http://www.foscam.es/descarga/ipcam_cgi_sdk.pdf. I don't have a camera to test with that supports iris, focus, and zoom, so it's possible I have the values reversed for those (i.e. zoom in instead of zoom out).  I attempted to simplify the original module by getting rid of duplicated code and creating a hash of the decode command values instead of having them hard-coded into the methods. I also added code to handle inverted cameras, it swaps the up/down and left/right commands if Orientation is set to inverted.

FYI, there appears to be a bug in the Foscam command doc. On my cameras left and right are reversed from what is in the spec and this corresponds to the values that are in the initial FI8908W module. It's possible that it is just an issue with these cameras, or it may be true for all Foscam cameras. If anyone can verify this with an additional Foscam model, I can fix the module appropriately.