### PR TITLE
I was using the wrong field to check for portal authentication

### DIFF
--- a/web/api/app/Controller/AppController.php
+++ b/web/api/app/Controller/AppController.php
@@ -56,7 +56,7 @@ class AppController extends Controller {
 	// its pretty simple to extend this to also check
 	// for role and deny API access in future 
 	public function beforeFilter() {
-		if (!$this->Session->Read('username')) 
+		if (!$this->Session->Read('user.Username')) 
 		{
 			
 			throw new NotFoundException(__('Not Authenticated'));


### PR DESCRIPTION
Should be user.Username instead of username. The latter is set irrespective of whether you login or not. The former is set only after you successfully log in (which is what we need)