### PR TITLE
echo the URL to the RTSP device during the OPTIONS directive

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -361,7 +361,7 @@ int RtspThread::run()
     int localPorts[2] = { 0, 0 };
 
     // Request supported RTSP commands by the server
-    message = "OPTIONS * RTSP/1.0\r\n";
+    message = "OPTIONS "+mUrl+" RTSP/1.0\r\n";
     if ( !sendCommand( message ) )
         return( -1 );
     if ( !recvResponse( response ) )
@@ -680,7 +680,7 @@ int RtspThread::run()
             select.addReader( &mRtspSocket );
 
             Buffer buffer( ZM_NETWORK_BUFSIZ );
-            std::string keepaliveMessage = "OPTIONS * RTSP/1.0\r\n";
+            std::string keepaliveMessage = "OPTIONS "+mUrl+" RTSP/1.0\r\n";
             std::string keepaliveResponse = "RTSP/1.0 200 OK\r\n";
             while ( !mStop && select.wait() >= 0 )
             {


### PR DESCRIPTION
The RTSP code in zoneminder follows RFC 2326 pretty closely, as it should.

The initial handshake between zoneminder and rtsp camera is broken down into directives. The first directive sent to the camera is called OPTIONS and, according to RFC 2326, it should look like this:
`OPTIONS * RTSP/1.0`

Indeed that is exactly what zoneminder does.  However, over the years of using zoneminder, I have never had a camera that accepted this.  Each camera would immediately respond with "Bad Request".

The interesting thing is the [WiKi](http://en.wikipedia.org/wiki/Real_Time_Streaming_Protocol#Protocol_directives) shows a different OPTIONS directive.  

Instead of sending *, it sends the devices own URL back to it.  Further investigation using wireshark reveals that is exactly what ffmpeg & vlc do.  They don't send * with their OPTIONS directive.  Instead, they send the URL.

This pull request brings zoneminder in-line with what ffmepg & vlc do.  I can't explain why the RTSP RFC isn't being followed in this case, but it appears that is what we need to do (e.g. everyone else is doing it!).

I've tested this on my Foscam 9821.  Foscam is not only fairly popular, but its firmware is cloned by many other manufacturers.  That means this should allow the RTSP method to work with a lot of cameras now.
