### PR TITLE
Reorder RTSPDescribe to avoid -wreorder warnings

### DIFF
--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -30,8 +30,9 @@
 
 RemoteCameraRtsp::RemoteCameraRtsp( int p_id, const std::string &p_method, const std::string &p_host, const std::string &p_port, const std::string &p_path, int p_width, int p_height, bool p_rtsp_describe, int p_colours, int p_brightness, int p_contrast, int p_hue, int p_colour, bool p_capture ) :
     RemoteCamera( p_id, "rtsp", p_host, p_port, p_path, p_width, p_height, p_colours, p_brightness, p_contrast, p_hue, p_colour, p_capture ),
-    rtspThread( 0 ),
-    rtsp_describe( p_rtsp_describe )
+    rtsp_describe( p_rtsp_describe ),
+    rtspThread( 0 )
+
 {
     if ( p_method == "rtpUni" )
         method = RtspThread::RTP_UNICAST;

--- a/src/zm_rtsp.h
+++ b/src/zm_rtsp.h
@@ -50,12 +50,13 @@ private:
 
 private:
     int mId;
-    bool mRtspDescribe;
+
     RtspMethod mMethod;
     std::string mProtocol;
     std::string mHost;
     std::string mPort;
     std::string mPath;
+    bool mRtspDescribe;
     std::string mUrl;
     
     // Reworked authentication system


### PR DESCRIPTION
@knnniggett please check this out as this is your area, just moved the RTSPDescribe around a bit as I was getting build warnings and nobody likes them on a release.