### PR TITLE
Fix build issues on kFreeBSD. Fixes #771

### DIFF
--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -32,6 +32,13 @@
 #include <stdlib.h>
 #include <limits.h>
 
+/* Workaround for GNU/kFreeBSD */
+#if defined(__FreeBSD_kernel__)
+#ifndef ENODATA
+#define ENODATA ENOATTR
+#endif
+#endif
+
 static unsigned int BigEndian;
 
 static int vidioctl( int fd, int request, void *arg )

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -538,7 +538,12 @@ void Logger::logPrint( bool hex, const char * const file, const int line, const 
         if (tid < 0 ) // Thread/Process id
 #else
 #ifdef HAVE_SYSCALL
+	#ifdef __FreeBSD_kernel__
+        if ( (syscall(SYS_thr_self, &tid)) < 0 ) // Thread/Process id
+
+	# else
         if ( (tid = syscall(SYS_gettid)) < 0 ) // Thread/Process id
+	#endif
 #endif // HAVE_SYSCALL
 #endif
         tid = getpid(); // Process id

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -515,14 +515,18 @@ bool Monitor::connect() {
         Error( "Got unexpected memory map file size %ld, expected %d", map_stat.st_size, mem_size );
 		return false;
 	} else {
+#ifdef MAP_LOCKED
 		mem_ptr = (unsigned char *)mmap( NULL, mem_size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_LOCKED, map_fd, 0 );
 		if ( mem_ptr == MAP_FAILED ) {
 			if ( errno == EAGAIN ) {
 				Debug( 1, "Unable to map file %s (%d bytes) to locked memory, trying unlocked", mem_file, mem_size );
+#endif
 				mem_ptr = (unsigned char *)mmap( NULL, mem_size, PROT_READ|PROT_WRITE, MAP_SHARED, map_fd, 0 );
 				Debug( 1, "Mapped file %s (%d bytes) to locked memory, unlocked", mem_file, mem_size );
+#ifdef MAP_LOCKED
 			}
 		}
+#endif
 		if ( mem_ptr == MAP_FAILED )
 			Fatal( "Can't map file %s (%d bytes) to memory: %s(%d)", mem_file, mem_size, strerror(errno), errno );
     }

--- a/src/zm_signal.cpp
+++ b/src/zm_signal.cpp
@@ -72,7 +72,11 @@ RETSIGTYPE zm_die_handler(int signal)
 		ip = (void *)(uc->uc_mcontext.gregs[REG_RIP]);
 	#endif
 #else
+	#ifdef __FreeBSD_kernel__
+		ip = (void *)(uc->uc_mcontext.mc_eip);
+	#else
 		ip = (void *)(uc->uc_mcontext.gregs[REG_EIP]);
+	#endif
 #endif				// defined(__x86_64__)
 
 		// Print the signal address and instruction pointer if available

--- a/src/zm_signal.cpp
+++ b/src/zm_signal.cpp
@@ -64,11 +64,14 @@ RETSIGTYPE zm_die_handler(int signal)
 		      info->si_uid, info->si_status);
 
 		ucontext_t *uc = (ucontext_t *) context;
+		cr2 = info->si_addr;
 #if defined(__x86_64__)
-		cr2 = info->si_addr;
+	#ifdef __FreeBSD_kernel__
+		ip = (void *)(uc->uc_mcontext.mc_rip);
+	#else
 		ip = (void *)(uc->uc_mcontext.gregs[REG_RIP]);
+	#endif
 #else
-		cr2 = info->si_addr;
 		ip = (void *)(uc->uc_mcontext.gregs[REG_EIP]);
 #endif				// defined(__x86_64__)
 

--- a/src/zm_thread.h
+++ b/src/zm_thread.h
@@ -36,15 +36,19 @@ class ThreadException : public Exception
 {
 private:
 pid_t pid() {
-pid_t tid; 
+    pid_t tid; 
 #ifdef __FreeBSD__ 
-long lwpid; 
-thr_self(&lwpid); 
-tid = lwpid; 
+    long lwpid; 
+    thr_self(&lwpid); 
+    tid = lwpid; 
 #else 
-tid=syscall(SYS_gettid); 
+    #ifdef __FreeBSD_kernel__
+        if ( (syscall(SYS_thr_self, &tid)) < 0 ) // Thread/Process id
+    # else
+        tid=syscall(SYS_gettid); 
+    #endif
 #endif
-return tid;
+    return tid;
 }	
 public:
     ThreadException( const std::string &message ) : Exception( stringtf( "(%d) "+message, (long int)pid() ) ) {
@@ -219,13 +223,18 @@ protected:
 
     pid_t id() const
     {
-pid_t tid; 
+        pid_t tid; 
 #ifdef __FreeBSD__ 
-long lwpid; 
-thr_self(&lwpid); 
-tid = lwpid; 
+        long lwpid; 
+        thr_self(&lwpid); 
+        tid = lwpid; 
 #else 
-tid=syscall(SYS_gettid); 
+    #ifdef __FreeBSD_kernel__
+        if ( (syscall(SYS_thr_self, &tid)) < 0 ) // Thread/Process id
+
+    #else
+        tid=syscall(SYS_gettid); 
+    #endif
 #endif
 return tid;
     }

--- a/src/zm_timer.h
+++ b/src/zm_timer.h
@@ -40,7 +40,11 @@ private:
 		thr_self(&lwpid);
 		tid = lwpid;
 #else
+    #ifdef __FreeBSD_kernel__
+                if ( (syscall(SYS_thr_self, &tid)) < 0 ) // Thread/Process id
+    #else
 		tid=syscall(SYS_gettid);
+    #endif
 #endif
 		return tid;
         }


### PR DESCRIPTION
kFreeBSD is apparently very different from FreeBSD.  

Some work arounds for missing defines.
Alternate syscall for getting thread id.
MAP_LOCKED is not defined so don't even bother to try the mmap LOCKED.
