### PR TITLE
Remove full path from Logger filename

### DIFF
--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -493,7 +493,7 @@ void Logger::closeSyslog()
     (void) closelog();
 }
 
-void Logger::logPrint( bool hex, const char * const file, const int line, const int level, const char *fstring, ... )
+void Logger::logPrint( bool hex, const char * const filepath, const int line, const int level, const char *fstring, ... )
 {
     if ( level <= mEffectiveLevel )
     {
@@ -502,6 +502,8 @@ void Logger::logPrint( bool hex, const char * const file, const int line, const 
         char            logString[8192];
         va_list         argPtr;
         struct timeval  timeVal;
+
+        const char * const file = basename(filepath);
         
         if ( level < PANIC || level > DEBUG9 )
             Panic( "Invalid logger level %d", level );

--- a/src/zm_logger.h
+++ b/src/zm_logger.h
@@ -186,7 +186,7 @@ private:
     void closeDatabase();
 
 public:
-    void logPrint( bool hex, const char * const file, const int line, const int level, const char *fstring, ... );
+    void logPrint( bool hex, const char * const filepath, const int line, const int level, const char *fstring, ... );
 };
 
 void logInit( const char *name, const Logger::Options &options=Logger::Options() );


### PR DESCRIPTION
fixes #958 

Only affects logging from cpp.  Does not affect Perl & PHP scripts.