### PR TITLE
Remove shared data warning for purpose query only

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -425,10 +425,6 @@ Monitor::Monitor(
             Error( "Shared data not initialised by capture daemon for monitor %s", name );
             exit( -1 );
         }
-        else
-        {
-            Warning( "Shared data not initialised by capture daemon, some query functions may not be available or produce invalid results for monitor %s", name );
-        }
     }
 
 	// Will this not happen every time a monitor is instantiated?  Seems like all the calls to the Monitor constructor pass a zero for n_zones, then load zones after..


### PR DESCRIPTION
This is one case (only) of the shared data not initialized warning, specifically when the Monitor::Monitor constructor is called with query purpose=QUERY.  In that case, the deleted warning message cannot be avoided -- mem_ptr is initialized to null, then (after a second of code that cannot be executed when purpose==QUERY) is tested and this warning given.

It also appears to work properly, so I cannot actually see that the mem_ptr needs to be initialized for purpose==QUERY at that point, as all paths I have tested seem to work properly.

This pull does not address whether the other shared data not initialized error, the one that does not end with "some query functions", is correct or not; I did not research it.