### PR TITLE
Fix a bug when closing RTSP session over TCP

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -768,10 +768,9 @@ int RtspThread::run()
             if ( !recvResponse( response ) )
                 return( -1 );
 #endif
+            // Send a teardown message but don't expect a response as this may not be implemented on the server when using TCP
             message = "TEARDOWN "+mUrl+" RTSP/1.0\r\nSession: "+session+"\r\n";
             if ( !sendCommand( message ) )
-                return( -1 );
-            if ( !recvResponse( response ) )
                 return( -1 );
 
             delete mSources[ssrc];


### PR DESCRIPTION
This patch solves an issue if the server does not send a response to the TEARDOWN command when using RTP over TCP. In this case zmc terminates with an abormal status.

This is the case with my AXIS devices (at least my Q7424-R encoder).
I checked with wireshark. In fact, once the TCP session is enabled, the AXIS RTSP server does not send any response. I believe it considers that a TCP ACK is enough.
