### PR TITLE
881 bootstrap loading config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@
 cmake_minimum_required (VERSION 2.6)
 project (zoneminder)
 set(zoneminder_VERSION "1.28.1")
+# make API version a minor of ZM version
+set(zoneminder_API_VERSION "${zoneminder_VERSION}.1")
 
 # CMake does not allow out-of-source build if CMakeCache.exists 
 # in the source folder. Abort and notify the user
@@ -627,6 +629,7 @@ endif(NOT POLKIT_FOUND)
 set(ZM_PID "${ZM_RUNDIR}/zm.pid")
 set(ZM_CONFIG "${ZM_CONFIG_DIR}/zm.conf")
 set(VERSION "${zoneminder_VERSION}")
+set(API_VERSION "${zoneminder_API_VERSION}")
 set(PKGDATADIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/zoneminder")
 set(BINDIR "${CMAKE_INSTALL_FULL_BINDIR}")
 set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")

--- a/web/api/app/Config/bootstrap.php.in
+++ b/web/api/app/Config/bootstrap.php.in
@@ -107,3 +107,37 @@ CakeLog::config('error', array(
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));
+
+Configure::write('ZM_CONFIG',  '@ZM_CONFIG@');
+Configure::write('ZM_VERSION', '@VERSION@');
+Configure::write('ZM_API_VERSION', '@API_VERSION@');
+
+loadConfigFile();
+
+function loadConfigFile() {
+		        $configFile = Configure::read('ZM_CONFIG');
+		        $localConfigFile = basename($configFile);
+		        if ( file_exists( $localConfigFile ) && filesize( $localConfigFile ) > 0 )
+		        {
+		            if ( php_sapi_name() == 'cli' && empty($_SERVER['REMOTE_ADDR']) )
+		                print( "Warning, overriding installed $localConfigFile file with local copy\n" );
+		            else
+		                error_log( "Warning, overriding installed $localConfigFile file with local copy" );
+			            $configFile = $localConfigFile;
+		        }
+
+		        $cfg = fopen( $configFile, "r") or die("Could not open config file.");
+		        while ( !feof($cfg) )
+		        {
+		            $str = fgets( $cfg, 256 );
+		            if ( preg_match( '/^\s*$/', $str ))
+		                continue;
+		            elseif ( preg_match( '/^\s*#/', $str ))
+		                continue;
+		            elseif ( preg_match( '/^\s*([^=\s]+)\s*=\s*(.*?)\s*$/', $str, $matches ))
+	                    Configure::write("$matches[1]", "$matches[2]");
+		        }
+		        fclose( $cfg );
+}
+
+

--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -101,10 +101,12 @@ class HostController extends AppController {
 
 	function getVersion() {
 		$version = Configure::read('ZM_VERSION');
+		$apiversion = Configure::read('ZM_API_VERSION');
 
 		$this->set(array(
 			'version' => $version,
-			'_serialize' => array('version')
+			'apiversion' => $apiversion,
+			'_serialize' => array('version', 'apiversion')
 		));
 	}
 }


### PR DESCRIPTION
Reference: https://github.com/ZoneMinder/ZoneMinder/issues/881

Summary of changes:
a) CMakeLists.txt modified to also generate an API version (subclassed from ZM version)
b) getVersion API returns both API and ZM versions
c) There was code missing in bootstrap.php.in that identified the ZM config file and version - added it back (from angular-ui-branch)