### PR TITLE
fix extra slash when adding trackurl to controlurl

### DIFF
--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -440,7 +440,11 @@ int RtspThread::run()
                 }
                 else
                 {
-                    trackUrl += "/" + controlUrl;
+					if ( *trackUrl.rbegin() != '/') {
+						trackUrl += "/" + controlUrl;
+					} else {
+						trackUrl += controlUrl;
+					}
                 }
                 rtpClock = mediaDesc->getClock();
                 codecId = mFormatContext->streams[i]->codec->codec_id;


### PR DESCRIPTION
As discussed on IRC, Axis cameras will put an extra slash at the end of the control URL in teh DESCRIBE response.  So we need to check for it when adding the track Id part.