### PR TITLE
Versions command line args

### DIFF
--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -69,6 +69,7 @@ delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
 my $report = 0;
 my $interactive = 0;
 my $continuous = 0;
+my $version;
 
 sub usage
 {
@@ -78,6 +79,7 @@ Parameters are :-
 -r, --report                    - Just report don't actually do anything
 -i, --interactive               - Ask before applying any changes
 -c, --continuous                - Run continuously
+-v, --version					- Print the installed version of ZoneMinder
 ");
     exit( -1 );
 }
@@ -89,14 +91,18 @@ sub deleteSwapImage();
 logInit();
 logSetSignal();
 
-if ( !GetOptions( 'report'=>\$report, 'interactive'=>\$interactive, 'continuous'=>\$continuous ) )
+if ( !GetOptions( report=>\$report, interactive=>\$interactive, continuous=>\$continuous, version=>\$version ) )
 {
     usage();
 }
 
+if ( $version ) {
+	print( ZoneMinder::Base::ZM_VERSION . "\n");
+	exit(0);
+}
 if ( ($report + $interactive + $continuous) > 1 )
 {
-    print( STDERR "Error, only option may be specified\n" );
+    print( STDERR "Error, only one option may be specified\n" );
     usage();
 }
 

--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -55,15 +55,20 @@ my $noregex = 0;
 my $sqlfile = '';
 my $dbUser = $Config{ZM_DB_USER};
 my $dbPass = $Config{ZM_DB_PASS};
+my $version = 0;
 
 # Process commandline parameters with getopt long
-if ( !GetOptions( 'export'=>\$export, 'import'=>\$import, 'overwrite'=>\$overwrite, 'help'=>\$help, 'topreset'=>\$topreset, 'noregex'=>\$noregex, 'user:s'=>\$dbUser, 'pass:s'=>\$dbPass ) ) {
+if ( !GetOptions( 'export'=>\$export, 'import'=>\$import, 'overwrite'=>\$overwrite, 'help'=>\$help, 'topreset'=>\$topreset, 'noregex'=>\$noregex, 'user:s'=>\$dbUser, 'pass:s'=>\$dbPass, 'version'=>\$version ) ) {
 	Usage();
 }
 
 $Config{ZM_DB_USER} = $dbUser;
 $Config{ZM_DB_PASS} = $dbPass;
 
+if ( $version ) {
+	print( ZoneMinder::Base::ZM_VERSION . "\n");
+	exit(0);
+}
 # Check to make sure commandline params make sense
 if ( ((!$help) && ($import + $export + $topreset) != 1 )) {
 	print( STDERR qq/Please give only one of the following: "import", "export", or "topreset".\n/ );

--- a/scripts/zmdc.pl.in
+++ b/scripts/zmdc.pl.in
@@ -78,7 +78,7 @@ sub Usage
 Usage: zmdc.pl <command> [daemon [options]]
 Parameters are :-
 <command>           - One of 'startup|shutdown|status|check|logrot' or
-                      'start|stop|restart|reload'.
+                      'start|stop|restart|reload|version'.
 [daemon [options]]  - Daemon name and options, required for second group of commands
 ");     
     exit( -1 );
@@ -90,7 +90,11 @@ if( !$command )
     print( STDERR "No command given\n" );
     Usage();
 }
-my $needs_daemon = $command !~ /(?:startup|shutdown|status|check|logrot)/;
+if ( $command eq 'version' ) {
+	print ZoneMinder::Base::ZM_VERSION."\n";
+	exit( 0 );
+}
+my $needs_daemon = $command !~ /(?:startup|shutdown|status|check|logrot|version)/;
 my $daemon = shift( @ARGV );
 if( $needs_daemon && !$daemon )
 {

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -115,11 +115,12 @@ delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
 my $delay = $Config{ZM_FILTER_EXECUTE_INTERVAL};
 my $event_id = 0;
 my $filter_parm = "";
+my $version = 0;
 
 sub Usage
 {
     print( "
-Usage: zmfilter.pl [-f <filter name>,--filter=<filter name>]
+Usage: zmfilter.pl [-f <filter name>,--filter=<filter name>] | -v, --version
 Parameters are :-
 -f<filter name>, --filter=<filter name>  - The name of a specific filter to run
 ");
@@ -158,9 +159,13 @@ sub DateTimeToSQL
     return( strftime( "%Y-%m-%d %H:%M:%S", localtime( $dt_val ) ) );
 }
 
-if ( !GetOptions( 'filter=s'=>\$filter_parm ) )
+if ( !GetOptions( 'filter=s'=>\$filter_parm, version=>\$version ) )
 {
     Usage();
+}
+if ( $version ) {
+	print ZoneMinder::Base::ZM_VERSION . "\n";
+	exit(0);
 }
 
 if ( ! EVENT_PATH ) {

--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -47,15 +47,20 @@ delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
 logInit();
 
 my $command = $ARGV[0];
+if ( $command eq 'version' ) {
+	print ZoneMinder::Base::ZM_VERSION . "\n";
+	exit(0);
+}
 
 my $state;
 
-my $dbh = zmDbConnect();
+my $dbh;
 
-if ( !$command || $command !~ /^(?:start|stop|restart|status|logrot)$/ )
+if ( !$command || $command !~ /^(?:start|stop|restart|status|logrot|version)$/ )
 {
 	if ( $command )
 	{
+		$dbh = zmDbConnect();
 		# Check to see if it's a valid run state
 		my $sql = 'select * from States where Name = ?';
 		my $sth = $dbh->prepare_cached( $sql ) or Fatal( "Can't prepare '$sql': ".$dbh->errstr() );
@@ -78,10 +83,11 @@ if ( !$command || $command !~ /^(?:start|stop|restart|status|logrot)$/ )
 	}
 	if ( !$command )
 	{
-		print( "Usage: zmpkg.pl <start|stop|restart|status|logrot|'state'>\n" );
+		print( "Usage: zmpkg.pl <start|stop|restart|status|logrot|'state'|version>\n" );
 		exit( -1 );
 	}
 }
+$dbh = zmDbConnect() if ! $dbh;
 
 # Move to the right place
 chdir( $Config{ZM_PATH_WEB} ) or Fatal( "Can't chdir to '".$Config{ZM_PATH_WEB}."': $!" );

--- a/scripts/zmsystemctl.pl.in
+++ b/scripts/zmsystemctl.pl.in
@@ -35,10 +35,10 @@ use ZoneMinder::Logger qw(:all);
 
 my $command = $ARGV[0];
 
-if ( (scalar(@ARGV) == 1) && ($command =~ /^(start|stop|restart)$/ )) {
+if ( (scalar(@ARGV) == 1) && ($command =~ /^(start|stop|restart|version)$/ )) {
 	$command = $1;
 } else {
-	die(" USAGE: zmsystemctl.pl <start|stop|restart>\n");
+	die(" USAGE: zmsystemctl.pl <start|stop|restart|version>\n");
 }
 
 my $path = qx(which systemctl);

--- a/scripts/zmvideo.pl.in
+++ b/scripts/zmvideo.pl.in
@@ -55,6 +55,7 @@ my $scale = '';
 my $fps = '';
 my $size = '';
 my $overwrite = 0;
+my $version = 0;
 
 my @formats = split( /\s+/, $Config{ZM_FFMPEG_FORMATS} );
 for ( my $i = 0; $i < @formats; $i++ )
@@ -77,13 +78,19 @@ Parameters are :-
 -F<fps>, --fps=<fps>              - Absolute frame rate, in frames per second
 -S<size>, --size=<size>           - Absolute video size, WxH or other specification supported by ffmpeg
 -o, --overwrite                   - Whether to overwrite an existing file, off by default.
+-v, --version                     - Outputs the currently installed version of ZoneMinder
 ");
 	exit( -1 );
 }
 
-if ( !GetOptions( 'event=i'=>\$event_id, 'format|f=s'=>\$format, 'rate|r=f'=>\$rate, 'scale|s=f'=>\$scale, 'fps|F=f'=>\$fps, 'size|S=s'=>\$size, 'overwrite'=>\$overwrite ) )
+if ( !GetOptions( 'event=i'=>\$event_id, 'format|f=s'=>\$format, 'rate|r=f'=>\$rate, 'scale|s=f'=>\$scale, 'fps|F=f'=>\$fps, 'size|S=s'=>\$size, 'overwrite'=>\$overwrite, version=>\$version ) )
 {
 	Usage();
+}
+
+if ( $version ) {
+	print ZoneMinder::Base::ZM_VERSION . "\n";
+	exit(0);
 }
 
 if ( !$event_id || $event_id < 0 )

--- a/scripts/zmx10.pl.in
+++ b/scripts/zmx10.pl.in
@@ -63,6 +63,7 @@ Usage: zmx10.pl -c <command>,--command=<command> [-u <unit code>,--unit-code=<un
 Parameters are :-
 -c <command>, --command=<command>       - Command to issue, one of 'on','off','dim','bright','status','shutdown'
 -u <unit code>, --unit-code=<unit code> - Unit code to act on required for all commands except 'status' (optional) and 'shutdown'
+-v, --verison                           - Pirnts the currently installed version of ZoneMinder
 ");
 	exit( -1 );
 }
@@ -72,10 +73,15 @@ logSetSignal();
 
 my $command;
 my $unit_code;
+my $version;
 
-if ( !GetOptions( 'command=s'=>\$command, 'unit-code=i'=>\$unit_code ) )
+if ( !GetOptions( 'command=s'=>\$command, 'unit-code=i'=>\$unit_code, version=>\$version ) )
 {
     Usage();
+}
+if ( $version ) {
+	print ZoneMinder::Base::ZM_VERSION;
+	exit(0);
 }
 
 die( "No command given" ) unless( $command );

--- a/src/zma.cpp
+++ b/src/zma.cpp
@@ -31,6 +31,7 @@ void Usage()
 	fprintf( stderr, "Options:\n" );
 	fprintf( stderr, "  -m, --monitor <monitor_id>   : Specify which monitor to use\n" );
 	fprintf( stderr, "  -h, --help                   : This screen\n" );
+	fprintf( stderr, "  -v, --version                : Report the installed version of ZoneMinder\n" );		
 	exit( 0 );
 }
 
@@ -45,6 +46,7 @@ int main( int argc, char *argv[] )
 	static struct option long_options[] = {
 		{"monitor", 1, 0, 'm'},
 		{"help", 0, 0, 'h'},
+		{"version", 0, 0, 'v'},
 		{0, 0, 0, 0}
 	};
 
@@ -52,7 +54,7 @@ int main( int argc, char *argv[] )
 	{
 		int option_index = 0;
 
-		int c = getopt_long (argc, argv, "m:h", long_options, &option_index);
+		int c = getopt_long (argc, argv, "m:h:v", long_options, &option_index);
 		if (c == -1)
 		{
 			break;
@@ -67,6 +69,9 @@ int main( int argc, char *argv[] )
 			case '?':
 				Usage();
 				break;
+			case 'v':
+				cout << ZM_VERSION << "\n";
+				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );
 				break;

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -45,6 +45,7 @@ void Usage()
 	fprintf( stderr, "  -f, --file <file_path>                   : For local images, jpg file to access.\n" );
 	fprintf( stderr, "  -m, --monitor <monitor_id>               : For sources associated with a single monitor\n" );
 	fprintf( stderr, "  -h, --help                               : This screen\n" );
+	fprintf( stderr, "  -v, --version                            : Report the installed version of ZoneMinder\n" );
 	exit( 0 );
 }
 
@@ -71,6 +72,7 @@ int main( int argc, char *argv[] )
 	 	{"file", 1, 0, 'f'},
 		{"monitor", 1, 0, 'm'},
 		{"help", 0, 0, 'h'},
+		{"version", 0, 0, 'v'},
 		{0, 0, 0, 0}
 	};
 
@@ -78,7 +80,7 @@ int main( int argc, char *argv[] )
 	{
 		int option_index = 0;
 
-		int c = getopt_long (argc, argv, "d:H:P:p:f:m:h", long_options, &option_index);
+		int c = getopt_long (argc, argv, "d:H:P:p:f:m:h:v", long_options, &option_index);
 		if (c == -1)
 		{
 			break;
@@ -108,6 +110,9 @@ int main( int argc, char *argv[] )
 			case '?':
 				Usage();
 				break;
+			case 'v':
+				cout << ZM_VERSION << "\n";
+				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );
 				break;

--- a/src/zmf.cpp
+++ b/src/zmf.cpp
@@ -99,6 +99,7 @@ void Usage()
 	fprintf( stderr, "Options:\n" );
 	fprintf( stderr, "  -m, --monitor <monitor_id>   : Specify which monitor to use\n" );
 	fprintf( stderr, "  -h, --help                   : This screen\n" );
+	fprintf( stderr, "  -v, --version                : Report the installed version of ZoneMinder\n" );
 	exit( 0 );
 }
 
@@ -113,6 +114,7 @@ int main( int argc, char *argv[] )
 	static struct option long_options[] = {
 		{"monitor", 1, 0, 'm'},
 		{"help", 0, 0, 'h'},
+		{"version", 0, 0, 'v'},
 		{0, 0, 0, 0}
 	};
 
@@ -120,7 +122,7 @@ int main( int argc, char *argv[] )
 	{
 		int option_index = 0;
 
-		int c = getopt_long (argc, argv, "m:h", long_options, &option_index);
+		int c = getopt_long (argc, argv, "m:h:v", long_options, &option_index);
 		if (c == -1)
 		{
 			break;
@@ -135,6 +137,9 @@ int main( int argc, char *argv[] )
 			case '?':
 				Usage();
 				break;
+			case 'v':
+				cout << ZM_VERSION << "\n";
+				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );
 				break;

--- a/src/zmstreamer.cpp
+++ b/src/zmstreamer.cpp
@@ -33,7 +33,7 @@
 #include "zm_stream.h"
 
 // Possible command-line options
-#define OPTIONS "e:o:u:f:s:b:m:d:i:?"
+#define OPTIONS "e:o:u:f:s:b:m:d:i:?:h:v"
 
 // Default ZMS values
 #define ZMS_DEFAULT_DEBUG 0
@@ -87,6 +87,7 @@ int main(int argc, char** argv) {
             case 'd':
                 debug = atoi(optarg);
                 break;
+            case 'h':
             case 'i':
             case '?':
                 printf("-e <mode> : Specify output mode: mpeg/jpg/zip/single/raw. Default = %s\n", ZMS_DEFAULT_MODE);
@@ -97,8 +98,12 @@ int main(int argc, char** argv) {
                 printf("-b <bitrate in bps> : Specify bitrate. Default = %d\n", ZMS_DEFAULT_BITRATE);
                 printf("-m <monitor id> : Specify monitor id. Default = %d\n", ZMS_DEFAULT_ID);
                 printf("-d <debug mode> : 0 = off, 1 = no streaming, 2 = with streaming. Default = 0\n");
-                printf("-i or -? : This information\n");
+                printf("-i or -? or -h: This information\n");
+                printf("-v : This installed version of ZoneMinder\n");
                 return EXIT_SUCCESS;
+            case 'v':
+                cout << ZM_VERSION << "\n";
+                exit(0);
         }
     }
 


### PR DESCRIPTION
This implements a -v and a --version or just a version command as appropriate to the various programs that make up ZoneMinder.

Why?  Because we no longer have the version in the config file and so it is slightly harder to get the current version in a script or whatnot.

