### PR TITLE
Add FFMPEGInit back to feature-h264-videostorage

### DIFF
--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -195,6 +195,9 @@ extern "C" {
  #endif
 #endif
 
+/* A single function to initialize ffmpeg, to avoid multiple initializations */		
+void FFMPEGInit();
+
 #if HAVE_LIBAVUTIL
 enum _AVPIXELFORMAT GetFFMPEGPixelFormat(unsigned int p_colours, unsigned p_subpixelorder);
 #endif // HAVE_LIBAVUTIL


### PR DESCRIPTION
Got dropped out in a recent merge, broke build for me.