### PR TITLE
RTSP Fixes

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -560,7 +560,11 @@ int RtspThread::run()
 
     int seq = 0;
     unsigned long rtpTime = 0;
-    if ( rtpInfo )
+    if ( rtpInfo.empty() )
+    {
+	Debug( 1, "No RTP Info from Camera. Starting values for Sequence and Rtptime shall be zero.");
+    }
+    else
     {
 	Debug( 2, "Got RTP Info %s", rtpInfo );
 	parts = split( rtpInfo.c_str(), ";" );
@@ -578,8 +582,6 @@ int RtspThread::run()
 	    }
 	}
     }
-    else
-	Debug( 1, "No RTP Info from Camera. Starting values for Sequence and Rtptime shall be zero.");
 
     Debug( 2, "RTSP Seq is %d", seq );
     Debug( 2, "RTSP Rtptime is %ld", rtpTime );


### PR DESCRIPTION
Missing RTP Info should be non-fatal
commits 9a7220d and b600be1

When using the RTSP method, zoneminder listens for the camera to send the RTP sequence and rpttime values during the initial handshake.  This allows zoneminder to verify that the first video frames are in the proper sequence.  However, some devices just don't send this information (yet they still work fine with ffmpeg & vlc).  All is not lost if we don't have it.

By setting seq & rtptime to zero, we guarantee that the first frame will be flagged as out-of-sequence, but that also triggers the re-sync logic to get back into the proper sequence.

The end user will get warnings in the log similar to the following, but as long as zoneminder understands the stream coming from the camera, it should work.

```
2014-11-29 14:41:53.599501  zmc_m7  22318   WAR Discarding incomplete frame 0, 0 bytes  /home/abauer/rpmbuild/BUILD/ZoneMinder-1.28digest/src/zm_rtp_source.cpp 336
2014-11-29 14:41:53.494540  zmc_m7  22318   WAR Discarding frame 0  /home/abauer/rpmbuild/BUILD/ZoneMinder-1.28digest/src/zm_rtp_source.cpp 349
2014-11-29 14:41:53.492548  zmc_m7  22318   WAR Sequence in probation 2, out of sequence    /home/abauer/rpmbuild/BUILD/ZoneMinder-1.28digest/src/zm_rtp_source.cpp 112
```
