### PR TITLE
fix timeline view for SaveJPEGs monitors (without enabled VideoWriter)

### DIFF
--- a/web/skins/classic/views/js/timeline.js
+++ b/web/skins/classic/views/js/timeline.js
@@ -22,7 +22,7 @@ function createEventHtml( event, frame )
     if ( event.Archived > 0 )
         eventHtml.addClass( 'archived' );
 
-    new Element( 'p' ).inject( eventHtml ).set( 'text', monitorNames[event.MonitorId] );
+    new Element( 'p' ).inject( eventHtml ).set( 'text', monitors[event.MonitorId].Name );
     new Element( 'p' ).inject( eventHtml ).set( 'text', event.Name+(frame?("("+frame.FrameId+")"):"") );
     new Element( 'p' ).inject( eventHtml ).set( 'text', event.StartTime+" - "+event.Length+"s" );
     new Element( 'p' ).inject( eventHtml ).set( 'text', event.Cause );

--- a/web/skins/classic/views/js/timeline.js.php
+++ b/web/skins/classic/views/js/timeline.js.php
@@ -1,17 +1,21 @@
 var filterQuery = '<?php echo validJsStr($filterQuery) ?>';
 
-var monitorNames = {};
 <?php
+$jsMonitors = array();
+$fields = array('Name', 'SaveJPEGs', 'VideoWriter');
 foreach ( $monitors as $monitor )
 {
     if ( !empty($monitorIds[$monitor['Id']]) )
     {
-?>
-monitorNames[<?php echo $monitor['Id'] ?>] = '<?php echo validJsStr($monitor['Name']) ?>';
-<?php
+        $jsMonitor = array();
+        foreach ($fields as $field)
+        {
+            $jsMonitor[$field] = $monitor[$field];
+        }
+        $jsMonitors[$monitor['Id']] = $jsMonitor;
     }
 }
 ?>
-var monitors = <?php echo json_encode($monitors) ?>;
+var monitors = <?php echo json_encode($jsMonitors) ?>;
 
 var archivedString = "<?php echo translate('Archived') ?>";

--- a/web/skins/classic/views/js/timeline.js.php
+++ b/web/skins/classic/views/js/timeline.js.php
@@ -1,6 +1,6 @@
 var filterQuery = '<?php echo validJsStr($filterQuery) ?>';
 
-var monitorNames = new Object();
+var monitorNames = {};
 <?php
 foreach ( $monitors as $monitor )
 {
@@ -12,5 +12,6 @@ monitorNames[<?php echo $monitor['Id'] ?>] = '<?php echo validJsStr($monitor['Na
     }
 }
 ?>
+var monitors = <?php echo json_encode($monitors) ?>;
 
 var archivedString = "<?php echo translate('Archived') ?>";

--- a/web/skins/classic/views/timeline.php
+++ b/web/skins/classic/views/timeline.php
@@ -812,8 +812,7 @@ xhtmlHeaders(__FILE__, translate('Timeline') );
       <div id="topPanel" class="graphWidth">
         <div id="imagePanel">
           <div id="image" class="imageHeight">
-			<!-- <img id="imageSrc" class="imageWidth" src="graphics/transparent.gif" alt="<?php echo translate('ViewEvent') ?>" title="<?php echo translate('ViewEvent') ?>"/>-->
-			<!-- width="<?php echo $event['Width']; ?>" height="<?php echo $event['Height']; ?>" -->
+		        <img id="imageSrc" class="imageWidth" src="graphics/transparent.gif" alt="<?php echo translate('ViewEvent') ?>" title="<?php echo translate('ViewEvent') ?>"/>
 			<video id="preview" width="100%" controls>
 				<source src="<?php echo "/events/".getEventPath($event)."/event.mp4"; ?>" type="video/mp4">
 Your browser does not support the video tag.
@@ -929,6 +928,10 @@ foreach( array_keys($monEventSlots) as $monitorId )
 <?php
     unset( $currEventSlots );
     $currEventSlots = &$monEventSlots[$monitorId];
+    $monitorMouseover = $mouseover;
+    if ($monitors[$monitorId]['SaveJPEGs'] == 2) {
+        $monitorMouseover = false;
+    }
     for ( $i = 0; $i < $chart['graph']['width']; $i++ )
     {
         if ( isset($currEventSlots[$i]) )
@@ -936,7 +939,7 @@ foreach( array_keys($monEventSlots) as $monitorId )
             unset( $slot );
             $slot = &$currEventSlots[$i];
 
-            if ( $mouseover )
+            if ( $monitorMouseover )
             {
                 $behaviours = array(
                     'onclick="'.getSlotShowEventBehaviour( $slot ).'"',


### PR DESCRIPTION
in the videostorage branch, if a monitor is configured to have VideoWriter=0, and SaveJPEGs is non-zero, timeline view does not work

this fixes this problem.

in addition, it has some special handling for the case where SaveJPEGs=2 (only save analyse image) so that only analyse image will be loaded in the timeline imageSrc element