### PR TITLE
* use pthread_join instead of pthread_tryjoin_np

### DIFF
--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -120,7 +120,7 @@ int FfmpegCamera::Capture( Image &image )
         void *retval = 0;
         int ret;
         
-        ret = pthread_tryjoin_np(mReopenThread, &retval);
+        ret = pthread_join(mReopenThread, &retval);
         if (ret != 0){
             Error("Could not join reopen thread.");
         }


### PR DESCRIPTION
Use pthread_join in ffmpeg_camera to make ZM compile on non-linux.