### PR TITLE
Don't check for zmdc.pl when stopping via systemd

### DIFF
--- a/distros/debian8/zoneminder.service
+++ b/distros/debian8/zoneminder.service
@@ -12,7 +12,7 @@ User=www-data
 Type=forking
 ExecStart=/usr/bin/zmpkg.pl start
 ExecReload=/usr/bin/zmpkg.pl restart
-ExecStop=/bin/bash -c '[[ "$(/usr/bin/pgrep zmdc.pl)" > 0 ]] && /usr/bin/zmpkg.pl stop'
+ExecStop=/usr/bin/zmpkg.pl stop
 PIDFile=/var/run/zm/zm.pid
 
 [Install]


### PR DESCRIPTION
If this check ever actually returns true, it makes ExecStop a no-op
and systemd will forcefully kill all processes in the service
see man systemd.service

This also prevents a deadlock when running systemctl stop,
zmpkg.pl detects bash as it's parent and attempts to call
systemctl stop itself, which blocks forever waiting for the
task it's in to complete
