### PR TITLE
try harder to find arp.

### DIFF
--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -292,7 +292,7 @@ unset($output);
 $arp_command = '';
 $result = exec( 'type -p arp', $output, $status );
 if ( $status ) {
-    Warning( "Unable to determine path for arp command, type -p arp returned '$status'" );
+    Warning( "Unable to determine path for arp command, type -p arp returned '$status' output is: " . implode( "\n", $output ) );
     unset($output);
     $result = exec( 'which arp', $output, $status );
     if ( $status ) {

--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -289,12 +289,25 @@ $macBases = array(
 unset($output);
 // Calling arp without the full path was reported to fail on some systems
 // Use the builtin unix command "type" to tell us where the command is
-$command = "type -p arp";
-$result = exec( escapeshellcmd($command), $output, $status );
-if ( $status )
-    Fatal( "Unable to determine path for arp command, type -p arp returned '$status'" );
+$arp_command = '';
+$result = exec( 'type -p arp', $output, $status );
+if ( $status ) {
+    Warning( "Unable to determine path for arp command, type -p arp returned '$status'" );
+    unset($output);
+    $result = exec( 'which arp', $output, $status );
+    if ( $status ) {
+        Warning( "Unable to determine path for arp command, which arp returned '$status'" );
+        if ( file_exists( '/usr/sbin/arp' ) ) {
+            $arp_command = '/usr/sbin/arp';
+        }
+    } else {
+        $arp_command = $output[0];
+    }
+} else {
+    $arp_command = $output[0];
+}
 // Now that we know where arp is, call it using the full path
-$command = $output[0]." -a";
+$command = $arp_command." -a";
 unset($output);
 $result = exec( escapeshellcmd($command), $output, $status );
 if ( $status )


### PR DESCRIPTION
If type -p doesn't work, try which.  If that doesn't work, just look for /usr/sbin/arp.

Also don't bother with escapeshellcmd because these are not user inputs.

The reason for this instead of pr #682 is that this is a minimal fix that we could include in 1.28.2.

Once this is merged, I intend to take #682 and improve upon it to use either ip or arp. For now though, just want a quick fix for 1.28.2.  