### PR TITLE
Fixed bug in rtsp streaming caused by a bad string concatenation

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -414,7 +414,16 @@ int RtspThread::run()
             if ( mFormatContext->streams[i]->codec->codec_type == CODEC_TYPE_VIDEO )
 #endif
             {
-                trackUrl += "/"+mediaDesc->getControlUrl();
+                // Check if control Url is absolute or relative
+                std::string controlUrl = mediaDesc->getControlUrl();
+                if (std::equal(trackUrl.begin(), trackUrl.end(), controlUrl.begin()))
+                {
+                    trackUrl = controlUrl;
+                }
+                else
+                {
+                    trackUrl += "/" + controlUrl;
+                }
                 rtpClock = mediaDesc->getClock();
                 codecId = mFormatContext->streams[i]->codec->codec_id;
                 // Hackery pokery


### PR DESCRIPTION
This patch solves a RTSP streaming issue if the SDP descriptor provides an absolute URL for the "a=control" attribute.

Section C.1.1 of RFC2326 (http://tools.ietf.org/html/rfc2326#page-80) says that the "a=control" may contain either relative and absolute URLs.

ZM always considers the control URL as relative and appends it to the base URL which may result in bad RTSP SETUP commands.

Example : SETUP rtsp://192.168.1.1:8080/test.sdp/rtsp://192.168.1.1:8080/test.sdp/trackID=0 RTSP/1.0

This bug can be reproduced by using the VLC streaming capabilities as a RTSP input.

I added an instruction to check if the control URL starts with the base URL, which means that the URL is absolute and we don't have to concatenate.
