### PR TITLE
fixing POD errors

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigAdmin.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigAdmin.pm
@@ -195,6 +195,8 @@ Loads existing configuration from the database (if any) and merges it with the d
 
 Saves configuration held in memory to the database. The act of loading and saving configuration is a convenient way to ensure that the configuration held in the database corresponds with the most recent definitions and that all components are using the same set of configuration.
 
+=back
+
 =head2 EXPORT
 
 None by default.

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -2012,6 +2012,8 @@ Loads existing configuration from the database (if any) and merges it with the d
 
 Saves configuration held in memory to the database. The act of loading and saving configuration is a convenient way to ensure that the configuration held in the database corresponds with the most recent definitions and that all components are using the same set of configuration.
 
+=back
+
 =head2 EXPORT
 
 None by default.

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8608W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8608W_Y2k.pm
@@ -658,9 +658,9 @@ sub presetGoto
 __END__
 # Below is stub documentation for your module. You'd better edit it!
 
-=head1 FI-8608W
+=head1 NAME
 
-ZoneMinder::Database - Perl extension for FOSCAM FI-8608W by Christophe_Y2k
+ZoneMinder::Control::FI-8608W - Perl extension for FOSCAM FI-8608W by Christophe_Y2k
 
 =head1 SYNOPSIS
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8620_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8620_Y2k.pm
@@ -734,9 +734,9 @@ sub presetGoto
 __END__
 # Below is stub documentation for your module. You'd better edit it!
 
-=head1 FI8620
+=head1 NAME
 
-ZoneMinder::Database - Perl extension for FOSCAM FI8620
+ZoneMinder::Control::FI8620 - Perl extension for FOSCAM FI8620
 
 =head1 SYNOPSIS
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8908W.pm
@@ -220,6 +220,10 @@ sub presetHome
 __END__
 =pod
 
+=head1 NAME
+
+ZoneMinder::Control::FI8908W - Foscam FI8908W camera control
+
 =head1 DESCRIPTION
 
 This module contains the implementation of the Foscam FI8908W / FI8918W IP camera control

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
@@ -696,9 +696,9 @@ sub presetGoto
 __END__
 # Below is stub documentation for your module. You'd better edit it!
 
-=head1 FI9821W
+=head1 NAME
 
-ZoneMinder::Database - Perl extension for FOSCAM FI9821W
+ZoneMinder::Control::FI9821W - Perl extension for FOSCAM FI9821W
 
 =head1 SYNOPSIS
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
@@ -827,6 +827,8 @@ This method will output a fatal error message and then die if the current debug 
 
 This method will output a panic error message and then die with a stack trace if the current debug level permits it, otherwise does nothing. This message will be tagged with the PNC string in the logs.
 
+=back
+
 =head2 EXPORT
 
 None by default.

--- a/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
@@ -733,9 +733,9 @@ The core elements of ZoneMinder used mapped memory to allow multiple access to r
 
 All the methods listed below require a 'monitor' parameter. This must be a reference to a hash with at least the 'Id' field set to the monitor id of the mapped memory you wish to access. Using database methods to select the monitor details will also return this kind of data. Some of the mapped memory methods will add and amend new fields to this hash.
 
-=over 4
-
 =head1 METHODS
+
+=over 4
 
 =item zmMemVerify ( $monitor );
 
@@ -809,6 +809,8 @@ Cancel any previous trigger on or off requests. This stops a triggered alarm if 
 
 Indicate that the given text should be displayed in the timestamp annotation on any images captured, if the format of the annotation string defined for the monitor permits.
 
+=back
+
 =head1 DATA
 
 The data fields in mapped memory that may be accessed are as follows. There are two main sections, shared_data which is general data and trigger_data which is used for event triggering. Whilst reading from these fields is harmless, extreme care must be taken when writing to mapped memory, especially in the shared_data section as this is normally written to only by monitor capture and analysis processes.
@@ -844,6 +846,8 @@ The data fields in mapped memory that may be accessed are as follows. There are 
 
 The following constants are used by the methods above, but can also be used by user scripts if required.
 
+=over 4
+
 =item STATE_IDLE STATE_PREALARM STATE_ALARM STATE_ALERT STATE_TAPE
 
 These constants define the state of the monitor with respect to alarms and events. They are used in the shared_data:state field.
@@ -852,9 +856,11 @@ These constants define the state of the monitor with respect to alarms and event
 
 These constants defines the various values that can exist in the shared_data:action field. This is a bitmask which when non-zero defines an action that an executing monitor process should take. ACTION_GET requires that the current values of brightness, contrast, colour and hue are taken from the camera and written to the equivalent mapped memory fields. ACTION_SET implies the reverse, that the values in mapped memory should be written to the camera. ACTION_RELOAD signal that the monitor process should reload itself from the database in case any settings have changed there. ACTION_SUSPEND signals that a monitor should stop exaiming images for motion, though other alarms may still occur. ACTION_RESUME sigansl that a monitor should resume motion detectiom.
 
-=item TRIGGER_CANCEL TRIGGER_ON TRIGGER_OFF 
+=item TRIGGER_CANCEL TRIGGER_ON TRIGGER_OFF
 
 These constants are used in the definition of external triggers. TRIGGER_CANCEL is used to indicated that any previous trigger settings should be cancelled, TRIGGER_ON signals that an alarm should be created (or continued)) as a result of the current trigger and TRIGGER_OFF signals that the trigger should prevent any alarms from being generated. See the trigger methods above for further details.
+
+=back
 
 =head1 EXPORT
 


### PR DESCRIPTION
 manpage-has-errors-from-pod2man (forgotten '=back' before '=head2')

Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>