### PR TITLE
fix content-type parsing when there are options on it

### DIFF
--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -446,6 +446,13 @@ int RemoteCameraHttp::GetResponse()
                 }
                 case CONTENT :
                 {
+
+					// if content_type is something like image/jpeg;size=, this will strip the ;size=
+					char * semicolon = strchr( (char *)content_type, ';' );
+					if ( semicolon ) {
+						*semicolon = '\0';
+					}
+
                     if ( !strcasecmp( content_type, "image/jpeg" ) || !strcasecmp( content_type, "image/jpg" ) )
                     {
                         format = JPEG;
@@ -1010,7 +1017,14 @@ int RemoteCameraHttp::GetResponse()
                 }
                 case CONTENT :
                 {
-                    if ( !strcasecmp( content_type, "image/jpeg" ) || !strcasecmp( content_type, "image/jpg" ) )
+
+					// if content_type is something like image/jpeg;size=, this will strip the ;size=
+					char * semicolon = strchr( content_type, ';' );
+					if ( semicolon ) {
+						*semicolon = '\0';
+					}
+
+					if ( !strcasecmp( content_type, "image/jpeg" ) || !strcasecmp( content_type, "image/jpg" ) )
                     {
                         format = JPEG;
                     }


### PR DESCRIPTION
I have a camera a Trendnet TV-IP302PI that when it send the mjpeg stream it gives it a content-type of image/jpeg;size=

this is legal.  You can have options in the content-type.  So I've added some code to find the ; and drop the rest.