### PR TITLE
close the session before requiring the page contents to fix the concurre...

### DIFF
--- a/web/ajax/event.php
+++ b/web/ajax/event.php
@@ -1,4 +1,6 @@
 <?php
+# We use session vars in here, so we need to restart the session because we stopped it in index.php to improve concurrency.
+session_start();
 
 if ( empty($_REQUEST['id']) && empty($_REQUEST['eids']) ) {
     ajaxError( "No event id(s) supplied" );

--- a/web/index.php
+++ b/web/index.php
@@ -143,6 +143,10 @@ if ( ZM_OPT_USE_AUTH && ! isset($user) && $view != 'login' ) {
     $view = 'login';
 }
 
+# Only one request can open the session file at a time, so let's close the session here to improve concurrency.
+# Any file/page that uses the session must re-open it.
+session_write_close();
+
 if ( isset( $_REQUEST['request'] ) )
 {
     foreach ( getSkinIncludes( 'ajax/'.$request.'.php', true, true ) as $includeFile )

--- a/web/skins/classic/views/export.php
+++ b/web/skins/classic/views/export.php
@@ -24,6 +24,9 @@ if ( !canView( 'Events' ) )
     return;
 }
 
+# Must re-start session because we close it now in index.php to improve concurrency
+session_start();
+
 if ( isset($_SESSION['export']) )
 {
     if ( isset($_SESSION['export']['detail']) )


### PR DESCRIPTION
...ncy issue that exists due to using the file-backed session.

See #806 

The idea here is that we close the session before including the page view to free up the session lock.  If a page needs to use the session it should re-open it.  Currently only ajax/event.php and views/export.php are the only ones that do.