### PR TITLE
this fixes Digest Auth for the mjpeg stream on a TV-IP302PI

### DIFF
--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -114,7 +114,7 @@ std::string Authenticator::getAuthHeader(std::string method, std::string uri)
 		if ( ! fQop.empty() ) {
 			result += ", qop=" + fQop;
 			result += ", nc=" + stringtf("%08x",nc);
-			result += ", cnonce=\"" + fCnonce "\"";
+			result += ", cnonce=\"" + fCnonce + "\"";
 		}
 		result += ", response=\"" + computeDigestResponse(method, uri) + "\"";
 		result += ", algorithm=\"MD5\"";

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -114,9 +114,10 @@ std::string Authenticator::getAuthHeader(std::string method, std::string uri)
 		if ( ! fQop.empty() ) {
 			result += ", qop=" + fQop;
 			result += ", nc=" + stringtf("%08x",nc);
-			result += ", cnonce=" + fCnonce;
+			result += ", cnonce=\"" + fCnonce "\"";
 		}
 		result += ", response=\"" + computeDigestResponse(method, uri) + "\"";
+		result += ", algorithm=\"MD5\"";
                   
         //Authorization: Digest username="zm",
         //                      realm="NC-336PW-HD-1080P",


### PR DESCRIPTION
Digest Auth worked for the RTSP stream, but not http.
This adds quotes around the cnonce value, which matches what curl and wget do and adds the algorithm line which also matches what curl and wget do.  With these two changes the auth is accepted.