### PR TITLE
Fix memory leaks with rtsp and a bug

### DIFF
--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -91,7 +91,7 @@ RemoteCameraRtsp::~RemoteCameraRtsp()
     if ( mCodecContext )
     {
        avcodec_close( mCodecContext );
-       mCodecContext = NULL; // Freed by av_close_input_file
+       mCodecContext = NULL; // Freed by avformat_free_context in the destructor of RtspThread class
     }
 
 	if ( capture )

--- a/src/zm_rtsp.h
+++ b/src/zm_rtsp.h
@@ -26,6 +26,7 @@
 #include "zm_thread.h"
 #include "zm_rtp_source.h"
 #include "zm_rtsp_auth.h"
+#include "zm_sdp.h"
 
 #include <set>
 #include <map>
@@ -73,6 +74,7 @@ private:
 
     SourceMap mSources;
 
+    SessionDescriptor *mSessDesc;
     AVFormatContext *mFormatContext;
 
     uint16_t mSeq;

--- a/src/zm_sdp.cpp
+++ b/src/zm_sdp.cpp
@@ -184,9 +184,15 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
                 mInfo = line;
                 break;
             case 'c' :
+                // This prevent a memory leak if the field appears more than one time
+                if ( mConnInfo )
+                    delete mConnInfo;
                 mConnInfo = new ConnInfo( line );
                 break;
             case 'b' :
+                // This prevent a memory leak if the field appears more than one time
+                if ( mBandInfo )
+                    delete mBandInfo;
                 mBandInfo = new BandInfo( line );
                 break;
             case 't' :
@@ -337,6 +343,16 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
             }
         }
     }
+}
+
+SessionDescriptor::~SessionDescriptor()
+{
+    if ( mConnInfo )
+        delete mConnInfo;
+    if ( mBandInfo )
+        delete mBandInfo;
+    for ( unsigned int i = 0; i < mMediaList.size(); i++ )
+        delete mMediaList[i];
 }
 
 AVFormatContext *SessionDescriptor::generateFormatContext() const

--- a/src/zm_sdp.h
+++ b/src/zm_sdp.h
@@ -213,6 +213,7 @@ protected:
 
 public:
     SessionDescriptor( const std::string &url, const std::string &sdp );
+    ~SessionDescriptor();
 
     const std::string &getUrl() const
     {


### PR DESCRIPTION
Memory leaks fixed:
- mysql_store_result is called but not mysql_free_result
- avformat_alloc_context is called but not avformat_free_context
- sessDesc is dynamically allocated but memory is never released
- mAuthenticator is dynamically allocated but memory is never released
- Dynamic allocation of memory by the use of '%a' in sccanf function is not released (sccanf replaced by c++ functions)
- Memory for mConnInfo and mBandInfo may be allocated multiple times if the corresponding field appears more than one time in SDP and memory is never released (code added to keep only the last value)
- New MediaDescriptors are added to the mMediaList vector but they are never deleted

All this leaks have been detected with valgrind.

A question: 

Does zm binaries have ever passed successfully a single memory check test ?
I think no because every zm binaries open a logger session but never close it (the same for database access).

Bugs fixed:

The response to a SETUP command may not include the timeout parameter (fixed with the new code to address the memory leak).
