### PR TITLE
Change from info to debug

### DIFF
--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -235,7 +235,7 @@ void Logger::initialise( const std::string &id, const Options &options )
 
 void Logger::terminate()
 {
-    Info( "Terminating Logger" );
+    Debug(1, "Terminating Logger" );
 
     if ( mFileLevel > NOLOG )
         closeFile();


### PR DESCRIPTION
Because zms (and maybe others) use this and can be called very fast at times, it seems silly to fill up the log with these as info messages as they really do not convey the level of useful information that seems appropriate to info; it seems more like debug info.