### PR TITLE
Fix: typo in options_libvlc

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -889,7 +889,7 @@ $OLANG = array(
 		          "\"loglevel=debug\" Set verbosiy of FFmpeg (quiet, panic, fatal, error, warning, info, verbose, debug)"
 	),
 	'OPTIONS_LIBVLC' => array(
-		'Help' => "Parameters in this field are passwd on to libVLC. Multiple parameters can be separated by ,~~ ".
+		'Help' => "Parameters in this field are passed on to libVLC. Multiple parameters can be separated by ,~~ ".
 		          "Examples (do not enter quotes)~~~~".
 		          "\"--rtp-client-port=nnn\" Set local port to use for rtp data~~~~". 
 		          "\"--verbose=2\" Set verbosity of libVLC"


### PR DESCRIPTION
Fixed typo in the OPTIONS_LIBVLC help.