### PR TITLE
Login screen instead of error

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -64,11 +64,11 @@ else
     $skin = "classic";
 
 if ( isset($_GET['css']) )
-	$css = $_GET['css'];
+    $css = $_GET['css'];
 elseif ( isset($_COOKIE['zmCSS']) )
-	$css = $_COOKIE['zmCSS'];
+    $css = $_COOKIE['zmCSS'];
 else
-	$css = "classic";
+    $css = "classic";
 
 define( "ZM_BASE_PATH", dirname( $_SERVER['REQUEST_URI'] ) );
 define( "ZM_SKIN_PATH", "skins/$skin" );
@@ -90,8 +90,8 @@ if ( !isset($_SESSION['skin']) || isset($_REQUEST['skin']) )
 }
 
 if ( !isset($_SESSION['css']) || isset($_REQUEST['css']) ) {
-	$_SESSION['css'] = $css;
-	setcookie( "zmCSS", $css, time()+3600*24*30*12*10 );
+    $_SESSION['css'] = $css;
+    setcookie( "zmCSS", $css, time()+3600*24*30*12*10 );
 }
 
 require_once( 'includes/config.php' );
@@ -142,7 +142,18 @@ else
                 Fatal( "View '$view' does not exist" );
             require_once $includeFile;
         }
+        
+        // If the view overrides $view to 'error', and the user is not logged in, then the
+        // issue is probably resolvable by logging in, so provide the opportunity to do so.
+        // The login view should handle redirecting to the correct location afterward.
+        if ($view == 'error' && !isset($user))
+        {
+            foreach ( getSkinIncludes( 'views/login.php', true, true ) as $includeFile )
+                require_once $includeFile;
+        }
     }
+    // If the view is missing or the view still returned error with the user logged in,
+    // then it is not recoverable.
     if ( !$includeFiles || $view == 'error' )
     {
         foreach ( getSkinIncludes( 'views/error.php', true, true ) as $includeFile )

--- a/web/skins/classic/views/js/postlogin.js
+++ b/web/skins/classic/views/js/postlogin.js
@@ -1,1 +1,0 @@
-(function () { window.location.replace( thisUrl ); }).delay( 500 );

--- a/web/skins/classic/views/js/postlogin.js.php
+++ b/web/skins/classic/views/js/postlogin.js.php
@@ -1,0 +1,23 @@
+<?php
+// $thisUrl is the base URL used to access ZoneMinder.
+//
+// If the user attempts to access a privileged view but is not logged in, then he may
+// be given the opportunity to log in via the login view.  In that case, the login view
+// will save the GET request via the postLoginQuery variable.  After logging in, this
+// view receives the postLoginQuery via the login form submission, and we can then
+// redirect the user to his original intended destination by appending it to the URL.
+?>
+
+(
+    function () 
+    {
+        // Append '?(GET query)' to URL if the GET query is not empty.
+        var querySuffix = "<?php
+            if (!empty($_POST["postLoginQuery"]))
+                echo "?".$_POST["postLoginQuery"];
+            ?>";
+
+        var newUrl = thisUrl + querySuffix;
+        window.location.replace(newUrl);
+    }
+).delay( 500 );

--- a/web/skins/classic/views/login.php
+++ b/web/skins/classic/views/login.php
@@ -29,6 +29,7 @@ xhtmlHeaders(__FILE__, $SLANG['Login'] );
       <form name="loginForm" id="loginForm" method="post" action="<?php echo $_SERVER['PHP_SELF'] ?>">
         <input type="hidden" name="action" value="login"/>
         <input type="hidden" name="view" value="postlogin"/>
+        <input type="hidden" name="postLoginQuery" value="<?php echo $_SERVER['QUERY_STRING'] ?>">
         <table id="loginTable" class="minor" cellspacing="0">
           <tbody>
             <tr>


### PR DESCRIPTION
If a view returns an error and the user is not logged in, the user gets
a login prompt which auto redirects him to the originally intended
location after he logs in.  Postlogin.js.php now redirects to the
ZoneMinder URL with any specified GET query string appended to the URL.
 The query string is saved as a hidden field in the login screen so
that after the user logs in, he gets redirected to his original
destination instead of the ZM console.

If the user is logged in and there is an error, then the user gets the
original error screen.

This change allows a person to click a ZoneMinder event e-mail link,
enter his username and password, and then see the intended event
without having to access the ZoneMinder front page separately to log in
first.

Changed a couple stray tabs to spaces in login.php.
