### PR TITLE
Improve delete event

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -574,9 +574,10 @@ if ( !empty($action) )
                             // well time out before completing, in which case zmaudit will still tidy up
                             if ( !ZM_OPT_FAST_DELETE )
                             {
-                                $markEids = dbFetchAll( "select Id from Events where MonitorId=?", 'Id', array($markMid) );
+								// Slight hack, we maybe should load *, but we happen to know that the deleteEvent function uses Id and StartTime.
+                                $markEids = dbFetchAll( "SELECT Id,StartTime FROM Events WHERE MonitorId=?", NULL, array($markMid) );
                                 foreach( $markEids as $markEid )
-                                    deleteEvent( $markEid );
+                                    deleteEvent( $markEid, $markMid );
 
                                 deletePath( ZM_DIR_EVENTS."/".basename($monitor['Name']) );
                                 deletePath( ZM_DIR_EVENTS."/".$monitor['Id'] ); // I'm trusting the Id.  

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -507,42 +507,57 @@ function deletePath( $path )
     }
 }
 
-function deleteEvent( $eid, $mid=false )
-{
+function deleteEvent( $event, $mid=false ) {
+
+	if ( empty($event) ) {
+		Error( "Empty event passed to deleteEvent.");
+		return;
+	}
+
+    if ( gettype($event) != 'array' ) {
+		# $event could be an eid, so turn it into an event hash
+        $event = dbFetchOne( 'SELECT Id, MonitorId, StartTime, EndTime FROM Events WHERE Id=?', NULL, array( $event ) );
+    }
+
     global $user;
 
     if ( !$mid )
-        $mid = '*';
-    if ( $user['Events'] == 'Edit' && !empty($eid) )
-    {
-        dbQuery( 'delete from Events where Id = ?', array($eid) );
-        if ( !ZM_OPT_FAST_DELETE )
-        {
-            dbQuery( 'delete from Stats where EventId = ?', array($eid) );
-            dbQuery( 'delete from Frames where EventId = ?', array($eid) );
-            if ( ZM_USE_DEEP_STORAGE )
-            {
-                if ( $id_files = glob( ZM_DIR_EVENTS.'/'.$mid.'/*/*/*/.'.$eid ) )
-                    $eventPath = preg_replace( "/\.$eid$/", readlink($id_files[0]), $id_files[0] );
+        $mid = $event['MonitorId'];
+
+    if ( $user['Events'] == 'Edit' ) {
+
+        dbQuery( 'DELETE FROM Events WHERE Id = ?', array($event['Id']) );
+        if ( !ZM_OPT_FAST_DELETE ) {
+            dbQuery( 'DELETE FROM Stats WHERE EventId = ?', array($event['Id']) );
+            dbQuery( 'DELETE FROM Frames WHERE EventId = ?', array($event['Id']) );
+            if ( ZM_USE_DEEP_STORAGE ) {
+
+				$start_date = date_parse( $event['StartTime'] );
+
+				# So this is  because ZM creates a link under teh day pointing to the time that the event happened. 
+				$eventlink_path = implode( '/', array( ZM_DIR_EVENTS, $mid, $start_date['year'], $start_date['month'], $start_date['day'], '.'.$event['Id'] ) );
+
+                if ( $id_files = glob( $eventlink_path ) ) {
+					# I know we are using arrays here, but really there can only ever be 1 in the array
+                    $eventPath = preg_replace( "/\.$event$/", readlink($id_files[0]), $id_files[0] );
+					deletePath( $eventPath );
+					deletePath( $id_files[0] );
+					$pathParts = explode(  '/', $eventPath );
+					for ( $i = count($pathParts)-1; $i >= 2; $i-- ) {
+						$deletePath = join( '/', array_slice( $pathParts, 0, $i ) );
+						if ( !glob( $deletePath."/*" ) ) {
+							deletePath( $deletePath );
+						}
+					}
+				} else {
+					Warning( "Found no event files under $eventlink_path" );
+				} # end if found files
+            } else {
+                $eventPath = implode( '/', array( ZM_DIR_EVENTS, $mid, $event['Id'] ) );
                 deletePath( $eventPath );
-                deletePath( $id_files[0] );
-                $pathParts = explode(  '/', $eventPath );
-                for ( $i = count($pathParts)-1; $i >= 2; $i-- )
-                {
-                    $deletePath = join( '/', array_slice( $pathParts, 0, $i ) );
-                    if ( !glob( $deletePath."/*" ) )
-                    {
-                        deletePath( $deletePath );
-                    }
-                }
-            }
-            else
-            {
-                $eventPath = ZM_DIR_EVENTS.'/'.$mid.'/'.$eid;
-                deletePath( $eventPath );
-            }
-        }
-    }
+            } # USE_DEEP_STORAGE OR NOT
+        } # ! ZM_OPT_FAST_DELETE
+    } # CAN EDIT
 }
 
 function makeLink( $url, $label, $condition=1, $options="" )

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -532,6 +532,7 @@ function deleteEvent( $event, $mid=false ) {
             dbQuery( 'DELETE FROM Frames WHERE EventId = ?', array($event['Id']) );
             if ( ZM_USE_DEEP_STORAGE ) {
 
+				# Assumption: All events haev a start time
 				$start_date = date_parse( $event['StartTime'] );
 
 				# So this is  because ZM creates a link under teh day pointing to the time that the event happened. 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -534,13 +534,14 @@ function deleteEvent( $event, $mid=false ) {
 
 				# Assumption: All events haev a start time
 				$start_date = date_parse( $event['StartTime'] );
+				$start_date['year'] = $start_date['year'] % 100;
 
 				# So this is  because ZM creates a link under teh day pointing to the time that the event happened. 
-				$eventlink_path = implode( '/', array( ZM_DIR_EVENTS, $mid, $start_date['year'], $start_date['month'], $start_date['day'], '.'.$event['Id'] ) );
+				$eventlink_path = sprintf('%s/%d/%02d/%02d/%02d/.%d', ZM_DIR_EVENTS, $mid, $start_date['year'], $start_date['month'], $start_date['day'], $event['Id'] );
 
                 if ( $id_files = glob( $eventlink_path ) ) {
 					# I know we are using arrays here, but really there can only ever be 1 in the array
-                    $eventPath = preg_replace( "/\.$event$/", readlink($id_files[0]), $id_files[0] );
+                    $eventPath = preg_replace( '/\.'.$event['Id'].'$/', readlink($id_files[0]), $id_files[0] );
 					deletePath( $eventPath );
 					deletePath( $id_files[0] );
 					$pathParts = explode(  '/', $eventPath );

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -516,7 +516,7 @@ function deleteEvent( $event, $mid=false ) {
 
     if ( gettype($event) != 'array' ) {
 		# $event could be an eid, so turn it into an event hash
-        $event = dbFetchOne( 'SELECT Id, MonitorId, StartTime, EndTime FROM Events WHERE Id=?', NULL, array( $event ) );
+        $event = dbFetchOne( 'SELECT Id, MonitorId, StartTime FROM Events WHERE Id=?', NULL, array( $event ) );
     }
 
     global $user;


### PR DESCRIPTION
I noticed that deleting an event globbed the entire event structure under a monitor.  That made for some pretty bad performance on my systems with a lot of events.

This converts the deleteEvent function to handle an event hash or an eid and use the StartTime value to figure out which day the event happened and so we only glob that day which drastically reduces filesystem hits.