### PR TITLE
Move iostream inclusion in zm.h and declare explicitely the namespace

### DIFF
--- a/src/zm.h
+++ b/src/zm.h
@@ -33,6 +33,8 @@
 
 #include <stdint.h>
 
+#include <iostream>
+
 extern const char* self;
 
 #endif // ZM_H

--- a/src/zm_image_analyser.h
+++ b/src/zm_image_analyser.h
@@ -6,7 +6,6 @@
 #include <list>
 #include <string>
 #include <stdexcept>
-#include <iostream>
 #include <memory>
 
 #include "zm.h"

--- a/src/zma.cpp
+++ b/src/zma.cpp
@@ -70,7 +70,7 @@ int main( int argc, char *argv[] )
 				Usage();
 				break;
 			case 'v':
-				cout << ZM_VERSION << "\n";
+				std::cout << ZM_VERSION << "\n";
 				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -115,7 +115,7 @@ int main( int argc, char *argv[] )
 				Usage();
 				break;
 			case 'v':
-				cout << ZM_VERSION << "\n";
+				std::cout << ZM_VERSION << "\n";
 				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );

--- a/src/zmf.cpp
+++ b/src/zmf.cpp
@@ -138,7 +138,7 @@ int main( int argc, char *argv[] )
 				Usage();
 				break;
 			case 'v':
-				cout << ZM_VERSION << "\n";
+				std::cout << ZM_VERSION << "\n";
 				exit(0);
 			default:
 				//fprintf( stderr, "?? getopt returned character code 0%o ??\n", c );

--- a/src/zmstreamer.cpp
+++ b/src/zmstreamer.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
                 printf("-v : This installed version of ZoneMinder\n");
                 return EXIT_SUCCESS;
             case 'v':
-                cout << ZM_VERSION << "\n";
+                std::cout << ZM_VERSION << "\n";
                 exit(0);
         }
     }


### PR DESCRIPTION
I got this issue:
```bash
make  all-recursive
make[1]: Entering directory '/home/lokidor/src/zm/git/ZoneMinder'
Making all in src
make[2]: Entering directory '/home/lokidor/src/zm/git/ZoneMinder/src'
x86_64-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I..  -I/usr/include -I/usr/include -I/usr/include -D__STDC_CONSTANT_MACROS -Wall -finline-functions -fomit-frame-pointer -I/usr/include -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -rdynamic -DHAVE_LIBCRYPTO -c -o zmc.o zmc.cpp
zmc.cpp: In function ‘int main(int, char**)’:
zmc.cpp:120:5: error: ‘cout’ was not declared in this scope
     cout << ZM_VERSION << "\n";
     ^
Makefile:870: recipe for target 'zmc.o' failed
make[2]: *** [zmc.o] Error 1
make[2]: Leaving directory '/home/lokidor/src/zm/git/ZoneMinder/src'
Makefile:562: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/lokidor/src/zm/git/ZoneMinder'
Makefile:460: recipe for target 'all' failed
make: *** [all] Error 2
```
PR https://github.com/ZoneMinder/ZoneMinder/pull/664 has added a dependancy to iostream cpp library but this library is included only in `src/zm_image_analyser.h`.
This header file is included indirectly by multiple interposed links and I think this is the root cause.
I don't know what exactly happened but this PR definitively solves my problem and it's cleaner.