### PR TITLE
"zmpkg.pl start" gets into lock on "systemd"-based system

### DIFF
--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -275,7 +275,7 @@ sub calledBysystem
 	my $output = qx(ps -o comm="" $ppid);
 	chomp( $output );
 
-	if ($output =~ /^(?:systemd|init)$/) {
+	if ($output =~ /^(?:systemd|init|zoneminder)$/) {
 		$result = 1;
 	}
 


### PR DESCRIPTION
I have noticed that on my system, which is "systemd"-based, `zmpkg.pl start` is not working correctly. In particular it calls itself again and gets into deadlock.

The problem is that `calledBysystem()` relies on that `zmpkg.pl` is called from `systemd`, but in fact it is called from `/etc/init.d/zoneminder`:

```
# ps axl
0     0 18717 16903  20   0  26416  8800 -      S+   pts/3      0:00 /usr/bin/perl -wT /usr/bin/zmpkg.pl start
4     0 18724 18717  20   0   5968  1068 -      S+   pts/3      0:00 /bin/systemctl start zoneminder
4     0 18729     1  20   0   2244   548 -      Ss   ?          0:00 /bin/sh /etc/init.d/zoneminder start
0     0 18734 18729  20   0  26408  8792 -      S    ?          0:00 /usr/bin/perl -wT /usr/bin/zmpkg.pl start
4     0 18741 18734  20   0   5968  1096 -      S    ?          0:00 /bin/systemctl start zoneminder
```
