### PR TITLE
Stray semicolon causes SQL error

### DIFF
--- a/db/zm_update-1.28.108.sql
+++ b/db/zm_update-1.28.108.sql
@@ -10,7 +10,7 @@ SET @s = (SELECT IF(
 	FROM INFORMATION_SCHEMA.STATISTICS
 	WHERE table_name = 'Frames'
 	AND table_schema = DATABASE()
-	AND index_name='EventId_idx';
+	AND index_name = 'EventId_idx'
 	) > 0,
 "SELECT 'EventId Index already exists on Frames table'",
 "CREATE INDEX `EventId_idx` ON `Frames` (`EventId`)"


### PR DESCRIPTION
also normalized space around '='