### PR TITLE
Update version check URL

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -170,7 +170,7 @@ if ( $check && $Config{ZM_CHECK_FOR_UPDATES} )
             if ( $Config{ZM_UPDATE_CHECK_PROXY} ) {
 				$ua->proxy( "http", $Config{ZM_UPDATE_CHECK_PROXY} );
             }
-            my $req = HTTP::Request->new( GET=>'http://zoneminder.github.io/ZoneMinder/version.txt' );
+            my $req = HTTP::Request->new( GET=>'https://update.zoneminder.com/version.txt' );
             my $res = $ua->request($req);
 
             if ( $res->is_success )


### PR DESCRIPTION
This commit tells zmupdate.pl to check the version from https://update.zoneminder.com/version.txt

update.zoneminder.com is now hosted on one of my servers, with SSL.

A cronjob fires off every 15 minutes and 1) pulls down the latest version from https://github.com/ZoneMinder/ZoneMinder/blob/master/version. 2) 'pings' [DeadMansSnitch](https://deadmanssnitch.com/r/9a6ce705e7)

If the cronjob has not succeeded within the last hour, I am alerted (via [DeadMansSnitch](https://deadmanssnitch.com/r/9a6ce705e7)).  This should prevent any silently failing issues.

The reason for this is simple:  We can now take a look at the updates.zoneminder.com access log and get a rough estimate on the number of users that we have.