### PR TITLE
hide USE_DEEP_STORAGE

### DIFF
--- a/db/zm_update-1.28.99.sql
+++ b/db/zm_update-1.28.99.sql
@@ -108,4 +108,9 @@ SELECT * FROM (SELECT NULL as Id,
 WHERE NOT EXISTS (
     SELECT Name FROM Controls WHERE name = 'ONVIF Camera'
 ) LIMIT 1;
+--
+-- Hide USE_DEEP_STORAGE from user to prevent accidental event loss
+--
+UPDATE `zm`.`Config` SET `Category`='hidden' WHERE `Name`='ZM_USE_DEEP_STORAGE';
+
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -183,7 +183,7 @@ our @options =
 		description => "Use a deep filesystem hierarchy for events",
 		help => "This option is now the default for new ZoneMinder systems and should not be changed. Previous versions of ZoneMinder stored all events for a monitor under one folder. Enabling USE_DEEP_STORAGE causes ZoneMinder to store events under a folder structure that follows year/month/day/hour/min/second. Storing events this way avoids the limitation of storing more than 32k files in a single folder inherent in some filesystems. It is important to note that you cannot simply change this option. You must stop zoneminder, enable USE_DEEP_STORAGE, and then run \"sudo zmupdate.pl --migrate-events\". FAILURE TO DO SO WILL RESULT IN LOSS OF YOUR DATA! Consult the ZoneMinder WiKi for further details.",
 		type => $types{boolean},
-		category => "paths",
+		category => "hidden",
 	},
 	{
 		name => "ZM_DIR_IMAGES",


### PR DESCRIPTION
Addresses #783 
ZM_USE_DEEP_STORAGE is on by default on new systems and should never be turned off.
Turning it off will cause all events to be erased since zoneminder will no longer "see" them on the filesystem.
