### PR TITLE
Demote user auth info message to debug

### DIFF
--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -238,7 +238,7 @@ User *zmLoadAuthUser( const char *auth, bool use_remote_addr )
 			{
 				// We have a match
 				User *user = new User( dbrow );
-				Info( "Authenticated user '%s'", user->getUsername() );
+				Debug(1, "Authenticated user '%s'", user->getUsername() );
 				return( user );
 			}
 		}


### PR DESCRIPTION
This change reduces the level from Informational to Debug of the "Authenticated user" message that ZMS puts out when revalidating a user's authorization.  It does not reduce the one for initial user authentication load.

This prevents what can be very high speed logging when zms is called for individual frames.