### PR TITLE
reverse the if statement to reduce indenting

### DIFF
--- a/scripts/zmwatch.pl.in
+++ b/scripts/zmwatch.pl.in
@@ -85,15 +85,60 @@ while( 1 )
         or Fatal( "Can't execute: ".$sth->errstr() );
     while( my $monitor = $sth->fetchrow_hashref() )
     {
-        if ( $monitor->{Function} ne 'None' )
+        next if $monitor->{Function} eq 'None';
+        my $restart = 0;
+        if ( zmMemVerify( $monitor )
+             && zmMemRead( $monitor, "shared_data:valid" )
+        )
         {
-            my $restart = 0;
+            # Check we have got an image recently
+            my $image_time = zmGetLastWriteTime( $monitor );
+            next if ( !defined($image_time) ); # Can't read from shared data
+            next if ( !$image_time ); # We can't get the last capture time so can't be sure it's died.
+
+            my $max_image_delay = ( $monitor->{MaxFPS}
+                                    &&($monitor->{MaxFPS}>0)
+                                    &&($monitor->{MaxFPS}<1)
+                                  ) ? (3/$monitor->{MaxFPS})
+                                    : $Config{ZM_WATCH_MAX_DELAY}
+            ;
+            my $image_delay = $now-$image_time;
+            Debug( "Monitor $monitor->{Id} last captured $image_delay seconds ago, max is $max_image_delay\n" );
+            if ( $image_delay > $max_image_delay )
+            {
+                Info( "Restarting capture daemon for "
+                      .$monitor->{Name}.", time since last capture $image_delay seconds ($now-$image_time)\n"
+                );
+                $restart = 1;
+            }
+        }
+        else
+        {
+            #Info( "Restarting capture daemon for ".$monitor->{Name}.", shared data not valid\n" );
+            #$restart = 1;
+        }
+
+        if ( $restart )
+        {
+            my $command;
+            if ( $monitor->{Type} eq 'Local' )
+            {
+                $command = "zmdc.pl restart zmc -d $monitor->{Device}";
+            }
+            else
+            {
+                $command = "zmdc.pl restart zmc -m $monitor->{Id}";
+            }
+            runCommand( $command );
+        }
+        elsif ( $monitor->{Function} ne 'Monitor' )
+        {
             if ( zmMemVerify( $monitor )
                  && zmMemRead( $monitor, "shared_data:valid" )
             )
             {
                 # Check we have got an image recently
-                my $image_time = zmGetLastWriteTime( $monitor );
+                my $image_time = zmGetLastReadTime( $monitor );
                 next if ( !defined($image_time) ); # Can't read from shared data
                 next if ( !$image_time ); # We can't get the last capture time so can't be sure it's died.
 
@@ -104,67 +149,20 @@ while( 1 )
                                         : $Config{ZM_WATCH_MAX_DELAY}
                 ;
                 my $image_delay = $now-$image_time;
-                Debug( "Monitor $monitor->{Id} last captured $image_delay seconds ago, max is $max_image_delay\n" );
+                Debug( "Monitor $monitor->{Id} last analysed $image_delay seconds ago, max is $max_image_delay\n" );
                 if ( $image_delay > $max_image_delay )
                 {
-                    Info( "Restarting capture daemon for "
-                          .$monitor->{Name}.", time since last capture $image_delay seconds ($now-$image_time)\n"
+                    Info( "Restarting analysis daemon for "
+                          .$monitor->{Name}.", time since last analysis $image_delay seconds ($now-$image_time)\n"
                     );
-                    $restart = 1;
-                }
-            }
-            else
-            {
-                #Info( "Restarting capture daemon for ".$monitor->{Name}.", shared data not valid\n" );
-                #$restart = 1;
-            }
-
-            if ( $restart )
-            {
-                my $command;
-                if ( $monitor->{Type} eq 'Local' )
-                {
-                    $command = "zmdc.pl restart zmc -d $monitor->{Device}";
-                }
-                else
-                {
-                    $command = "zmdc.pl restart zmc -m $monitor->{Id}";
-                }
-                runCommand( $command );
-            }
-            elsif ( $monitor->{Function} ne 'Monitor' )
-            {
-                if ( zmMemVerify( $monitor )
-                     && zmMemRead( $monitor, "shared_data:valid" )
-                )
-                {
-                    # Check we have got an image recently
-                    my $image_time = zmGetLastReadTime( $monitor );
-                    next if ( !defined($image_time) ); # Can't read from shared data
-                    next if ( !$image_time ); # We can't get the last capture time so can't be sure it's died.
-
-                    my $max_image_delay = ( $monitor->{MaxFPS}
-                                            &&($monitor->{MaxFPS}>0)
-                                            &&($monitor->{MaxFPS}<1)
-                                          ) ? (3/$monitor->{MaxFPS})
-                                            : $Config{ZM_WATCH_MAX_DELAY}
-                    ;
-                    my $image_delay = $now-$image_time;
-                    Debug( "Monitor $monitor->{Id} last analysed $image_delay seconds ago, max is $max_image_delay\n" );
-                    if ( $image_delay > $max_image_delay )
-                    {
-                        Info( "Restarting analysis daemon for "
-                              .$monitor->{Name}.", time since last analysis $image_delay seconds ($now-$image_time)\n"
-                        );
-                        my $command = "zmdc.pl restart zma -m ".$monitor->{Id};
-                        runCommand( $command );
-                    }
+                    my $command = "zmdc.pl restart zma -m ".$monitor->{Id};
+                    runCommand( $command );
                 }
             }
         }
-        # Prevent open handles building up if we have connect to shared memory
-        zmMemInvalidate( $monitor );
     }
+    # Prevent open handles building up if we have connect to shared memory
+    zmMemInvalidate( $monitor );
     sleep( $Config{ZM_WATCH_CHECK_INTERVAL} );
 }
 Info( "Watchdog exiting\n" );


### PR DESCRIPTION
This alters a lot of lines, but it's really just a removal of indenting by reversing the if condition.  Please note that there is a secondary effect of not calling zmMemInvalidate for monitors that are Function==None, but we never attempt to connect to the shared mem for them, so that is fine.

I could have altered the SQL statement to just be Function!=None but maybe someday we will want to add a debug line for None Monitors, I don't know.  