### PR TITLE
Replace deprecated FFmpeg API

### DIFF
--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -24,8 +24,8 @@
 #if HAVE_LIBAVCODEC || HAVE_LIBAVUTIL || HAVE_LIBSWSCALE
 
 #if HAVE_LIBAVUTIL
-enum PixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixelorder) {
-	enum PixelFormat pf;
+enum AVPixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixelorder) {
+	enum AVPixelFormat pf;
 
 	Debug(8,"Colours: %d SubpixelOrder: %d",p_colours,p_subpixelorder);
 
@@ -34,10 +34,10 @@ enum PixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixe
 	  {
 	    if(p_subpixelorder == ZM_SUBPIX_ORDER_BGR) {
 	      /* BGR subpixel order */
-	      pf = PIX_FMT_BGR24;
+	      pf = AV_PIX_FMT_BGR24;
 	    } else {
 	      /* Assume RGB subpixel order */
-	      pf = PIX_FMT_RGB24;
+	      pf = AV_PIX_FMT_RGB24;
 	    }
 	    break;
 	  }
@@ -45,25 +45,25 @@ enum PixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixe
 	  {
 	    if(p_subpixelorder == ZM_SUBPIX_ORDER_ARGB) {
 	      /* ARGB subpixel order */
-	      pf = PIX_FMT_ARGB;
+	      pf = AV_PIX_FMT_ARGB;
 	    } else if(p_subpixelorder == ZM_SUBPIX_ORDER_ABGR) {
 	      /* ABGR subpixel order */
-	      pf = PIX_FMT_ABGR;
+	      pf = AV_PIX_FMT_ABGR;
 	    } else if(p_subpixelorder == ZM_SUBPIX_ORDER_BGRA) {
 	      /* BGRA subpixel order */
-	      pf = PIX_FMT_BGRA;
+	      pf = AV_PIX_FMT_BGRA;
 	    } else {
 	      /* Assume RGBA subpixel order */
-	      pf = PIX_FMT_RGBA;
+	      pf = AV_PIX_FMT_RGBA;
 	    }
 	    break;
 	  }
 	  case ZM_COLOUR_GRAY8:
-	    pf = PIX_FMT_GRAY8;
+	    pf = AV_PIX_FMT_GRAY8;
 	    break;
 	  default:
 	    Panic("Unexpected colours: %d",p_colours);
-	    pf = PIX_FMT_GRAY8; /* Just to shush gcc variable may be unused warning */
+	    pf = AV_PIX_FMT_GRAY8; /* Just to shush gcc variable may be unused warning */
 	    break;
 	}
 
@@ -99,7 +99,7 @@ SWScale::SWScale() : gotdefaults(false), swscale_ctx(NULL), input_avframe(NULL),
 SWScale::~SWScale() {
 
 	/* Free up everything */
-	av_free(input_avframe);
+	av_frame_free(&input_avframe);
 	input_avframe = NULL;
 
 	av_free(output_avframe);
@@ -113,7 +113,7 @@ SWScale::~SWScale() {
 	Debug(4,"SWScale object destroyed");
 }
 
-int SWScale::SetDefaults(enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height) {
+int SWScale::SetDefaults(enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height) {
 
 	/* Assign the defaults */
 	default_input_pf = in_pf;
@@ -126,7 +126,7 @@ int SWScale::SetDefaults(enum PixelFormat in_pf, enum PixelFormat out_pf, unsign
 	return 0;
 }
 
-int SWScale::Convert(const uint8_t* in_buffer, const size_t in_buffer_size, uint8_t* out_buffer, const size_t out_buffer_size, enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height) {
+int SWScale::Convert(const uint8_t* in_buffer, const size_t in_buffer_size, uint8_t* out_buffer, const size_t out_buffer_size, enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height) {
 	/* Parameter checking */
 	if(in_buffer == NULL || out_buffer == NULL) {
 		Error("NULL Input or output buffer");
@@ -189,7 +189,7 @@ int SWScale::Convert(const uint8_t* in_buffer, const size_t in_buffer_size, uint
 	return 0;
 }
 
-int SWScale::Convert(const Image* img, uint8_t* out_buffer, const size_t out_buffer_size, enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height) {
+int SWScale::Convert(const Image* img, uint8_t* out_buffer, const size_t out_buffer_size, enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height) {
 	if(img->Width() != width) {
 		Error("Source image width differs. Source: %d Output: %d",img->Width(), width);
 		return -12;

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -143,14 +143,8 @@ extern "C" {
  #endif
 #endif
 
-/* Fix for not having SWS_CPU_CAPS_SSE2 defined */
-#ifndef SWS_CPU_CAPS_SSE2
-#define SWS_CPU_CAPS_SSE2     0x02000000
-#endif
-
-
 #if HAVE_LIBAVUTIL
-enum PixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixelorder);
+enum AVPixelFormat GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixelorder);
 #endif // HAVE_LIBAVUTIL
 
 
@@ -160,19 +154,19 @@ class SWScale {
 public:
 	SWScale();
 	~SWScale();
-	int SetDefaults(enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height);
+	int SetDefaults(enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height);
 	int ConvertDefaults(const Image* img, uint8_t* out_buffer, const size_t out_buffer_size);
 	int ConvertDefaults(const uint8_t* in_buffer, const size_t in_buffer_size, uint8_t* out_buffer, const size_t out_buffer_size);
-	int Convert(const Image* img, uint8_t* out_buffer, const size_t out_buffer_size, enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height);
-	int Convert(const uint8_t* in_buffer, const size_t in_buffer_size, uint8_t* out_buffer, const size_t out_buffer_size, enum PixelFormat in_pf, enum PixelFormat out_pf, unsigned int width, unsigned int height);
+	int Convert(const Image* img, uint8_t* out_buffer, const size_t out_buffer_size, enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height);
+	int Convert(const uint8_t* in_buffer, const size_t in_buffer_size, uint8_t* out_buffer, const size_t out_buffer_size, enum AVPixelFormat in_pf, enum AVPixelFormat out_pf, unsigned int width, unsigned int height);
 
 protected:
 	bool gotdefaults;
 	struct SwsContext* swscale_ctx;
 	AVFrame* input_avframe;
 	AVFrame* output_avframe;
-	enum PixelFormat default_input_pf;
-	enum PixelFormat default_output_pf;
+	enum AVPixelFormat default_input_pf;
+	enum AVPixelFormat default_output_pf;
 	unsigned int default_width;
 	unsigned int default_height;
 };

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -62,13 +62,13 @@ FfmpegCamera::FfmpegCamera( int p_id, const std::string &p_path, const std::stri
 	/* Has to be located inside the constructor so other components such as zma will receive correct colours and subpixel order */
 	if(colours == ZM_COLOUR_RGB32) {
 		subpixelorder = ZM_SUBPIX_ORDER_RGBA;
-		imagePixFormat = PIX_FMT_RGBA;
+		imagePixFormat = AV_PIX_FMT_RGBA;
 	} else if(colours == ZM_COLOUR_RGB24) {
 		subpixelorder = ZM_SUBPIX_ORDER_RGB;
-		imagePixFormat = PIX_FMT_RGB24;
+		imagePixFormat = AV_PIX_FMT_RGB24;
 	} else if(colours == ZM_COLOUR_GRAY8) {
 		subpixelorder = ZM_SUBPIX_ORDER_NONE;
-		imagePixFormat = PIX_FMT_GRAY8;
+		imagePixFormat = AV_PIX_FMT_GRAY8;
 	} else {
 		Panic("Unexpected colours: %d",colours);
 	}
@@ -188,7 +188,7 @@ int FfmpegCamera::Capture( Image &image )
 #if HAVE_LIBSWSCALE
 		if(mConvertContext == NULL) {
 			if(config.cpu_extensions && sseversion >= 20) {
-				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC | SWS_CPU_CAPS_SSE2, NULL, NULL, NULL );
+				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 			} else {
 				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 			}
@@ -389,8 +389,8 @@ int FfmpegCamera::CloseFfmpeg(){
 
     mCanCapture = false;
 
-    av_freep( &mFrame );
-    av_freep( &mRawFrame );
+    av_frame_free( &mFrame );
+    av_frame_free( &mRawFrame );
     
 #if HAVE_LIBSWSCALE
     if ( mConvertContext )

--- a/src/zm_ffmpeg_camera.h
+++ b/src/zm_ffmpeg_camera.h
@@ -46,7 +46,7 @@ protected:
     AVCodec             *mCodec;
     AVFrame             *mRawFrame; 
     AVFrame             *mFrame;
-    PixelFormat         imagePixFormat;
+    AVPixelFormat         imagePixFormat;
 
     int OpenFfmpeg();
     int ReopenFfmpeg();

--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -52,67 +52,67 @@ static int vidioctl( int fd, int request, void *arg )
 }
 
 #if HAVE_LIBSWSCALE
-static PixelFormat getFfPixFormatFromV4lPalette( int v4l_version, int palette )
+static AVPixelFormat getFfPixFormatFromV4lPalette( int v4l_version, int palette )
 {
-    PixelFormat pixFormat = PIX_FMT_NONE;
+    AVPixelFormat pixFormat = AV_PIX_FMT_NONE;
      
 #if ZM_HAS_V4L2
     if ( v4l_version == 2 )
     {
         switch( palette )
         {
-#if defined(V4L2_PIX_FMT_RGB444) && defined(PIX_FMT_RGB444)
+#if defined(V4L2_PIX_FMT_RGB444) && defined(AV_PIX_FMT_RGB444)
             case V4L2_PIX_FMT_RGB444 :
-                pixFormat = PIX_FMT_RGB444;
+                pixFormat = AV_PIX_FMT_RGB444;
                 break;
 #endif // V4L2_PIX_FMT_RGB444
             case V4L2_PIX_FMT_RGB555 :
-                pixFormat = PIX_FMT_RGB555;
+                pixFormat = AV_PIX_FMT_RGB555;
                 break;
             case V4L2_PIX_FMT_RGB565 :
-                pixFormat = PIX_FMT_RGB565;
+                pixFormat = AV_PIX_FMT_RGB565;
                 break;
             case V4L2_PIX_FMT_BGR24 :
-                pixFormat = PIX_FMT_BGR24;
+                pixFormat = AV_PIX_FMT_BGR24;
                 break;
             case V4L2_PIX_FMT_RGB24 :
-                pixFormat = PIX_FMT_RGB24;
+                pixFormat = AV_PIX_FMT_RGB24;
                 break;
             case V4L2_PIX_FMT_BGR32 :
-                pixFormat = PIX_FMT_BGRA;
+                pixFormat = AV_PIX_FMT_BGRA;
                 break;
             case V4L2_PIX_FMT_RGB32 :
-                pixFormat = PIX_FMT_ARGB;
+                pixFormat = AV_PIX_FMT_ARGB;
                 break;
             case V4L2_PIX_FMT_GREY :
-                pixFormat = PIX_FMT_GRAY8;
+                pixFormat = AV_PIX_FMT_GRAY8;
                 break;
             case V4L2_PIX_FMT_YUYV :
-                pixFormat = PIX_FMT_YUYV422;
+                pixFormat = AV_PIX_FMT_YUYV422;
                 break;
             case V4L2_PIX_FMT_YUV422P :
-                pixFormat = PIX_FMT_YUV422P;
+                pixFormat = AV_PIX_FMT_YUV422P;
                 break;
             case V4L2_PIX_FMT_YUV411P :
-                pixFormat = PIX_FMT_YUV411P;
+                pixFormat = AV_PIX_FMT_YUV411P;
                 break;
 #ifdef V4L2_PIX_FMT_YUV444
             case V4L2_PIX_FMT_YUV444 :
-                pixFormat = PIX_FMT_YUV444P;
+                pixFormat = AV_PIX_FMT_YUV444P;
                 break;
 #endif // V4L2_PIX_FMT_YUV444
             case V4L2_PIX_FMT_YUV410 :
-                pixFormat = PIX_FMT_YUV410P;
+                pixFormat = AV_PIX_FMT_YUV410P;
                 break;
             case V4L2_PIX_FMT_YUV420 :
-                pixFormat = PIX_FMT_YUV420P;
+                pixFormat = AV_PIX_FMT_YUV420P;
                 break;
             case V4L2_PIX_FMT_JPEG :
             case V4L2_PIX_FMT_MJPEG :
-                pixFormat = PIX_FMT_YUVJ444P;
+                pixFormat = AV_PIX_FMT_YUVJ444P;
                 break;
             case V4L2_PIX_FMT_UYVY :
-                pixFormat = PIX_FMT_UYVY422;
+                pixFormat = AV_PIX_FMT_UYVY422;
                 break;
             // These don't seem to have ffmpeg equivalents
             // See if you can match any of the ones in the default clause below!?
@@ -154,32 +154,30 @@ static PixelFormat getFfPixFormatFromV4lPalette( int v4l_version, int palette )
                 Fatal( "Can't find swscale format for palette %d", palette );
                 break;
                 // These are all spare and may match some of the above
-                pixFormat = PIX_FMT_YUVJ420P;
-                pixFormat = PIX_FMT_YUVJ422P;
-                pixFormat = PIX_FMT_XVMC_MPEG2_MC;
-                pixFormat = PIX_FMT_XVMC_MPEG2_IDCT;
-                pixFormat = PIX_FMT_UYVY422;
-                pixFormat = PIX_FMT_UYYVYY411;
-                pixFormat = PIX_FMT_BGR565;
-                pixFormat = PIX_FMT_BGR555;
-                pixFormat = PIX_FMT_BGR8;
-                pixFormat = PIX_FMT_BGR4;
-                pixFormat = PIX_FMT_BGR4_BYTE;
-                pixFormat = PIX_FMT_RGB8;
-                pixFormat = PIX_FMT_RGB4;
-                pixFormat = PIX_FMT_RGB4_BYTE;
-                pixFormat = PIX_FMT_NV12;
-                pixFormat = PIX_FMT_NV21;
-                pixFormat = PIX_FMT_RGB32_1;
-                pixFormat = PIX_FMT_BGR32_1;
-                pixFormat = PIX_FMT_GRAY16BE;
-                pixFormat = PIX_FMT_GRAY16LE;
-                pixFormat = PIX_FMT_YUV440P;
-                pixFormat = PIX_FMT_YUVJ440P;
-                pixFormat = PIX_FMT_YUVA420P;
-                //pixFormat = PIX_FMT_VDPAU_H264;
-                //pixFormat = PIX_FMT_VDPAU_MPEG1;
-                //pixFormat = PIX_FMT_VDPAU_MPEG2;
+                pixFormat = AV_PIX_FMT_YUVJ420P;
+                pixFormat = AV_PIX_FMT_YUVJ422P;
+                pixFormat = AV_PIX_FMT_UYVY422;
+                pixFormat = AV_PIX_FMT_UYYVYY411;
+                pixFormat = AV_PIX_FMT_BGR565;
+                pixFormat = AV_PIX_FMT_BGR555;
+                pixFormat = AV_PIX_FMT_BGR8;
+                pixFormat = AV_PIX_FMT_BGR4;
+                pixFormat = AV_PIX_FMT_BGR4_BYTE;
+                pixFormat = AV_PIX_FMT_RGB8;
+                pixFormat = AV_PIX_FMT_RGB4;
+                pixFormat = AV_PIX_FMT_RGB4_BYTE;
+                pixFormat = AV_PIX_FMT_NV12;
+                pixFormat = AV_PIX_FMT_NV21;
+                pixFormat = AV_PIX_FMT_RGB32_1;
+                pixFormat = AV_PIX_FMT_BGR32_1;
+                pixFormat = AV_PIX_FMT_GRAY16BE;
+                pixFormat = AV_PIX_FMT_GRAY16LE;
+                pixFormat = AV_PIX_FMT_YUV440P;
+                pixFormat = AV_PIX_FMT_YUVJ440P;
+                pixFormat = AV_PIX_FMT_YUVA420P;
+                //pixFormat = AV_PIX_FMT_VDPAU_H264;
+                //pixFormat = AV_PIX_FMT_VDPAU_MPEG1;
+                //pixFormat = AV_PIX_FMT_VDPAU_MPEG2;
             }
         }
     }
@@ -191,67 +189,65 @@ static PixelFormat getFfPixFormatFromV4lPalette( int v4l_version, int palette )
         {
             case VIDEO_PALETTE_RGB32 :
 		if(BigEndian)
-			pixFormat = PIX_FMT_ARGB;
+			pixFormat = AV_PIX_FMT_ARGB;
 		else
-			pixFormat = PIX_FMT_BGRA;
+			pixFormat = AV_PIX_FMT_BGRA;
 		break;
             case VIDEO_PALETTE_RGB24 :
 		if(BigEndian)
-			pixFormat = PIX_FMT_RGB24;
+			pixFormat = AV_PIX_FMT_RGB24;
 		else
-			pixFormat = PIX_FMT_BGR24;
+			pixFormat = AV_PIX_FMT_BGR24;
 		break;
             case VIDEO_PALETTE_GREY :
-                pixFormat = PIX_FMT_GRAY8;
+                pixFormat = AV_PIX_FMT_GRAY8;
                 break;
             case VIDEO_PALETTE_RGB555 :
-                pixFormat = PIX_FMT_RGB555;
+                pixFormat = AV_PIX_FMT_RGB555;
                 break;
             case VIDEO_PALETTE_RGB565 :
-                pixFormat = PIX_FMT_RGB565;
+                pixFormat = AV_PIX_FMT_RGB565;
                 break;
             case VIDEO_PALETTE_YUYV :
             case VIDEO_PALETTE_YUV422 :
-                pixFormat = PIX_FMT_YUYV422;
+                pixFormat = AV_PIX_FMT_YUYV422;
                 break;
             case VIDEO_PALETTE_YUV422P :
-                pixFormat = PIX_FMT_YUV422P;
+                pixFormat = AV_PIX_FMT_YUV422P;
                 break;
             case VIDEO_PALETTE_YUV420P :
-                pixFormat = PIX_FMT_YUV420P;
+                pixFormat = AV_PIX_FMT_YUV420P;
                 break;
             default :
             {
                 Fatal( "Can't find swscale format for palette %d", palette );
                 break;
                 // These are all spare and may match some of the above
-                pixFormat = PIX_FMT_YUVJ420P;
-                pixFormat = PIX_FMT_YUVJ422P;
-                pixFormat = PIX_FMT_YUVJ444P;
-                pixFormat = PIX_FMT_XVMC_MPEG2_MC;
-                pixFormat = PIX_FMT_XVMC_MPEG2_IDCT;
-                pixFormat = PIX_FMT_UYVY422;
-                pixFormat = PIX_FMT_UYYVYY411;
-                pixFormat = PIX_FMT_BGR565;
-                pixFormat = PIX_FMT_BGR555;
-                pixFormat = PIX_FMT_BGR8;
-                pixFormat = PIX_FMT_BGR4;
-                pixFormat = PIX_FMT_BGR4_BYTE;
-                pixFormat = PIX_FMT_RGB8;
-                pixFormat = PIX_FMT_RGB4;
-                pixFormat = PIX_FMT_RGB4_BYTE;
-                pixFormat = PIX_FMT_NV12;
-                pixFormat = PIX_FMT_NV21;
-                pixFormat = PIX_FMT_RGB32_1;
-                pixFormat = PIX_FMT_BGR32_1;
-                pixFormat = PIX_FMT_GRAY16BE;
-                pixFormat = PIX_FMT_GRAY16LE;
-                pixFormat = PIX_FMT_YUV440P;
-                pixFormat = PIX_FMT_YUVJ440P;
-                pixFormat = PIX_FMT_YUVA420P;
-                //pixFormat = PIX_FMT_VDPAU_H264;
-                //pixFormat = PIX_FMT_VDPAU_MPEG1;
-                //pixFormat = PIX_FMT_VDPAU_MPEG2;
+                pixFormat = AV_PIX_FMT_YUVJ420P;
+                pixFormat = AV_PIX_FMT_YUVJ422P;
+                pixFormat = AV_PIX_FMT_YUVJ444P;
+                pixFormat = AV_PIX_FMT_UYVY422;
+                pixFormat = AV_PIX_FMT_UYYVYY411;
+                pixFormat = AV_PIX_FMT_BGR565;
+                pixFormat = AV_PIX_FMT_BGR555;
+                pixFormat = AV_PIX_FMT_BGR8;
+                pixFormat = AV_PIX_FMT_BGR4;
+                pixFormat = AV_PIX_FMT_BGR4_BYTE;
+                pixFormat = AV_PIX_FMT_RGB8;
+                pixFormat = AV_PIX_FMT_RGB4;
+                pixFormat = AV_PIX_FMT_RGB4_BYTE;
+                pixFormat = AV_PIX_FMT_NV12;
+                pixFormat = AV_PIX_FMT_NV21;
+                pixFormat = AV_PIX_FMT_RGB32_1;
+                pixFormat = AV_PIX_FMT_BGR32_1;
+                pixFormat = AV_PIX_FMT_GRAY16BE;
+                pixFormat = AV_PIX_FMT_GRAY16LE;
+                pixFormat = AV_PIX_FMT_YUV440P;
+                pixFormat = AV_PIX_FMT_YUVJ440P;
+                pixFormat = AV_PIX_FMT_YUVA420P;
+                //pixFormat = AV_PIX_FMT_VDPAU_H264;
+                //pixFormat = AV_PIX_FMT_VDPAU_MPEG1;
+                //pixFormat = AV_PIX_FMT_VDPAU_MPEG2;
             }
         }
     }
@@ -376,7 +372,7 @@ LocalCamera::LocalCamera( int p_id, const std::string &p_device, int p_channel, 
 #if HAVE_LIBSWSCALE
 		/* Get ffmpeg pixel format based on capture palette and endianness */
 		capturePixFormat = getFfPixFormatFromV4lPalette( v4l_version, palette );
-		imagePixFormat = PIX_FMT_NONE;
+		imagePixFormat = AV_PIX_FMT_NONE;
 #endif // HAVE_LIBSWSCALE   
 	}
 
@@ -423,13 +419,13 @@ LocalCamera::LocalCamera( int p_id, const std::string &p_device, int p_channel, 
 			Debug(2,"Using swscale for image conversion");
 			if(colours == ZM_COLOUR_RGB32) {
 				subpixelorder = ZM_SUBPIX_ORDER_RGBA;
-				imagePixFormat = PIX_FMT_RGBA;
+				imagePixFormat = AV_PIX_FMT_RGBA;
 			} else if(colours == ZM_COLOUR_RGB24) {
 				subpixelorder = ZM_SUBPIX_ORDER_RGB;
-				imagePixFormat = PIX_FMT_RGB24;
+				imagePixFormat = AV_PIX_FMT_RGB24;
 			} else if(colours == ZM_COLOUR_GRAY8) {
 				subpixelorder = ZM_SUBPIX_ORDER_NONE;
-				imagePixFormat = PIX_FMT_GRAY8;
+				imagePixFormat = AV_PIX_FMT_GRAY8;
 			} else {
 				Panic("Unexpected colours: %d",colours);
 			}
@@ -541,13 +537,13 @@ LocalCamera::LocalCamera( int p_id, const std::string &p_device, int p_channel, 
 			Debug(2,"Using swscale for image conversion");
 			if(colours == ZM_COLOUR_RGB32) {
 				subpixelorder = ZM_SUBPIX_ORDER_RGBA;
-				imagePixFormat = PIX_FMT_RGBA;
+				imagePixFormat = AV_PIX_FMT_RGBA;
 			} else if(colours == ZM_COLOUR_RGB24) {
 				subpixelorder = ZM_SUBPIX_ORDER_RGB;
-				imagePixFormat = PIX_FMT_RGB24;
+				imagePixFormat = AV_PIX_FMT_RGB24;
 			} else if(colours == ZM_COLOUR_GRAY8) {
 				subpixelorder = ZM_SUBPIX_ORDER_NONE;
-				imagePixFormat = PIX_FMT_GRAY8;
+				imagePixFormat = AV_PIX_FMT_GRAY8;
 			} else {
 				Panic("Unexpected colours: %d",colours);
 			}
@@ -636,7 +632,7 @@ LocalCamera::LocalCamera( int p_id, const std::string &p_device, int p_channel, 
 		}
 		
 		if(config.cpu_extensions && sseversion >= 20) {
-			imgConversionContext = sws_getContext(width, height, capturePixFormat, width, height, imagePixFormat, SWS_BICUBIC | SWS_CPU_CAPS_SSE2, NULL, NULL, NULL );
+			imgConversionContext = sws_getContext(width, height, capturePixFormat, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 		} else {
 			imgConversionContext = sws_getContext(width, height, capturePixFormat, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 		}
@@ -659,7 +655,7 @@ LocalCamera::~LocalCamera()
 		sws_freeContext(imgConversionContext);
 		imgConversionContext = NULL;
 		
-		av_free(tmpPicture);
+		av_frame_free(&tmpPicture);
 		tmpPicture = NULL;
 	}
 #endif
@@ -1089,7 +1085,7 @@ void LocalCamera::Terminate()
         for ( unsigned int i = 0; i < v4l2_data.reqbufs.count; i++ ) {
 #if HAVE_LIBSWSCALE
 			/* Free capture pictures */
-			av_free(capturePictures[i]);
+			av_frame_free(&capturePictures[i]);
 			capturePictures[i] = NULL;
 #endif
             if ( munmap( v4l2_data.buffers[i].start, v4l2_data.buffers[i].length ) < 0 )
@@ -1107,7 +1103,7 @@ void LocalCamera::Terminate()
 #if HAVE_LIBSWSCALE
 		for(int i=0; i < v4l1_data.frames.frames; i++) {    
 			/* Free capture pictures */
-			av_free(capturePictures[i]);
+			av_frame_free(&capturePictures[i]);
 			capturePictures[i] = NULL;
 		}
 #endif

--- a/src/zm_local_camera.h
+++ b/src/zm_local_camera.h
@@ -107,8 +107,8 @@ protected:
 
 #if HAVE_LIBSWSCALE
 	static AVFrame    	**capturePictures;
-	PixelFormat       	imagePixFormat;
-	PixelFormat       	capturePixFormat;
+	AVPixelFormat       	imagePixFormat;
+	AVPixelFormat       	capturePixFormat;
 	struct SwsContext 	*imgConversionContext;
 	AVFrame           	*tmpPicture;    
 #endif // HAVE_LIBSWSCALE

--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -131,10 +131,10 @@ void VideoStream::SetupCodec( int colours, int subpixelorder, int width, int hei
 	  {
 	    if(subpixelorder == ZM_SUBPIX_ORDER_BGR) {
 	      /* BGR subpixel order */
-	      pf = PIX_FMT_BGR24;
+	      pf = AV_PIX_FMT_BGR24;
 	    } else {
 	      /* Assume RGB subpixel order */
-	      pf = PIX_FMT_RGB24;
+	      pf = AV_PIX_FMT_RGB24;
 	    }
 	    break;
 	  }
@@ -142,21 +142,21 @@ void VideoStream::SetupCodec( int colours, int subpixelorder, int width, int hei
 	  {
 	    if(subpixelorder == ZM_SUBPIX_ORDER_ARGB) {
 	      /* ARGB subpixel order */
-	      pf = PIX_FMT_ARGB;
+	      pf = AV_PIX_FMT_ARGB;
 	    } else if(subpixelorder == ZM_SUBPIX_ORDER_ABGR) {
 	      /* ABGR subpixel order */
-	      pf = PIX_FMT_ABGR;
+	      pf = AV_PIX_FMT_ABGR;
 	    } else if(subpixelorder == ZM_SUBPIX_ORDER_BGRA) {
 	      /* BGRA subpixel order */
-	      pf = PIX_FMT_BGRA;
+	      pf = AV_PIX_FMT_BGRA;
 	    } else {
 	      /* Assume RGBA subpixel order */
-	      pf = PIX_FMT_RGBA;
+	      pf = AV_PIX_FMT_RGBA;
 	    }
 	    break;
 	  }
 	  case ZM_COLOUR_GRAY8:
-	    pf = PIX_FMT_GRAY8;
+	    pf = AV_PIX_FMT_GRAY8;
 	    break;
 	  default:
 	    Panic("Unexpected colours: %d",colours);
@@ -234,7 +234,7 @@ void VideoStream::SetupCodec( int colours, int subpixelorder, int width, int hei
 		c->codec_id = codec->id;
 		c->codec_type = codec->type;
 
-		c->pix_fmt = strcmp( "mjpeg", ofc->oformat->name ) == 0 ? PIX_FMT_YUVJ422P : PIX_FMT_YUV420P;
+		c->pix_fmt = strcmp( "mjpeg", ofc->oformat->name ) == 0 ? AV_PIX_FMT_YUVJ422P : AV_PIX_FMT_YUV420P;
 		if ( bitrate <= 100 )
 		{
 			// Quality based bitrate control (VBR). Scale is 1..31 where 1 is best.
@@ -337,7 +337,7 @@ void VideoStream::OpenStream( )
 		uint8_t *opicture_buf = (uint8_t *)av_malloc( size );
 		if ( !opicture_buf )
 		{
-			av_free( opicture );
+			av_frame_free( &opicture );
 			Panic( "Could not allocate opicture_buf" );
 		}
 		avpicture_fill( (AVPicture *)opicture, opicture_buf, c->pix_fmt, c->width, c->height );
@@ -361,7 +361,7 @@ void VideoStream::OpenStream( )
 			uint8_t *tmp_opicture_buf = (uint8_t *)av_malloc( size );
 			if ( !tmp_opicture_buf )
 			{
-				av_free( tmp_opicture );
+				av_frame_free( &tmp_opicture );
 				Panic( "Could not allocate tmp_opicture_buf" );
 			}
 			avpicture_fill( (AVPicture *)tmp_opicture, tmp_opicture_buf, pf, c->width, c->height );
@@ -512,11 +512,11 @@ VideoStream::~VideoStream( )
 	{
 		avcodec_close( ost->codec );
 		av_free( opicture->data[0] );
-		av_free( opicture );
+		av_frame_free( &opicture );
 		if ( tmp_opicture )
 		{
 			av_free( tmp_opicture->data[0] );
-			av_free( tmp_opicture );
+			av_frame_free( &tmp_opicture );
 		}
 		av_free( video_outbuf );
 	}

--- a/src/zm_mpeg.h
+++ b/src/zm_mpeg.h
@@ -42,7 +42,7 @@ protected:
 	const char *filename;
 	const char *format;
 	const char *codec_name;
-	enum PixelFormat pf;
+	enum AVPixelFormat pf;
 	AVOutputFormat *of;
 	AVFormatContext *ofc;
 	AVStream *ost;

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -63,13 +63,13 @@ RemoteCameraRtsp::RemoteCameraRtsp( int p_id, const std::string &p_method, const
 	/* Has to be located inside the constructor so other components such as zma will receive correct colours and subpixel order */
 	if(colours == ZM_COLOUR_RGB32) {
 		subpixelorder = ZM_SUBPIX_ORDER_RGBA;
-		imagePixFormat = PIX_FMT_RGBA;
+		imagePixFormat = AV_PIX_FMT_RGBA;
 	} else if(colours == ZM_COLOUR_RGB24) {
 		subpixelorder = ZM_SUBPIX_ORDER_RGB;
-		imagePixFormat = PIX_FMT_RGB24;
+		imagePixFormat = AV_PIX_FMT_RGB24;
 	} else if(colours == ZM_COLOUR_GRAY8) {
 		subpixelorder = ZM_SUBPIX_ORDER_NONE;
-		imagePixFormat = PIX_FMT_GRAY8;
+		imagePixFormat = AV_PIX_FMT_GRAY8;
 	} else {
 		Panic("Unexpected colours: %d",colours);
 	}
@@ -78,8 +78,8 @@ RemoteCameraRtsp::RemoteCameraRtsp( int p_id, const std::string &p_method, const
 
 RemoteCameraRtsp::~RemoteCameraRtsp()
 {
-    av_freep( &mFrame );
-    av_freep( &mRawFrame );
+    av_frame_free( &mFrame );
+    av_frame_free( &mRawFrame );
     
 #if HAVE_LIBSWSCALE
     if ( mConvertContext )
@@ -329,7 +329,7 @@ int RemoteCameraRtsp::Capture( Image &image )
 #if HAVE_LIBSWSCALE
 		if(mConvertContext == NULL) {
 			if(config.cpu_extensions && sseversion >= 20) {
-				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC | SWS_CPU_CAPS_SSE2, NULL, NULL, NULL );
+				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 			} else {
 				mConvertContext = sws_getContext( mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, width, height, imagePixFormat, SWS_BICUBIC, NULL, NULL, NULL );
 			}

--- a/src/zm_remote_camera_rtsp.h
+++ b/src/zm_remote_camera_rtsp.h
@@ -59,7 +59,7 @@ protected:
     AVCodec             *mCodec;
     AVFrame             *mRawFrame; 
     AVFrame             *mFrame;
-    PixelFormat         imagePixFormat;
+    AVPixelFormat         imagePixFormat;
 #endif // HAVE_LIBAVFORMAT
 
 #if HAVE_LIBSWSCALE


### PR DESCRIPTION
Fixes FTBFS with ffmpeg-2.9; compatible with ffmpeg-2.8.

Author: Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=803850