### PR TITLE
Update to FI982821W_Y2k

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
@@ -114,6 +114,10 @@ sub sendCmd
     my $result = undef;
 
 	my ($user, $password) = split /:/, $self->{Monitor}->{ControlDevice};
+	if ( ! $password ) {
+		$password = $user;
+		$user = 'admin';
+	}
 	$user = 'admin' if ! $user;
 	$password = 'pwd' if ! $password;
 


### PR DESCRIPTION
Fix printMsg.  We don't use it as an object method. 

Update to parse a user:password out of ControlAddress which is what  a lot of other scripts do.