### PR TITLE
Introduce a read_into function in the Buffer. 

### DIFF
--- a/src/zm_buffer.cpp
+++ b/src/zm_buffer.cpp
@@ -18,6 +18,7 @@
 */ 
 
 #include <string.h>
+#include <fcntl.h>
 
 #include "zm.h"
 #include "zm_buffer.h"
@@ -66,4 +67,15 @@ unsigned int Buffer::expand( unsigned int count )
         mTail = mHead + width;
     }
     return( mSize );
+}
+
+int Buffer::read_into( int sd, unsigned int bytes ) {
+    // Make sure there is enough space
+    this->expand(bytes);
+    int bytes_read = read( sd, mTail, bytes );
+    if ( bytes_read > 0 ) {
+        mTail += bytes_read;
+        mSize += bytes_read;
+    }
+    return bytes_read;
 }

--- a/src/zm_buffer.h
+++ b/src/zm_buffer.h
@@ -203,6 +203,7 @@ public:
     {
         return( (int)mSize );
     }
+	int read_into( int sd, unsigned int bytes );
 };
 
 #endif // ZM_BUFFER_H


### PR DESCRIPTION
 Use it when reading over http from a camera to remove an extra mem copy. 
Limit reads to 1 network buffer instead of reading everything that is available. This prevents our buffer from getting overly large and leaves the buffering in the OS.  