### PR TITLE
remove the case for level >= 2.  Since level is a bool, this code can ne...

### DIFF
--- a/src/zm_buffer.h
+++ b/src/zm_buffer.h
@@ -151,17 +151,11 @@ public:
         {
             if ( mSize == 0 )
                 mHead = mTail = mStorage;
-            else if ( level >= 1 )
+            else if ( level )
             {
                 if ( (mHead-mStorage) > mSize )
                 {
                     memcpy( mStorage, mHead, mSize );
-                    mHead = mStorage;
-                    mTail = mHead + mSize;
-                }
-                else if ( level >= 2 )
-                {
-                    memmove( mStorage, mHead, mSize );
                     mHead = mStorage;
                     mTail = mHead + mSize;
                 }


### PR DESCRIPTION
...ver execute.  Also, there are no calls to tidy in the current code with values other than 0 or 1, so it's safe to do.  Also it removes an error message when using clang++
