### PR TITLE
898 is running states

### DIFF
--- a/db/zm_create.sql.in
+++ b/db/zm_create.sql.in
@@ -382,12 +382,14 @@ CREATE TABLE `Monitors` (
 
 --
 -- Table structure for table `States`
+-- Added IsActive to track custom run states
 --
 
 DROP TABLE IF EXISTS `States`;
 CREATE TABLE `States` (
   `Name` varchar(64) NOT NULL default '',
   `Definition` text NOT NULL,
+  `IsActive` tinyint(3) unsigned NOT NULL default '0',
   PRIMARY KEY (`Name`)
 ) ENGINE=@ZM_MYSQL_ENGINE@;
 

--- a/db/zm_update-1.28.99.sql
+++ b/db/zm_update-1.28.99.sql
@@ -324,4 +324,20 @@ WHERE NOT EXISTS (
 --
 UPDATE `zm`.`Config` SET `Category`='hidden' WHERE `Name`='ZM_USE_DEEP_STORAGE';
 
+--- The States table will be updated to have a new column called IsActive
+--- used to keep track of which custom state is active (if any)
+SET @s = (SELECT IF(
+	(SELECT COUNT(*)
+	FROM INFORMATION_SCHEMA.COLUMNS
+	WHERE table_name = 'States'
+	AND table_schema = DATABASE()
+	AND column_name = 'IsActive'
+	) > 0,
+"SELECT 'Column IsActive  exists in States'",
+"ALTER TABLE `States` ADD `IsActive` tinyint(3) unsigned not null default 0 AFTER `Definition`"
+));
+
+PREPARE stmt FROM @s;
+EXECUTE stmt;
+
 

--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -55,6 +55,7 @@ use autouse 'Pod::Usage'=>qw(pod2usage);
 $ENV{PATH}  = '/bin:/usr/bin';
 $ENV{SHELL} = '/bin/sh' if exists $ENV{SHELL};
 delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
+my $store_state=""; # PP - will remember state name passed
 
 logInit();
 
@@ -90,6 +91,7 @@ if ( !$command || $command !~ /^(?:start|stop|restart|status|logrot|version)$/ )
                       { Id=>$id, Function=>$function, Enabled=>$enabled }
                 );
             }
+ 	    $store_state=$command; # PP - Remember the name that was passed to search in DB
             $command = 'state';
         }
         else
@@ -149,6 +151,18 @@ if ( $command eq "state" )
         }
     }
     $sth->finish();
+    #PP - lets go ahead and modify States DB
+
+      
+    Debug ("Marking $store_state as Enabled");
+    # PP  - Zero out other states being active
+    resetStates();
+    # PP - Now mark a specific state as active
+    $sql = "update States set IsActive = '1' where Name = ?";
+    $sth = $dbh->prepare_cached( $sql )
+         or Fatal( "Can't prepare '$sql': ".$dbh->errstr() );
+    $res = $sth->execute( $store_state )
+         or Fatal( "Can't execute: ".$sth->errstr() );
 
     $command = "restart";
 }
@@ -158,6 +172,9 @@ if ( $command =~ /^(start|stop|restart)$/ )
 {
     # We have to detaint to keep perl from complaining
     $command = $1;
+
+    # PP - if we are not switching to a custom state, zero out all isActive
+    resetStates() if (!$store_state); 
 
     if ( systemdRunning() && !calledBysystem() ) {
         qx(@BINDIR@/zmsystemctl.pl $command);
@@ -289,6 +306,19 @@ if ( $command eq "logrot" )
 }
 
 exit( $retval );
+
+# PP - when the system is restarted/started/stopped, it will 
+# not be in a custom state, so lets keep the DB consistent
+sub resetStates
+{
+        $dbh = zmDbConnect() if ! $dbh;
+        my $sql = "update States set IsActive = '0'";
+        my $sth = $dbh->prepare_cached( $sql )
+                or Fatal( "Can't prepare '$sql': ".$dbh->errstr() );
+                my $res = $sth->execute()
+                or Fatal( "Can't execute: ".$sth->errstr() );
+
+}
 
 sub systemdRunning
 {

--- a/web/api/app/Controller/Component/ImageComponent.php
+++ b/web/api/app/Controller/Component/ImageComponent.php
@@ -74,6 +74,7 @@ class ImageComponent extends Component {
 		      */
 		}
 
+		/*
 		$imageData = array(
 		    'eventPath' => $eventPath,
 		    'imagePath' => $imagePath,
@@ -86,6 +87,7 @@ class ImageComponent extends Component {
 		);
 
 		return( $imageData );
+	 */
 
 	}
 

--- a/web/api/app/Controller/Component/ImageComponent.php
+++ b/web/api/app/Controller/Component/ImageComponent.php
@@ -48,6 +48,14 @@ class ImageComponent extends Component {
 			$imageFile = $config['ZM_DIR_EVENTS']."/".$imagePath;
 			//$thumbFile = ZM_DIR_EVENTS."/".$thumbPath;
 			$thumbFile = $thumbPath;
+			// PP: This segment of code results in errors when trying to get Events API
+			// This actually seems to be generating images for the angular UI web view
+			// and should not be a part of the API anyway
+			// I've commented it so events APIs continue to work
+			// I did ask Kyle about this, but I don't have an answer from him
+			// Either way, it does no harm to remove it -- as the UI of master 
+			// does not use API code anyway
+			/*
 			if ( $overwrite || !file_exists( $thumbFile ) || !filesize( $thumbFile ) )
 			{
 			    // Get new dimensions
@@ -63,6 +71,7 @@ class ImageComponent extends Component {
 			    if ( !imagejpeg( $thumbImage, $thumbFile ) )
 			        Error( "Can't create thumbnail '$thumbPath'" );
 			}
+		      */
 		}
 
 		$imageData = array(

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -70,6 +70,8 @@ $eventCounts = array(
 
 $running = daemonCheck();
 $status = $running?translate('Running'):translate('Stopped');
+$run_state_array = dbFetchOne('select Name from States where  IsActive = 1');
+$run_state  = implode($run_state_array);
 
 $group = NULL;
 if ( ! empty($_COOKIE['zmGroup']) ) {
@@ -188,7 +190,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
       <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>%</h3>
-      <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
+      <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <div id="monitorSummary"><?php echo makePopupLink( '?view=groups', 'zmGroups', 'groups', translate('Group') . ': ' . ($group?' ('.$group['Name'].')':'All').': '. sprintf( $CLANG['MonitorCount'], count($displayMonitors), zmVlang( $VLANG['Monitor'], count($displayMonitors) ) ) ); ?></div>
 <?php


### PR DESCRIPTION
1) Updated zmpkg to update new IsActive column of states. If the user is switching to a custom state, IsActive for that state will be 1. If the user is not switching to a custom state (restart/stop/start) then IsActive will be 0 for all

2) Modified create DB script to add the new column

3) Modified updated DB script to update the new column

4) Modified console.php to reflect custom state new (convenience only). If the current state is just Running then nothing will show. This is only done in classic --> does not apply to mobile/xml

reference: https://github.com/ZoneMinder/ZoneMinder/issues/898