### PR TITLE
Fix event view

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -27,15 +27,13 @@ if ( !canView( 'Events' ) )
 $eid = validInt( $_REQUEST['eid'] );
 $fid = !empty($_REQUEST['fid'])?validInt($_REQUEST['fid']):1;
 
-$sql = 'SELECT E.*,M.Name AS MonitorName,M.Width,M.Height,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?';
-$sql_values = array( $eid );
+if ( $user['MonitorIds'] )
+    $midSql = " and MonitorId in (".join( ",", preg_split( '/["\'\s]*,["\'\s]*/', dbEscape($user['MonitorIds']) ) ).")";
+else
+    $midSql = '';
 
-if ( $user['MonitorIds'] ) {
-    $monitor_ids = preg_split( '/,/', $user['MonitorIds'] );
-    $sql .= ' AND MonitorId IN (' .implode( ',', array_fill(0,count($monitor_ids),'?') ) . ')';
-    $sql_values = array_merge( $sql_values, $monitor_ids );
-}
-$event = dbFetchOne( $sql, NULL, $sql_values );
+$sql = 'SELECT E.*,M.Name AS MonitorName,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?'.$midSql;
+$event = dbFetchOne( $sql, NULL, array($eid) );
 
 if ( isset( $_REQUEST['rate'] ) )
     $rate = validInt($_REQUEST['rate']);

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -27,13 +27,15 @@ if ( !canView( 'Events' ) )
 $eid = validInt( $_REQUEST['eid'] );
 $fid = !empty($_REQUEST['fid'])?validInt($_REQUEST['fid']):1;
 
-if ( $user['MonitorIds'] )
-    $midSql = " and MonitorId in (".join( ",", preg_split( '/["\'\s]*,["\'\s]*/', dbEscape($user['MonitorIds']) ) ).")";
-else
-    $midSql = '';
+$sql = 'SELECT E.*,M.Name AS MonitorName,M.Width,M.Height,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?';
+$sql_values = array( $eid );
 
-$sql = 'SELECT E.*,M.Name AS MonitorName,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?'.$midSql;
-$event = dbFetchOne( $sql, NULL, array($eid) );
+if ( $user['MonitorIds'] ) {
+    $monitor_ids = preg_split( '/,/', $user['MonitorIds'] );
+    $sql .= ' AND MonitorId IN (' .implode( ',', array_fill(0,count($monitor_ids),'?') ) . ')';
+    $sql_values = array_merge( $sql_values, $monitor_ids );
+}
+$event = dbFetchOne( $sql, NULL, $sql_values );
 
 if ( isset( $_REQUEST['rate'] ) )
     $rate = validInt($_REQUEST['rate']);

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -31,7 +31,7 @@ $sql = 'SELECT E.*,M.Name AS MonitorName,M.Width,M.Height,M.DefaultRate,M.Defaul
 $sql_values = array( $eid );
 
 if ( $user['MonitorIds'] ) {
-    $monitor_ids = preg_split( '/,/', $user['MonitorIds'] );
+    $monitor_ids = explode( ',', $user['MonitorIds'] );
     $sql .= ' AND MonitorId IN (' .implode( ',', array_fill(0,count($monitor_ids),'?') ) . ')';
     $sql_values = array_merge( $sql_values, $monitor_ids );
 }

--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -32,7 +32,7 @@ if ( !empty($_REQUEST['execute']) )
 $countSql = 'SELECT count(E.Id) AS EventCount FROM Monitors AS M INNER JOIN Events AS E ON (M.Id = E.MonitorId) WHERE';
 $eventsSql = 'SELECT E.Id,E.MonitorId,M.Name AS MonitorName,M.DefaultScale,E.Name,E.Width,E.Height,E.Cause,E.Notes,E.StartTime,E.Length,E.Frames,E.AlarmFrames,E.TotScore,E.AvgScore,E.MaxScore,E.Archived FROM Monitors AS M INNER JOIN Events AS E on (M.Id = E.MonitorId) WHERE';
 if ( $user['MonitorIds'] ) {
-	$user_monitor_ids = " M.Id in (".join( ",", preg_split( '/["\'\s]*,["\'\s]*/', $user['MonitorIds'] ) ).")";
+	$user_monitor_ids = ' M.Id in ('.$user['MonitorIds'].')';
 	$countSql .= $user_monitor_ids;
 	$eventsSql .= $user_monitor_ids;
 } else {

--- a/web/skins/classic/views/timeline.php
+++ b/web/skins/classic/views/timeline.php
@@ -147,7 +147,7 @@ $eventsSql = "select E.Id,E.Name,E.StartTime,E.EndTime,E.Length,E.Frames,E.MaxSc
 
 if ( !empty($user['MonitorIds']) )
 {
-    $monFilterSql = " and M.Id in (".join( ",", preg_split( '/["\'\s]*,["\'\s]*/', $user['MonitorIds'] ) ).")";
+    $monFilterSql = ' AND M.Id IN ('.$user['MonitorIds'].')';
 
     $rangeSql .= $monFilterSql;
     $eventsSql .= $monFilterSql;

--- a/web/skins/classic/views/video.php
+++ b/web/skins/classic/views/video.php
@@ -24,13 +24,17 @@ if ( !canView( 'Events' ) )
     return;
 }
 
-if ( !empty($user['MonitorIds']) )
-    $midSql = " and MonitorId in (".join( ",", preg_split( '/["\'\s]*,["\'\s]*/', $user['MonitorIds'] ) ).")";
-else
-    $midSql = '';
+$eid = validInt($_REQUEST['eid']);
 
-$sql = 'SELECT E.*,M.Name AS MonitorName,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?'.$midSql;
-$event = dbFetchOne( $sql, NULL, array( $_REQUEST['eid'] ) );
+$sql = 'SELECT E.*,M.Name AS MonitorName,M.DefaultRate,M.DefaultScale FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE E.Id = ?';
+$sql_values = array( $eid );
+
+if ( $user['MonitorIds'] ) {
+    $monitor_ids = explode( ',', $user['MonitorIds'] );
+    $sql .= ' AND MonitorId IN (' .implode( ',', array_fill(0,count($monitor_ids),'?') ) . ')';
+    $sql_values = array_merge( $sql_values, $monitor_ids );
+}
+$event = dbFetchOne( $sql, NULL, $sql_values );
 
 if ( isset( $_REQUEST['rate'] ) )
     $rate = validInt($_REQUEST['rate']);


### PR DESCRIPTION
Fixes #717 

The old dbEscape used to put quotes around the values so the preg_split was complex.  Now the monitors should just be comma separated and it only comes from DB so it SHOULD be clean.... so just explode it based on commas. 

No further db escaping is necessary due to our use of PDO.