### PR TITLE
Fix sgfault caused by the privacy mask stuff

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -331,7 +331,8 @@ Monitor::Monitor(
     n_zones( p_n_zones ),
     zones( p_zones ),
     timestamps( 0 ),
-    images( 0 )
+    images( 0 ),
+    privacy_bitmask( NULL )
 {
     strncpy( name, p_name, sizeof(name) );
 
@@ -692,11 +693,13 @@ void Monitor::AddZones( int p_n_zones, Zone *p_zones[] )
 
 void Monitor::AddPrivacyBitmask( Zone *p_zones[] )
 {
-    delete[] privacy_bitmask;
+	if ( privacy_bitmask )
+		delete[] privacy_bitmask;
     privacy_bitmask = NULL;
     Image *privacy_image = NULL;
 
     for ( int i = 0; i < n_zones; i++ )
+    {
         if ( p_zones[i]->IsPrivacy() )
         {
             if ( !privacy_image )
@@ -707,6 +710,7 @@ void Monitor::AddPrivacyBitmask( Zone *p_zones[] )
             privacy_image->Fill( 0xff, p_zones[i]->GetPolygon() );
             privacy_image->Outline( 0xff, p_zones[i]->GetPolygon() );
         }
+    } // end foreach zone
     if ( privacy_image )
         privacy_bitmask = privacy_image->Buffer();
 }


### PR DESCRIPTION
Didn't init privacy_bitmask, so later when we did delete[] privacy_bitmask it crashed.

Not sure why no one else was seeing this, but this fixes it anyways.

Also adds some needed braces for clarity.