### PR TITLE
better way of detecting showing image or video in timeline and event view

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -117,6 +117,7 @@ $statusData = array(
             "Height" => true,
             "Length" => true,
             "Frames" => true,
+            "DefaultVideo" => true,
             "AlarmFrames" => true,
             "TotScore" => true,
             "AvgScore" => true,

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -138,7 +138,7 @@ if ( $event['SaveJPEGs'] & 3 )
 			</div>
 			<div id="eventVideo" class="">
 <?php 
-if ( $event['VideoWriter'] )
+if ( $event['DefaultVideo'] )
 { 
 ?>
 <link href="//vjs.zencdn.net/4.11/video-js.css" rel="stylesheet">

--- a/web/skins/classic/views/js/timeline.js
+++ b/web/skins/classic/views/js/timeline.js
@@ -111,8 +111,8 @@ function previewEvent( eventId, frameId )
             {
                 showEventDetail( events[eventId]['frames'][frameId]['html'] );
                 var imagePath = events[eventId].frames[frameId].Image.imagePath;
-                var showVideo = parseInt(monitors[events[eventId].MonitorId].VideoWriter);
-                loadEventImage( imagePath, eventId, frameId, events[eventId].Width, events[eventId].Height, events[eventId].Frames/events[eventId].Length, showVideo);
+                var videoName = events[eventId].DefaultVideo;
+                loadEventImage( imagePath, eventId, frameId, events[eventId].Width, events[eventId].Height, events[eventId].Frames/events[eventId].Length, videoName);
                 return;
             }
         }
@@ -120,15 +120,15 @@ function previewEvent( eventId, frameId )
     requestFrameData( eventId, frameId );
 }
 
-function loadEventImage( imagePath, eid, fid, width, height, fps, showVideo )
+function loadEventImage( imagePath, eid, fid, width, height, fps, videoName )
 {
     var vid= $('preview');
     var imageSrc = $('imageSrc');
-    if(showVideo)
+    if(videoName)
     {
         vid.show();
         imageSrc.hide();
-        var newsource=imagePrefix+imagePath.slice(0,imagePath.lastIndexOf('/'))+"/event.mp4";
+        var newsource=imagePrefix+imagePath.slice(0,imagePath.lastIndexOf('/'))+"/"+videoName;
         //console.log(newsource);
         //console.log(sources[0].src.slice(-newsource.length));
         if(newsource!=vid.currentSrc.slice(-newsource.length) || vid.readyState==0)


### PR DESCRIPTION
instead of Monitor.VideoWriter, Event.DefaultVideo is used, so even if
VideoWriter/SaveJPEG option is changed, a valid image or video will always be
displayed for historical events in both timeline and event view

this also fixes loading videos in timeline view