### PR TITLE
Create zmuser along with dB contents

### DIFF
--- a/db/zm_create.sql.in
+++ b/db/zm_create.sql.in
@@ -19,6 +19,8 @@
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `@ZM_DB_NAME@`;
 
+GRANT select,insert,update,delete,lock tables,alter on zm.* to '@ZM_DB_USER@'@localhost identified by '@ZM_DB_PASS@';
+
 USE `@ZM_DB_NAME@`;
 
 --


### PR DESCRIPTION
Looking for feedback.
Is there any reason why we can't auto-create zmuser when we create a new database?
