### PR TITLE
Check to make sure that skin and css are valid.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -63,7 +63,7 @@ if ( isset($_GET['skin']) )
     $skin = $_GET['skin'];
 elseif ( isset($_COOKIE['zmSkin']) )
     $skin = $_COOKIE['zmSkin'];
-elseif ( ZM_SKIN_DEFAULT )
+elseif ( defined(ZM_SKIN_DEFAULT) )
 	$skin = ZM_SKIN_DEFAULT;
 else
     $skin = "classic";

--- a/web/index.php
+++ b/web/index.php
@@ -68,14 +68,26 @@ elseif ( ZM_SKIN_DEFAULT )
 else
     $skin = "classic";
 
+$skins = array_map( 'basename', glob('skins/*',GLOB_ONLYDIR) );
+if ( ! in_array( $skin, $skins ) ) {
+	Fatal( "Invalid skin '$skin'" );
+	$skin = 'classic';
+}
+
 if ( isset($_GET['css']) )
 	$css = $_GET['css'];
 elseif ( isset($_COOKIE['zmCSS']) )
 	$css = $_COOKIE['zmCSS'];
-elseif (ZM_CSS_DEFAULT)
+elseif (defined(ZM_CSS_DEFAULT))
 	$css = ZM_CSS_DEFAULT;
 else
 	$css = "classic";
+
+$css_skins = array_map( 'basename', glob('skins/'.$skin.'/css/*',GLOB_ONLYDIR) );
+if ( ! in_array( $css, $css_skins ) ) {
+	Fatal( "Invalid skin css '$css'" );
+	$css = 'classic';
+}
 
 define( "ZM_BASE_PATH", dirname( $_SERVER['REQUEST_URI'] ) );
 define( "ZM_SKIN_PATH", "skins/$skin" );

--- a/web/index.php
+++ b/web/index.php
@@ -70,7 +70,7 @@ else
 
 $skins = array_map( 'basename', glob('skins/*',GLOB_ONLYDIR) );
 if ( ! in_array( $skin, $skins ) ) {
-	Fatal( "Invalid skin '$skin'" );
+	Error( "Invalid skin '$skin'" );
 	$skin = 'classic';
 }
 
@@ -85,7 +85,7 @@ else
 
 $css_skins = array_map( 'basename', glob('skins/'.$skin.'/css/*',GLOB_ONLYDIR) );
 if ( ! in_array( $css, $css_skins ) ) {
-	Fatal( "Invalid skin css '$css'" );
+	Error( "Invalid skin css '$css'" );
 	$css = 'classic';
 }
 


### PR DESCRIPTION
This checks installed skins and associated css choices for validity and will default to classic.  This should fix the master CSS complaints when upgrading from 1.28.*

