### PR TITLE
reduce the wait to 2/10ths instead of a whole second

### DIFF
--- a/web/ajax/stream.php
+++ b/web/ajax/stream.php
@@ -48,7 +48,7 @@ switch ( $_REQUEST['command'] )
 $remSockFile = ZM_PATH_SOCKS.'/zms-'.sprintf("%06d",$_REQUEST['connkey']).'s.sock';
 $max_socket_tries = 10;
 while ( !file_exists($remSockFile) && $max_socket_tries-- ) //sometimes we are too fast for our own good, if it hasn't been setup yet give it a second.
-    sleep(1);
+	usleep(200000);
 
 if ( !@socket_sendto( $socket, $msg, strlen($msg), 0, $remSockFile ) )
 {


### PR DESCRIPTION
Found this out on the net, and I agree with it.  A second is a long time.