### PR TITLE
Add Development note for non-release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ include (CheckPrototypeDefinition_fixed)
 include (CheckTypeSize)
 include (CheckStructHasMember)
 
+# Used to alert the user they are running a development snapshot
+set(ZM_DEVELOPMENT "")
+if(EXISTS "./utils/development.txt")
+	execute_process(COMMAND echo "DEVELOPMENT Snapshot built on "date +%D OUTPUT_VARIABLE ZM_DEVELOPMENT)
+endif()
+
 # Configuration options
 mark_as_advanced(FORCE ZM_EXTRA_LIBS ZM_MYSQL_ENGINE ZM_NO_MMAP CMAKE_INSTALL_FULL_BINDIR ZM_PERL_SUBPREFIX ZM_PERL_USE_PATH ZM_TARGET_DISTRO ZM_CONFIG_DIR)
 set(ZM_RUNDIR "/var/run/zm" CACHE PATH "Location of transient process files, default: /var/run/zm")

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,14 @@ AC_CONFIG_HEADERS(config.h)
 AC_SUBST([AM_CXXFLAGS], [-D__STDC_CONSTANT_MACROS])
 
 AC_SUBST(VERSION)
+
+# Used to alert the user they are running a development snapshot
+if test -f ./utils/development.txt; then
+	AC_SUBST(ZM_DEVELOPMENT,"DEVELOPMENT Snapshot built on `date +%D`")
+else
+	AC_SUBST(ZM_DEVELOPMENT,"")
+fi
+
 #
 # Platform specific setup
 #

--- a/hooks/makehooks.sh
+++ b/hooks/makehooks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ln -s update ../.git/hooks/
+

--- a/hooks/update
+++ b/hooks/update
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# get the branch we are pushing to
+ourbranch=`git rev-parse --abbrev-ref HEAD`
+
+# check if the branch is a release branch
+release=`echo $ourbranch | grep "release-[0-9]\..[0-9]\.[0-9]"`
+
+# if this is a release branch then delete the development.txt file
+if [ -n $release ]; then
+	rm ./utils/development.txt
+fi
+

--- a/utils/development.txt
+++ b/utils/development.txt
@@ -1,0 +1,2 @@
+The presence of this file causes zoneminder to enable the DEVELOPMENT notice on the console.
+This file is managed by git-hooks.  DO NOT MANUALLY DELETE.

--- a/web/includes/config.php.in
+++ b/web/includes/config.php.in
@@ -24,6 +24,8 @@
 define( "ZM_CONFIG", "@ZM_CONFIG@" );               // Path to config file
 // Define, and override any given in config file
 define( "ZM_VERSION", "@VERSION@" );               // Version
+// Used to notify the end user they are running a development snapshot
+define( "ZM_DEVELOPMENT", "@ZM_DEVELOPMENT@" );
 
 $configFile = ZM_CONFIG;
 $localConfigFile = basename($configFile);

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -189,6 +189,15 @@ xhtmlHeaders( __FILE__, $SLANG['Console'] );
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
       <h3 id="systemStats"><?php echo $SLANG['Load'] ?>: <?php echo getLoad() ?> / <?php echo $SLANG['Disk'] ?>: <?php echo getDiskPercent() ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo $SLANG['Console'] ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
+	<?php
+	define( "ZM_DEVELOPMENT", "DEVELOPMENT Snapshot built on 3/2/15" );
+	if ( ZM_DEVELOPMENT )
+	{
+	?>
+	      <h3 id="development"><center><?php echo ZM_DEVELOPMENT ?></center></h3>
+	<?php
+	}
+	?>
       <div class="clear"></div>
       <div id="monitorSummary"><?php echo makePopupLink( '?view=groups', 'zmGroups', 'groups', 'Group: ' . ($group?' ('.$group['Name'].')':'All').': '. sprintf( $CLANG['MonitorCount'], count($displayMonitors), zmVlang( $VLANG['Monitor'], count($displayMonitors) ) ) ); ?></div>
 <?php

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -190,7 +190,6 @@ xhtmlHeaders( __FILE__, $SLANG['Console'] );
       <h3 id="systemStats"><?php echo $SLANG['Load'] ?>: <?php echo getLoad() ?> / <?php echo $SLANG['Disk'] ?>: <?php echo getDiskPercent() ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo $SLANG['Console'] ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
 	<?php
-	define( "ZM_DEVELOPMENT", "DEVELOPMENT Snapshot built on 3/2/15" );
 	if ( ZM_DEVELOPMENT )
 	{
 	?>


### PR DESCRIPTION
This is not ready for merge.  I wrote this very quickly, and it will more than likely need additional love.
However, I wanted to show the idea I was working on and get feedback before I put much more time into this.

This pull request allows zoneminder to autodetect if it is a non-release build and will display a note on the web console accordingly. See the screenshot below.  

It does this via client side Git Hooks.  Server side git hooks would have been even better, but unfortunately github does not allow server-side hooks due to security reasons.

Side Note:
I abandoned the previously discussed idea of using the git commit hash in the development version number once I learned that server side hooks were not available.  We can discuss this if anyone wants to.

Pros:
-It is simple and straight forward
-This PR only displays a message on the console.  It does not require our current release versioning scheme to change.  

Cons:
-Requires strict naming of our release branches in the format "release-x.xx.x".  Maybe not a con.
-We all *have* to make sure and run "makehooks.sh" any time we create a new local repository on our local drive.  Actually, this isn't entirely true.  Just the person(s) who create the release branch will need to do this, but I'd rather we all run the script just in case.

Future:
I will likely expand the use of client-side git hooks to auto-bump the zoneminder version numbers (configure.ac, cmakelistst.txt, version, etc) for us when we create a new release branch.

![screenshot-zm - console - mozilla firefox](https://cloud.githubusercontent.com/assets/5150042/6454251/09ac40a0-c10d-11e4-9ae5-cad92213f84c.png)
