### PR TITLE
Send login activity to the zoneminder event log

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -56,6 +56,7 @@ function userLogin( $username, $password="", $passwordHashed=false )
     $_SESSION['remoteAddr'] = $_SERVER['REMOTE_ADDR']; // To help prevent session hijacking
     if ( $dbUser = dbFetchOne( $sql, NULL, $sql_values ) )
     {
+        Info( "Login successful for user \"$username\"" );
         $_SESSION['user'] = $user = $dbUser;
         if ( ZM_AUTH_TYPE == "builtin" )
         {
@@ -64,6 +65,7 @@ function userLogin( $username, $password="", $passwordHashed=false )
     }
     else
     {
+        Warning( "Login denied for user \"$username\"" );
         unset( $user );
     }
     if ( $cookies )
@@ -73,6 +75,9 @@ function userLogin( $username, $password="", $passwordHashed=false )
 function userLogout()
 {
     global $user;
+    $username = $user['Username'];
+
+    Info( "User \"$username\" logged out" );
 
     unset( $_SESSION['user'] );
     unset( $user );


### PR DESCRIPTION
Been meaning to do this for a while now.  
Login activity, both successful and failed, should be logged.

This PR makes it possible for third party utilities, such as fail2ban, to monitor for login/logout events and take action on it (e.g. ban the offending ip after X attempts).
