### PR TITLE
Don't trigger linked cameras on new events

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -251,7 +251,6 @@ bool Monitor::MonitorLink::hasAlarmed()
     else if( shared_data->last_event != (unsigned int)last_event )
     {
         last_event = shared_data->last_event;
-        return( true );
     }
     return( false );
 }


### PR DESCRIPTION
Currently, linked monitors trigger every time a new event is created on the monitor linked to. So if I have a setup as follows:
mon1: mocord
mon2: nodect, linked to mon1

While mon1 has no alarms at all, mon2 triggers with an alarm (cause being Linked) every 10 minutes (or however long the event interval is). This causes unnecessary recording and events.

This patch attempts to fix it by not triggering an alarm in zm_monitor when the only thing that's happened is a new event. It still updates the value of last_event, though this does make me wonder just how last_event is used.

Testing currently in process.