### PR TITLE
POD: zmupdate.pl converted to "pod2usage"

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -20,11 +20,33 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 # ==========================================================================
-#
-# This script just checks what the most recent release of ZoneMinder is
-# at the the moment. It will eventually be responsible for applying and
-# configuring upgrades etc, including on the fly upgrades.
-#
+
+=head1 NAME
+
+zmupdate.pl - check and upgrade Zoneminer database
+
+=head1 SYNOPSIS
+
+ zmupdate.pl -c,--check | -f,--freshen | -v<version>,--version=<version> [-u<dbuser> -p<dbpass>]
+
+=head1 DESCRIPTION
+
+This script just checks what the most recent release of ZoneMinder is
+at the the moment. It will eventually be responsible for applying and
+configuring upgrades etc, including on the fly upgrades.
+
+=head1 OPTIONS
+
+ -c, --check                      - Check for updated versions of ZoneMinder
+ -f, --freshen                    - Freshen the configuration in the database. Equivalent of old zmconfig.pl -noi
+ -v<version>, --version=<version> - Force upgrade to the current version from <version>
+ -u<dbuser>, --user=<dbuser>      - Alternate DB user with privileges to alter DB
+ -p<dbpass>, --pass=<dbpass>      - Password of alternate DB user with privileges to alter DB
+ -d<dir>,--dir=<dir>              - Directory containing update files if not in default build location
+ -interactive                     - interact with the user
+ -nointeractive                   - do not interact with the user
+
+=cut
 use strict;
 use bytes;
 
@@ -52,6 +74,7 @@ use ZoneMinder::ConfigAdmin qw( :functions );
 use POSIX;
 use DBI;
 use Getopt::Long;
+use autouse 'Pod::Usage'=>qw(pod2usage);
 use Data::Dumper;
 
 use constant EVENT_PATH => ($Config{ZM_DIR_EVENTS}=~m|/|)?$Config{ZM_DIR_EVENTS}:($Config{ZM_PATH_WEB}.'/'.$Config{ZM_DIR_EVENTS});
@@ -78,27 +101,19 @@ my $version = '';
 my $dbUser = $Config{ZM_DB_USER};
 my $dbPass = $Config{ZM_DB_PASS};
 my $updateDir = '';
-sub Usage
-{
-    print( "
-Usage: zmupdate.pl <-c,--check|-f,--freshen|-v<version>,--version=<version>> [-u<dbuser> -p<dbpass>]>
-Parameters are :-
--c, --check                      - Check for updated versions of ZoneMinder
--f, --freshen                    - Freshen the configuration in the database. Equivalent of old zmconfig.pl -noi
--v<version>, --version=<version> - Force upgrade to the current version from <version>
--u<dbuser>, --user=<dbuser>      - Alternate DB user with privileges to alter DB
--p<dbpass>, --pass=<dbpass>      - Password of alternate DB user with privileges to alter DB
--d<dir>,--dir=<dir>              - Directory containing update files if not in default build location
--interactive					 - interact with the user
--nointeractive                   - do not interact with the user
-");
-    exit( -1 );
-}
 
-if ( !GetOptions( 'check'=>\$check, 'freshen'=>\$freshen, 'rename'=>\$rename, 'zone-fix'=>\$zoneFix, 'migrate-events'=>\$migrateEvents, 'version=s'=>\$version, 'interactive!'=>\$interactive, 'user:s'=>\$dbUser, 'pass:s'=>\$dbPass, 'dir:s'=>\$updateDir ) )
-{
-    Usage();
-}
+GetOptions(
+    'check'          =>\$check,
+    'freshen'        =>\$freshen,
+    'rename'         =>\$rename,
+    'zone-fix'       =>\$zoneFix,
+    'migrate-events' =>\$migrateEvents,
+    'version=s'      =>\$version,
+    'interactive!'   =>\$interactive,
+    'user:s'         =>\$dbUser,
+    'pass:s'         =>\$dbPass,
+    'dir:s'          =>\$updateDir
+) or pod2usage(-exitstatus => -1);
 
 my $dbh = zmDbConnect();
 $Config{ZM_DB_USER} = $dbUser;
@@ -113,14 +128,14 @@ if ( ! ($check || $freshen || $rename || $zoneFix || $migrateEvents || $version)
     else
     {
         print( STDERR "Please give a valid option\n" );
-        Usage();
+        pod2usage(-exitstatus => -1);
     }
 }
 
 if ( ($check + $freshen + $rename + $zoneFix + $migrateEvents + ($version?1:0)) > 1 )
 {
     print( STDERR "Please give only one option\n" );
-    Usage();
+    pod2usage(-exitstatus => -1);
 }
 
 if ( $check && $Config{ZM_CHECK_FOR_UPDATES} )


### PR DESCRIPTION
 Best practice for POD documentation is to (re-)use it for displaying usage
 info. Now `perldoc zmupdate.pl` shows expected information and we can even
 generate man page automatically with `pod2man zmupdate.pl`.

I'm looking forward to see more scripts converted like this...
