### PR TITLE
Add scale as optional feature to image.php

### DIFF
--- a/web/views/image.php
+++ b/web/views/image.php
@@ -26,10 +26,10 @@
 //          Omitted or 100 = no scaling done, image passed through directly
 //          Scaling will increase response time slightly
 //
-//     width and height are optional, but if one is passed both should be passed (or they will be ignored)
-//          Pixel dimension to returned, scaling up or down
+//     width and height are each optional, ideally supply both, but if only one is supplied the other is calculated
+//          These are in pixels
 //
-//     If both scale and width & height are specified, scale is ignored
+//     If both scale and either width or height are specified, scale is ignored
 //
 
 if ( !canView( 'Events' ) )
@@ -95,17 +95,25 @@ if( !empty($_REQUEST['height']) )
 if ( $errorText )
     Error( $errorText );
 else
-    if($scale==100 && ($width==0 || $height==0) )
+    if( $scale==100 && $width==0 && $height==0 )
         readfile( ZM_DIR_EVENTS.'/'.$path );
     else
     {
         $i = imagecreatefromjpeg ( ZM_DIR_EVENTS.'/'.$path );
         $oldWidth=imagesx($i);
         $oldHeight=imagesy($i);
-        if($width==0 || $height==0)  // default to scale if either height or width is missing
+        if($width==0 && $height==0)
         {
             $width=$oldWidth * $scale / 100.0;
             $height=$oldHeight * $scale / 100.0;
+        }
+        elseif ($width==0 && $height!=0)
+        {
+            $width = ($oldWidth / $OldHeight) * $height;
+        }
+        elseif ($width!=0 && $height==0)
+        {
+            $height = ($oldHeight / $oldWidth) * $width;
         }
         if($width==$oldWidth && $height==$oldHeight)  // See if we really need to scale
         {

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -65,7 +65,7 @@ else
     }
 }
 
-$scale=100;
+$scale=0;
 if( !empty($_REQUEST['scale']) )
     if (is_numeric($_REQUEST['scale']))
     {
@@ -102,18 +102,18 @@ else
         $i = imagecreatefromjpeg ( ZM_DIR_EVENTS.'/'.$path );
         $oldWidth=imagesx($i);
         $oldHeight=imagesy($i);
-        if($width==0 && $height==0)
+        if($width==0 && $height==0)  // scale has to be set to get here with both zero
         {
-            $width=$oldWidth * $scale / 100.0;
-            $height=$oldHeight * $scale / 100.0;
+            $width = $oldWidth  * $scale / 100.0;
+            $height= $oldHeight * $scale / 100.0;
         }
         elseif ($width==0 && $height!=0)
         {
-            $width = ($oldWidth / $OldHeight) * $height;
+            $width = ($height * $oldWidth) / $oldHeight;
         }
         elseif ($width!=0 && $height==0)
         {
-            $height = ($oldHeight / $oldWidth) * $width;
+            $height = ($width * $oldHeight) / $oldWidth;
         }
         if($width==$oldWidth && $height==$oldHeight)  // See if we really need to scale
         {

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -95,7 +95,7 @@ if( !empty($_REQUEST['height']) )
 if ( $errorText )
     Error( $errorText );
 else
-    if( $scale==0 && $width==0 && $height==0 )
+    if( ($scale==0 || $scale==100) && $width==0 && $height==0 )
         readfile( ZM_DIR_EVENTS.'/'.$path );
     else
     {

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -95,7 +95,7 @@ if( !empty($_REQUEST['height']) )
 if ( $errorText )
     Error( $errorText );
 else
-    if( $scale==100 && $width==0 && $height==0 )
+    if( $scale==0 && $width==0 && $height==0 )
         readfile( ZM_DIR_EVENTS.'/'.$path );
     else
     {


### PR DESCRIPTION
This relates to the issue described in #1000.

It adds the ability to invoke the image.php view from with any of: 

1) No scale - does exactly as before
2) scale parameter - scales as indicated
3) Both width and height pixel size - scale as indicated

For consistency with past programs both the default, and what happens if there are errors in the parameters, is to pass the image out unchanged.

Editorial comment: While this program is preferable to accessing images insecurely through the /events path, I think the long term direction should be to roll single frame historical access, similar to single frame live access, into zms.  But in the meantime this allows clients (such as new mobile programs) to make the choice as to whether have the server scale (slower server access but much lower bandwidth consumption) or the client scale (less server load, more load on client and network).

This requires php5-gd, but that was recently added as a dependency anyway.
