### PR TITLE
fix #948 1

### DIFF
--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -70,8 +70,7 @@ $eventCounts = array(
 
 $running = daemonCheck();
 $status = $running?translate('Running'):translate('Stopped');
-$run_state_array = dbFetchOne('select Name from States where  IsActive = 1');
-$run_state  = implode($run_state_array);
+$run_state = dbFetchOne('select Name from States where  IsActive = 1', 'Name' );
 
 $group = NULL;
 if ( ! empty($_COOKIE['zmGroup']) ) {


### PR DESCRIPTION
So the code was pretty wrong.  

dbFetchOne could return  a hash, in which case implode is the wrong thing.  Or it could return false, and again implode is the wrong thing.

This code will need to be updated to pull status from the Servers table, but for now this should get rid of the error. I think.