### PR TITLE
Add version to the startup log line

### DIFF
--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -209,7 +209,7 @@ int main( int argc, char *argv[] )
 		exit ( -1 );
 	}
 
-	Info( "Starting Capture" );
+	Info( "Starting Capture version %s", ZM_VERSION );
 
 	zmSetDefaultTermHandler();
 	zmSetDefaultDieHandler();


### PR DESCRIPTION
The purpose is so that when people paste their logs we can quickly identify the version of ZM in use instead of having to ask.