### PR TITLE
Kill zmcontrol

### DIFF
--- a/scripts/zmcontrol.pl.in
+++ b/scripts/zmcontrol.pl.in
@@ -192,8 +192,11 @@ if ( !$server_up )
                     #Debug( Dumper( $params ) );
 
                     my $command = $params->{command};
-                    $control->$command( $params );
                     close( CLIENT );
+					if ( $command eq 'quit' ) {
+						last;
+					}
+                    $control->$command( $params );
                 }
                 else
                 {

--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -277,11 +277,6 @@ if ( !empty($action) )
                     zmaControl( $monitor, "stop" );
                     zmcControl( $monitor, $restart?"restart":"" );
                     zmaControl( $monitor, "start" );
-					if ( $monitor['Controllable'] ) {
-						require_once( 'control_functions.php' );
-						sendControlCommand( $mid, 'quit' );
-					} 
-					$ctrlCommand = ZM_PATH_BIN."/zmcontrol.pl --id=$mid --command=quit";
                 }
                 $refreshParent = true;
             }
@@ -541,6 +536,10 @@ if ( !empty($action) )
                     zmcControl( $monitor, "restart" );
                     zmaControl( $monitor, "start" );
                 }
+				if ( $monitor['Controllable'] ) {
+					require_once( 'control_functions.php' );
+					sendControlCommand( $mid, 'quit' );
+				} 
                 //daemonControl( 'restart', 'zmwatch.pl' );
                 $refreshParent = true;
             }

--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -175,40 +175,7 @@ if ( !empty($action) )
             $monitor = dbFetchOne( "select C.*,M.* from Monitors as M inner join Controls as C on (M.ControlId = C.Id) where M.Id = ?", NULL, array($mid) );
 
             $ctrlCommand = buildControlCommand( $monitor );
-
-            if ( $ctrlCommand )
-            {
-                $socket = socket_create( AF_UNIX, SOCK_STREAM, 0 );
-                if ( $socket < 0 )
-                {
-                    Fatal( "socket_create() failed: ".socket_strerror($socket) );
-                }
-                $sockFile = ZM_PATH_SOCKS.'/zmcontrol-'.$monitor['Id'].'.sock';
-                if ( @socket_connect( $socket, $sockFile ) )
-                {
-                    $options = array();
-                    foreach ( explode( " ", $ctrlCommand ) as $option )
-                    {
-                        if ( preg_match( '/--([^=]+)(?:=(.+))?/', $option, $matches ) )
-                        {
-                            $options[$matches[1]] = $matches[2]?$matches[2]:1;
-                        }
-                    }
-                    $optionString = jsonEncode( $options );
-                    if ( !socket_write( $socket, $optionString ) )
-                    {
-                        Fatal( "Can't write to control socket: ".socket_strerror(socket_last_error($socket)) );
-                    }
-                    socket_close( $socket );
-                }
-                else
-                {
-                    $ctrlCommand .= " --id=".$monitor['Id'];
-
-                    // Can't connect so use script
-                    $ctrlOutput = exec( escapeshellcmd( $ctrlCommand ) );
-                }
-            }
+			sendControlCommand( $monitor['Id'], $ctrlCommand );
         }
         elseif ( $action == "settings" )
         {
@@ -310,6 +277,11 @@ if ( !empty($action) )
                     zmaControl( $monitor, "stop" );
                     zmcControl( $monitor, $restart?"restart":"" );
                     zmaControl( $monitor, "start" );
+					if ( $monitor['Controllable'] ) {
+						require_once( 'control_functions.php' );
+						sendControlCommand( $mid, 'quit' );
+					} 
+					$ctrlCommand = ZM_PATH_BIN."/zmcontrol.pl --id=$mid --command=quit";
                 }
                 $refreshParent = true;
             }

--- a/web/includes/control_functions.php
+++ b/web/includes/control_functions.php
@@ -963,3 +963,30 @@ function buildControlCommand( $monitor )
     $ctrlCommand .= " --command=".$_REQUEST['control'];
     return( $ctrlCommand );
 }
+
+function sendControlCommand($mid,$command) {
+	// Either connects to running zmcontrol.pl or runs zmcontrol.pl to send the command.
+	$socket = socket_create( AF_UNIX, SOCK_STREAM, 0 );
+	if ( $socket < 0 ) {
+		Fatal( "socket_create() failed: ".socket_strerror($socket) );
+	}
+	$sockFile = ZM_PATH_SOCKS.'/zmcontrol-'.$mid.'.sock';
+	if ( @socket_connect( $socket, $sockFile ) ) {
+		$options = array();
+		foreach ( explode( " ", $command ) as $option ) {
+			if ( preg_match( '/--([^=]+)(?:=(.+))?/', $option, $matches ) ) {
+				$options[$matches[1]] = $matches[2]?$matches[2]:1;
+			}
+		}
+		$optionString = jsonEncode( $options );
+		if ( !socket_write( $socket, $optionString ) ) {
+			Fatal( "Can't write to control socket: ".socket_strerror(socket_last_error($socket)) );
+		}
+		socket_close( $socket );
+	} else if ( $command != 'quit' ) {
+		$command .= ' --id='.$mid;
+
+		// Can't connect so use script
+		$ctrlOutput = exec( escapeshellcmd( $command ) );
+	}
+} // end function sendControlCommand( $mid, $command )


### PR DESCRIPTION
This sends a quit command to the running zmcontrol.pl process for a monitor that is edited.

Fixes #590 