### PR TITLE
rpm packaging - require php-gd

### DIFF
--- a/distros/fedora/zoneminder.f20.spec
+++ b/distros/fedora/zoneminder.f20.spec
@@ -38,7 +38,7 @@ BuildRequires: gcc gcc-c++ vlc-devel libcurl-devel libv4l-devel
 BuildRequires:  httpd polkit-devel
 %{!?_without_ffmpeg:BuildRequires: ffmpeg}
 
-Requires: httpd php php-mysql cambozola polkit net-tools psmisc
+Requires: httpd php php-gd php-mysql cambozola polkit net-tools psmisc
 Requires: libjpeg-turbo vlc-core libcurl
 Requires: perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires: perl(DBD::mysql) perl(Archive::Tar) perl(Archive::Zip)

--- a/distros/fedora/zoneminder.f21.spec
+++ b/distros/fedora/zoneminder.f21.spec
@@ -38,7 +38,7 @@ BuildRequires: gcc gcc-c++ vlc-devel libcurl-devel libv4l-devel
 BuildRequires:  httpd polkit-devel
 %{!?_without_ffmpeg:BuildRequires: ffmpeg}
 
-Requires: httpd php php-mysql cambozola polkit net-tools psmisc
+Requires: httpd php php-gd php-mysql cambozola polkit net-tools psmisc
 Requires: libjpeg-turbo vlc-core libcurl
 Requires: perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires: perl(DBD::mysql) perl(Archive::Tar) perl(Archive::Zip)

--- a/distros/redhat/zoneminder.el6.spec
+++ b/distros/redhat/zoneminder.el6.spec
@@ -30,7 +30,7 @@ BuildRequires:  libcurl-devel vlc-devel ffmpeg-devel polkit-devel
 # cmake needs the following installed at build time due to the way it auto-detects certain parameters
 BuildRequires:  httpd ffmpeg
 
-Requires:   httpd php php-mysql mysql-server libjpeg-turbo polkit net-tools psmisc
+Requires:   httpd php php-gd php-mysql mysql-server libjpeg-turbo polkit net-tools psmisc
 Requires:   perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires:   perl(DBD::mysql) perl(Archive::Tar) perl(Archive::Zip)
 Requires:   perl(MIME::Entity) perl(MIME::Lite) perl(Net::SMTP) perl(Net::FTP)

--- a/distros/redhat/zoneminder.el7.spec
+++ b/distros/redhat/zoneminder.el7.spec
@@ -32,7 +32,7 @@ BuildRequires: ffmpeg ffmpeg-devel perl(X10::ActiveHome) perl(Astro::SunTime)
 # cmake needs the following installed at build time due to the way it auto-detects certain parameters
 BuildRequires:  httpd polkit-devel
 
-Requires: httpd php php-mysql mariadb-server polkit net-tools psmisc
+Requires: httpd php php-gd php-mysql mariadb-server polkit net-tools psmisc
 Requires: libjpeg-turbo vlc-core libcurl
 Requires: perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 Requires: perl(DBD::mysql) perl(Archive::Tar) perl(Archive::Zip)


### PR DESCRIPTION
This requirement is based on this thread in the user forum:
http://www.zoneminder.com/forums/viewtopic.php?f=32&t=23282

Other distros should likely follow suite.
