### PR TITLE
Monitorprobe - User selectable ARP tool

### DIFF
--- a/db/zm_update-1.28.99.sql
+++ b/db/zm_update-1.28.99.sql
@@ -1,0 +1,6 @@
+-- 
+-- New values for the Config table
+-- 
+insert into Config set Id = 107, Name = 'ZM_PATH_ARP', Value = '/sbin/ip neigh', Type = 'string', DefaultValue = '/sbin/ip neigh', Hint = '/absolute/path/to/somewhere', Pattern = '(?-xism:^((?:/[^/]*)+?)/?$)', Format = ' $1 ', Prompt = 'Path to a supported ARP tool', Help = 'The camera probe function uses Address Resolution Protocol in order to find known devices on the network. Supply the full path to \"ip neigh\", \"arp -a\", or any other tool on your system that returns ip/mac address pairs.', Category = 'paths', Readonly = '0', Requires = '';
+
+

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -655,6 +655,14 @@ our @options =
 		category => "paths",
 	},
 	{
+		name => "ZM_PATH_ARP",
+		default => "/sbin/ip neigh",
+		description => "Path to a supported ARP tool",
+		help => "The camera probe function uses Address Resolution Protocol in order to find known devices on the network. Supply the full path to \"ip neigh\", \"arp -a\", or any other tool on your system that returns ip/mac address pairs.",
+		type => $types{abs_path},
+		category => "paths",
+	},
+	{
 		name => "ZM_WEB_TITLE_PREFIX",
 		default => "ZM",
 		description => "The title prefix displayed on each window",

--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -287,27 +287,26 @@ $macBases = array(
 );
 
 unset($output);
-// Calling arp without the full path was reported to fail on some systems
+// Calling ip without the full path was reported to fail on some systems
 // Use the builtin unix command "type" to tell us where the command is
-$command = "type -p arp";
+$command = "type -p ip";
 $result = exec( escapeshellcmd($command), $output, $status );
 if ( $status )
-    Fatal( "Unable to determine path for arp command, type -p arp returned '$status'" );
-// Now that we know where arp is, call it using the full path
-$command = $output[0]." -a";
+    Fatal( "Unable to determine path for ip command, type -p ip returned '$status'" );
+// Now that we know where ip is, call it using the full path
+$command = $output[0]." neigh";
 unset($output);
 $result = exec( escapeshellcmd($command), $output, $status );
 if ( $status )
     Fatal( "Unable to probe network cameras, status is '$status'" );
 foreach ( $output as $line )
 {
-    if ( !preg_match( '/^(\S+) \(([\d.]+)\) at ([0-9a-f:]+)/', $line, $matches ) )
+    if ( !preg_match( '/^([\d.]+) \S+ \S+ \S+ ([0-9a-f:]+) REACHABLE$/', $line, $matches ) )
         continue;
-    $host = $matches[1];
-    $ip = $matches[2];
-    if ( !$host || $host == '?' )
-        $host = $ip;
-    $mac = $matches[3];
+    $ip = $matches[1];
+	// $host could be assigned by DNS reverse lookup for old behavior
+    $host = $ip;
+    $mac = $matches[2];
     //echo "I:$ip, H:$host, M:$mac<br/>";
     $macRoot = substr($mac,0,8);
     if ( isset($macBases[$macRoot]) )

--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -286,22 +286,19 @@ $macBases = array(
     '78:a5:dd' => array( 'type'=>'Wansview','probeFunc'=>'probeWansview' )
 );
 
-unset($output);
-// Calling ip without the full path was reported to fail on some systems
-// Use the builtin unix command "type" to tell us where the command is
-$command = "type -p ip";
-$result = exec( escapeshellcmd($command), $output, $status );
-if ( $status )
-    Fatal( "Unable to determine path for ip command, type -p ip returned '$status'" );
-// Now that we know where ip is, call it using the full path
-$command = $output[0]." neigh";
+$result = explode( " ", ZM_PATH_ARP );
+if ( !is_executable( $result[0] ) )
+	Fatal( "ARP tool not found. Verify ZM_PATH_ARP points to a valid arp tool, and it is marked executable." );
+
+$command = ZM_PATH_ARP;
+
 unset($output);
 $result = exec( escapeshellcmd($command), $output, $status );
 if ( $status )
     Fatal( "Unable to probe network cameras, status is '$status'" );
 foreach ( $output as $line )
 {
-    if ( !preg_match( '/^([\d.]+) \S+ \S+ \S+ ([0-9a-f:]+) REACHABLE$/', $line, $matches ) )
+    if ( !preg_match( '/^.*([\d.]+).*([0-9a-f:]+).*/', $line, $matches ) )
         continue;
     $ip = $matches[1];
 	// $host could be assigned by DNS reverse lookup for old behavior


### PR DESCRIPTION
The arp command is considered a legacy utility now. This replaces arp with
iproute2's ip neigh command.

One side effect: The $host variable is just set to $ip since ip neigh does not
use DNS. DNS resolution can be added back in with several different utilities
if desired. But DNS resolution tends to slow down response time.