### PR TITLE
Fix fast forward/reverse in event playback (#688)

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -1428,8 +1428,10 @@ void EventStream::runStream()
             if ( ((curr_frame_id-1)%frame_mod) == 0 )
             {
                 delta_us = (unsigned int)(frame_data->delta * 1000000);
-                if ( effective_fps < base_fps )
-                    delta_us = (unsigned int)((delta_us * base_fps)/effective_fps);
+                // if effective > base we should speed up frame delivery
+                delta_us = (unsigned int)((delta_us * base_fps)/effective_fps);
+                // but must not exceed maxfps
+                delta_us = max(delta_us, 1000000 / maxfps); 
                 send_frame = true;
             }
         }


### PR DESCRIPTION
Fixes subissue 2 of issue #688 

If the frame rate for an event is less than the maximum frame rate for playing events, then fast forward/reverse don't work properly.

Suppose a capture frame rate of 10fps, a frame skip of 9 (therefore 1fps saved when not in alarm mode). Maximum display fps set to 10 also. If the replay rate is 5x, then calls to updateFrameRate will set effective_fps to 5 and frame_skip to 1, since maxfps is 10.

However, actual playback of the event is controlled by delta_us in the runStream() loop. This is calculated from the time difference between frames and is only adjusted if the effective_fps is less than the base_fps of the stream (ie slowmo). This means that fast forward/reverse don't actually speed up until you get to the point that updateFrameRate sets frame_skip>1. 

This patch always scales delta_us by base_fps/effective_fps, which means that the frame loop will speed up when required to give proper FF/REW behaviour. A lower limit is applied to delta_us to ensure maxfps is not exceeded.

If maxfps can be zero, this line should be protected by 'if(maxfps>0)'.

Finally another idea, it would seem sensible to limit the delta_us maximum value too - for instance if there are several seconds between frames for some reason, it seems unlikely that anyone would want to sit through that period watching one frame waiting for the next to occur.

