### PR TITLE
User selectable arp tool

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -655,6 +655,14 @@ our @options =
 		category => "paths",
 	},
 	{
+		name => "ZM_PATH_ARP",
+		default => "",
+		description => "Path to a supported ARP tool",
+		help => "The camera probe function uses Address Resolution Protocol in order to find known devices on the network. Optionally supply the full path to \"ip neigh\", \"arp -a\", or any other tool on your system that returns ip/mac address pairs. If this field is left empty, ZoneMinder will search for the command \"arp\" and attempt to use that.",
+		type => $types{abs_path},
+		category => "paths",
+	},
+	{
 		name => "ZM_WEB_TITLE_PREFIX",
 		default => "ZM",
 		description => "The title prefix displayed on each window",


### PR DESCRIPTION
Add the ability for the end user to supply the full path to their own preferred arp tool.
Note that I do not own any devices the monitorprobe currently supports so my testing was limited.