### PR TITLE
fix segmentation fault in zma with ubuntu 14.04 and ffmpeg 2.5.8 (gcc…

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -58,7 +58,8 @@ Event::Event( Monitor *p_monitor, struct timeval p_start_time, const std::string
     start_time( p_start_time ),
     cause( p_cause ),
     noteSetMap( p_noteSetMap ),
-    videoEvent( p_videoEvent )
+    videoEvent( p_videoEvent ),
+    videowriter( NULL )
 {
     if ( !initialised )
         Initialise();


### PR DESCRIPTION
in ubuntu 14.04, with gcc 4.8 and ffmpeg 2.8.5 (without libx264), zma crashes with rtsp cameras:

the crash is:
```
zm_die_handler(int, siginfo_t, void)
/root/ZoneMinder/src/zm_signal.cpp:96
??
??:0
Event::Event(Monitor*, timeval, std::string const&, std::map, std::allocatorstd::string >, std::lessstd::string, std::allocator, std::allocatorstd::string > > > > const&, bool)
/root/ZoneMinder/src/zm_event.cpp:197
Monitor::Analyse()
/root/ZoneMinder/src/zm_monitor.cpp:1552 (discriminator 1)
main
/root/ZoneMinder/src/zma.cpp:179
??
??:0
_start
??:?
```