### PR TITLE
Fixes #710 Added libavformat version check around free context functions

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -211,7 +211,11 @@ RtspThread::~RtspThread()
 {
     if ( mFormatContext )
     {
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(52, 96, 0)
         avformat_free_context( mFormatContext );
+#else
+        av_free_format_context( mFormatContext );
+#endif
         mFormatContext = NULL;
     }
     if ( mSessDesc )


### PR DESCRIPTION
Just put in standard version check code for new ffmpeg API functions.