### PR TITLE
fixed version compare logic

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -50,6 +50,7 @@ configuring upgrades etc, including on the fly upgrades.
 =cut
 use strict;
 use bytes;
+use version;
 
 # ==========================================================================
 #
@@ -1027,16 +1028,23 @@ if ( $version )
 		my @files;
 		$updateDir = $Config{ZM_PATH_DATA}."/db" if ! $updateDir;
 		opendir( my $dh, $updateDir ) || die "Can't open updateDir $!";
-		@files = sort grep { (!/^\./) && /^zm_update\-[\d\.]+\.sql$/ && -f "$updateDir/$_" } readdir($dh);
+		#@files = sort grep { (!/^\./) && /^zm_update\-[\d\.]+\.sql$/ && -f "$updateDir/$_" } readdir($dh);
+                #PP - use perl version sort
+                @files = sort { 
+                        my ($x) = ($a =~ m/^zm_update\-(.*)\.sql$/);
+                        my ($y) = ($b =~ m/^zm_update\-(.*)\.sql$/);
+                        version->parse($x)  <=> version->parse($y)
+                	} grep { (!/^\./) && /^zm_update\-[\d\.]+\.sql$/ && -f "$updateDir/$_" } readdir($dh);
 		closedir $dh;
-        if ( ! @files ) {
-            die "Should have found upgrade scripts at $updateDir\n";
-        } # end if
+        	if ( ! @files ) {
+            	die "Should have found upgrade scripts at $updateDir\n";
+        	} # end if
 		
 		$dbh->{'AutoCommit'} = 0;
 		foreach my $patch ( @files ) {
 			my ( $v ) = $patch =~ /^zm_update\-([\d\.]+)\.sql$/;
-			if ( $v ge $version ) {
+			#PP make sure we use version compare 
+			if ( version->parse($v) ge version->parse($version) ) {
 				print( "Upgrading DB to $v from $version\n" );
 				patchDB( $dbh, $v );
 				if ( $dbh->errstr() ) {


### PR DESCRIPTION
Fixes https://github.com/ZoneMinder/ZoneMinder/issues/1051#issuecomment-145349629

Fixes how DB upgrading is done. The change uses perl version which should be built into perl (starting  perl version 5.10 according to [this](http://search.cpan.org/~jpeacock/version/lib/version.pod)) with no additional packages required

The current compare breaks down if you are comparing from "1.28.2" to "1.28.107" - it assumes 2 > 1, so skips all updates except for 1.28.99 and yet marks the DB as upgraded to "107" net result is we have all sorts of DB field missing issues

[Here](https://gist.github.com/pliablepixels/ff0d4cb270b978ca267b) is an example of what happened using the old zmupdate.pl

And [here](https://gist.github.com/pliablepixels/cd72533c7c6f7561073b) is what happens after we fix it with this PR, which I think is the intended output

