### PR TITLE
Use avconv as alternative to ffmpeg executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,9 @@ if(NOT ZM_NO_FFMPEG)
 	endif(SWSCALE_LIBRARIES)
 
 	# Find the path to the ffmpeg executable
-	find_program(FFMPEG_EXECUTABLE ffmpeg PATH_SUFFIXES ffmpeg)
+	find_program(FFMPEG_EXECUTABLE 
+		NAMES ffmpeg avconv
+		PATH_SUFFIXES ffmpeg)
 	if(FFMPEG_EXECUTABLE)
 		set(PATH_FFMPEG "${FFMPEG_EXECUTABLE}")
 		set(OPT_FFMPEG "yes")


### PR DESCRIPTION
Pulling some patches from the debian package. This one seems something we can implement upstream without an issue.