### PR TITLE
Add the ability to specify the zm configdir at build time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include (CheckTypeSize)
 include (CheckStructHasMember)
 
 # Configuration options
-mark_as_advanced(FORCE ZM_EXTRA_LIBS ZM_MYSQL_ENGINE ZM_NO_MMAP CMAKE_INSTALL_FULL_BINDIR ZM_PERL_SUBPREFIX ZM_PERL_USE_PATH ZM_TARGET_DISTRO)
+mark_as_advanced(FORCE ZM_EXTRA_LIBS ZM_MYSQL_ENGINE ZM_NO_MMAP CMAKE_INSTALL_FULL_BINDIR ZM_PERL_SUBPREFIX ZM_PERL_USE_PATH ZM_TARGET_DISTRO ZM_CONFIG_DIR)
 set(ZM_RUNDIR "/var/run/zm" CACHE PATH "Location of transient process files, default: /var/run/zm")
 set(ZM_SOCKDIR "/var/run/zm" CACHE PATH "Location of Unix domain socket files, default /var/run/zm")
 set(ZM_TMPDIR "/var/tmp/zm" CACHE PATH "Location of temporary files, default: /tmp/zm")
@@ -59,6 +59,7 @@ set(ZM_DB_PASS "zmpass" CACHE STRING "Password of ZoneMinder database user, defa
 set(ZM_WEB_USER "" CACHE STRING "The user apache or the local web server runs on. Leave empty for automatic detection. If that fails, you can use this variable to force")
 set(ZM_WEB_GROUP "" CACHE STRING "The group apache or the local web server runs on, Leave empty to be the same as the web user")
 # Advanced
+set(ZM_CONFIG_DIR "/${CMAKE_INSTALL_SYSCONFDIR}" CACHE PATH "Location of ZoneMinder configuration, default system config directory")
 set(ZM_EXTRA_LIBS "" CACHE STRING "A list of optional libraries, separated by semicolons, e.g. ssl;theora")
 set(ZM_MYSQL_ENGINE "InnoDB" CACHE STRING "MySQL engine to use with database, default: InnoDB")
 set(ZM_NO_MMAP "OFF" CACHE BOOL "Set to ON to not use mmap shared memory. Shouldn't be enabled unless you experience problems with the shared memory. default: OFF")
@@ -486,6 +487,7 @@ endif(NOT POLKIT_FOUND)
 
 # Some variables that zm expects
 set(ZM_PID "${ZM_RUNDIR}/zm.pid")
+set(ZM_CONFIG "${ZM_CONFIG_DIR}/zm.conf")
 set(ZM_CONFIG "/${CMAKE_INSTALL_SYSCONFDIR}/zm.conf")
 set(VERSION "${zoneminder_VERSION}")
 set(PKGDATADIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/zoneminder")
@@ -535,7 +537,7 @@ else(zmconfgen_result EQUAL 0)
 endif(zmconfgen_result EQUAL 0)
 
 # Install zm.conf
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zm.conf" DESTINATION "/${CMAKE_INSTALL_SYSCONFDIR}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zm.conf" DESTINATION "${ZM_CONFIG_DIR}")
 
 # Uninstall target
 configure_file(

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,9 @@ AUTOMAKE_OPTIONS = foreign
 # And these to the user and group of your webserver
 webuser = @WEB_USER@
 webgroup = @WEB_GROUP@
+zmconfigdir = @ZM_CONFIG_DIR@
 
-sysconf_DATA = \
+zmconfig_DATA = \
 	zm.conf
 
 SUBDIRS = \
@@ -20,7 +21,7 @@ EXTRA_DIST = \
 
 # Yes, you are correct. This is a HACK!
 install-data-hook:
-	( cd $(DESTDIR)$(sysconfdir); chown $(webuser):$(webgroup) $(sysconf_DATA); chmod 600 $(sysconf_DATA) )
+	( cd $(DESTDIR)$(zmconfigdir); chown $(webuser):$(webgroup) $(zmconfig_DATA); chmod 600 $(zmconfig_DATA) )
 	( if ! test -e $(DESTDIR)$(ZM_RUNDIR); then mkdir -p $(DESTDIR)$(ZM_RUNDIR); fi; if test "$(DESTDIR)$(ZM_RUNDIR)" != "/var/run"; then chown $(webuser):$(webgroup) $(DESTDIR)$(ZM_RUNDIR); chmod u+w $(DESTDIR)$(ZM_RUNDIR); fi )
 	( if ! test -e $(DESTDIR)$(ZM_SOCKDIR); then mkdir -p $(DESTDIR)$(ZM_SOCKDIR); fi; if test "$(DESTDIR)$(ZM_SOCKDIR)" != "/var/run"; then chown $(webuser):$(webgroup) $(DESTDIR)$(ZM_SOCKDIR); chmod u+w $(DESTDIR)$(ZM_SOCKDIR); fi )
 	( if ! test -e $(DESTDIR)$(ZM_TMPDIR); then mkdir -m 700 -p $(DESTDIR)$(ZM_TMPDIR); fi; if test "$(DESTDIR)$(ZM_TMPDIR)" != "/tmp" && test "$(DESTDIR)$(ZM_TMPDIR)" != "/var/tmp"; then chown $(webuser):$(webgroup) $(DESTDIR)$(ZM_TMPDIR); chmod u+w $(DESTDIR)$(ZM_TMPDIR); fi )

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ AC_ARG_VAR(ZM_RUNDIR,[Location of transient process files, default /var/run/zm])
 AC_ARG_VAR(ZM_SOCKDIR,[Location of Unix domain socket files, default /var/run/zm])
 AC_ARG_VAR(ZM_TMPDIR,[Location of temporary files, default /var/tmp/zm])
 AC_ARG_VAR(ZM_LOGDIR,[Location of generated log files, default /var/log/zm])
+AC_ARG_VAR(ZM_CONFIG_DIR,[Location of ZoneMinder configuration, default system config directory])
 
 if test "$ZM_DB_TYPE" == ""; then
 	AC_SUBST(ZM_DB_TYPE,[mysql])
@@ -79,6 +80,10 @@ if test "$ZM_TMPDIR" == ""; then
 fi
 if test "$ZM_LOGDIR" == ""; then
 	AC_SUBST(ZM_LOGDIR,[/var/log/zm])
+fi
+AC_DEFINE_DIR([SYSCONFDIR],[sysconfdir],[Expanded configuration directory])
+if test "$ZM_CONFIG_DIR" == ""; then
+	AC_SUBST(ZM_CONFIG_DIR,[$SYSCONFDIR])
 fi
 
 LIB_ARCH=lib
@@ -428,8 +433,9 @@ AC_DEFINE_DIR([LIBDIR],[libdir],[Expanded library directory])
 AC_DEFINE_DIR([DATADIR],[datadir],[Expanded data directory])
 AC_SUBST(PKGDATADIR,"$DATADIR/$PACKAGE")
 AC_SUBST(ZM_PID,"$ZM_RUNDIR/zm.pid")
-AC_DEFINE_DIR([SYSCONFDIR],[sysconfdir],[Expanded configuration directory])
-AC_SUBST(ZM_CONFIG,"$SYSCONFDIR/zm.conf")
+#AC_DEFINE_DIR([SYSCONFDIR],[sysconfdir],[Expanded configuration directory])
+#AC_SUBST(ZM_CONFIG,"$SYSCONFDIR/zm.conf")
+AC_SUBST(ZM_CONFIG,"$ZM_CONFIG_DIR/zm.conf")
 
 # Slight hack for non-standard perl install paths
 if test "$prefix" != "NONE"; then

--- a/zm.conf.in
+++ b/zm.conf.in
@@ -19,7 +19,7 @@ ZM_PATH_BIN=@BINDIR@
 ZM_PATH_LIB=@LIBDIR@
 
 # Path to ZoneMinder configuration (this file only at present)
-ZM_PATH_CONF=@SYSCONFDIR@
+ZM_PATH_CONF=@ZM_CONFIG_DIR@
 
 # Path to ZoneMinder web files
 ZM_PATH_WEB=@WEB_PREFIX@


### PR DESCRIPTION
This is targeted towards Debian based distros that put zm.conf under a subfolder rather than directly into the system configdir, which is probably the better thing to do.  Works with cmake or autotools.
