### PR TITLE
build: fix FTBFS with format-hardening (please review)

### DIFF
--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -109,7 +109,7 @@ void VideoStream::SetupFormat( )
 	
 	if(filename)
 	{
-		snprintf( s->filename, sizeof(s->filename), filename );
+		snprintf( s->filename, sizeof(s->filename), "%s", filename );
 	}
 	
 	ofc = s;


### PR DESCRIPTION
~~~~
x86_64-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I..  -I/usr/include -I/usr/include -I/usr/include -D__STDC_CONSTANT_MACROS -Wall -finline-functions -fomit-frame-pointer -I/usr/include -D__STDC_CONSTANT_MACROS -D_FORTIFY_SOURCE=2 -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DZM_FFMPEG_CVS -DHAVE_LIBCRYPTO -MT zm_mpeg.o -MD -MP -MF .deps/zm_mpeg.Tpo -c -o zm_mpeg.o zm_mpeg.cpp
zm_mpeg.cpp: In member function ‘void VideoStream::SetupFormat()’:
zm_mpeg.cpp:112:56: error: format not a string literal and no format arguments [-Werror=format-security]
snprintf( s->filename, sizeof(s->filename), filename );
                                                     ^
zm_mpeg.cpp:112:56: error: format not a string literal and no format arguments [-Werror=format-security]
~~~~

Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>