### PR TITLE
use deleteAll() vs. delete() when deleting an Event's Frames

### DIFF
--- a/web/api/app/Model/Event.php
+++ b/web/api/app/Model/Event.php
@@ -62,7 +62,7 @@ class Event extends AppModel {
 			'order' => '',
 			'limit' => '',
 			'offset' => '',
-			'exclusive' => '',
+			'exclusive' => 'true',
 			'finderQuery' => '',
 			'counterQuery' => ''
 		)


### PR DESCRIPTION
This resolves #1072 and makes #1074 unnecessary.  Should have been part of #1075 