### PR TITLE
freshen dB when needed

### DIFF
--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -104,6 +104,11 @@ void zmLoadConfig()
 	config.Assign();
 }
 
+int zmFreshenConfig()
+{
+	return( system( "zmupdate.pl -f" ) );
+}
+
 StaticConfig staticConfig;
 
 ConfigItem::ConfigItem( const char *p_name, const char *p_value, const char *const p_type )
@@ -164,8 +169,10 @@ bool ConfigItem::BooleanValue() const
 
 	if ( cfg_type != CFG_BOOLEAN )
 	{
-		Error( "Attempt to fetch boolean value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {
+			Error( "Attempt to fetch boolean value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
+			exit( -1 );
+		}
 	}
 
 	return( cfg_value.boolean_value );
@@ -178,8 +185,10 @@ int ConfigItem::IntegerValue() const
 
 	if ( cfg_type != CFG_INTEGER )
 	{
-		Error( "Attempt to fetch integer value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {
+			Error( "Attempt to fetch integer value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
+			exit( -1 );
+		}
 	}
 
 	return( cfg_value.integer_value );
@@ -192,8 +201,10 @@ double ConfigItem::DecimalValue() const
 
 	if ( cfg_type != CFG_DECIMAL )
 	{
-		Error( "Attempt to fetch decimal value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {
+			Error( "Attempt to fetch decimal value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
+			exit( -1 );
+		}
 	}
 
 	return( cfg_value.decimal_value );
@@ -206,8 +217,10 @@ const char *ConfigItem::StringValue() const
 
 	if ( cfg_type != CFG_STRING )
 	{
-		Error( "Attempt to fetch string value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {
+			Error( "Attempt to fetch string value for %s, actual type is %s. Try running 'zmupdate.pl -f' to reload config.", name, type );
+			exit( -1 );
+		}
 	}
 
 	return( cfg_value.string_value );
@@ -252,8 +265,10 @@ void Config::Load()
 
 	if ( n_items <= ZM_MAX_CFG_ID )
 	{
-		Error( "Config mismatch, expected %d items, read %d. Try running 'zmupdate.pl -f' to reload config.", ZM_MAX_CFG_ID+1, n_items );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {
+			Error( "Config mismatch, expected %d items, read %d. Try running 'zmupdate.pl -f' to reload config.", ZM_MAX_CFG_ID+1, n_items );
+			exit( -1 );
+		}
 	}
 
 	items = new ConfigItem *[n_items];
@@ -279,8 +294,10 @@ const ConfigItem &Config::Item( int id )
 
 	if ( id < 0 || id > ZM_MAX_CFG_ID )
 	{
-		Error( "Attempt to access invalid config, id = %d. Try running 'zmupdate.pl -f' to reload config.", id );
-		exit( -1 );
+		if ( zmFreshenConfig() ) {	
+			Error( "Attempt to access invalid config, id = %d. Try running 'zmupdate.pl -f' to reload config.", id );
+			exit( -1 );
+		}
 	}
 
 	ConfigItem *item = items[id];


### PR DESCRIPTION
Older versions of zoneminder called "zmupdate.pl -f" every time zoneminder was started.  However, that was inefficient.  More recent versions of zoneminder went to the other extreme and never called zmupdate.pl -f.  This leads to errors in the log on occasion that ask the user to manually run zmupdate.pl -f.

The logic to detect a Config mismatch already exists in zm_config.cpp.  This PR hooks into that logic and calls zmudpate.pl automatically.

Posting the PR simply for discussion.  
I'm not sure we should merge this as is.  Zoneminder probably needs to be restarted so that the updated config takes effect.
