### PR TITLE
Don't die if db goes away during logging

### DIFF
--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -604,8 +604,7 @@ void Logger::logPrint( bool hex, const char * const file, const int line, const 
             if ( mysql_query( &mDbConnection, sql ) )
             {
                 databaseLevel( NOLOG );
-                Fatal( "Can't insert log entry: %s", mysql_error( &mDbConnection ) );
-                exit( mysql_errno( &mDbConnection ) );
+				Error( "Can't insert log entry: %s", mysql_error( &mDbConnection ) );
             }
         }
         if ( level <= mSyslogLevel )


### PR DESCRIPTION
So I don't know why I was getting a mysql has gone away error (mysql wasn't logging anything).  

That is beside the point.  There is no reason to die because of it.  

Now this is a very minimal fix. It turns off db logging and continues.  However it should probably attempt to reconnect on every log line.  

