### PR TITLE
Tz

### DIFF
--- a/distros/debian/init.d
+++ b/distros/debian/init.d
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p $RUNDIR && chown www-data:www-data $RUNDIR
 	mkdir -p $TMPDIR && chown www-data:www-data $TMPDIR
 	$command start

--- a/distros/debian_cmake/init.d
+++ b/distros/debian_cmake/init.d
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p $RUNDIR $TMPDIR && chown www-data:www-data $RUNDIR $TMPDIR
 	$command start
 	RETVAL=$?

--- a/distros/ubuntu1204/init.d
+++ b/distros/ubuntu1204/init.d
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p $RUNDIR && chown www-data:www-data $RUNDIR
 	mkdir -p $TMPDIR && chown www-data:www-data $TMPDIR
 	$command start

--- a/distros/ubuntu1204_cmake/zoneminder.init
+++ b/distros/ubuntu1204_cmake/zoneminder.init
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p "$RUNDIR" && chown www-data:www-data "$RUNDIR"
 	mkdir -p "$TMPDIR" && chown www-data:www-data "$TMPDIR"
 	$command start

--- a/distros/ubuntu1504_cmake/zoneminder.init
+++ b/distros/ubuntu1504_cmake/zoneminder.init
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p "$RUNDIR" && chown www-data:www-data "$RUNDIR"
 	mkdir -p "$TMPDIR" && chown www-data:www-data "$TMPDIR"
 	$command start

--- a/distros/ubuntu1504_cmake_split_packages/zoneminder-core.zoneminder.init
+++ b/distros/ubuntu1504_cmake_split_packages/zoneminder-core.zoneminder.init
@@ -23,6 +23,7 @@ command="$ZM_PATH_BIN/zmpkg.pl"
 
 start() {
 	echo -n "Starting $prog: "
+	export TZ=:/etc/localtime
 	mkdir -p $RUNDIR && chown www-data:www-data $RUNDIR
 	mkdir -p $TMPDIR && chown www-data:www-data $TMPDIR
 	$command start


### PR DESCRIPTION
Setting the TZ ENV variable prevents every gettimeofday call from reading /etc/timezone which actually has a noticeable performance hit.