### PR TITLE
Implemented #989 (highlight current row in tables) for dark CSS

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -245,6 +245,11 @@ ul.tabList li.active a {
     font-size: 120%;
 }
 
+#content table > tbody > tr:hover
+{
+    background-color: #333333;
+}
+
 .overlay {
     font-size: 11px;
     background-color: #222222;


### PR DESCRIPTION
This patch does the row highlighting even in the dark CSS. It's so useful and yet so simple...!