### PR TITLE
Use the 3.0 branch of crud, compatible with cakephp 2.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "web/api/app/Plugin/Crud"]
 	path = web/api/app/Plugin/Crud
 	url = https://github.com/FriendsOfCake/crud.git
+	branch = 3.0


### PR DESCRIPTION
The master branch of crud doesn't support cakephp 2.x.  The 3.0 branch does.