### PR TITLE
Add support for IPv6 in RTSP code

### DIFF
--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -399,10 +399,13 @@ public:
 
 class InetSocket : virtual public Socket
 {
+protected:
+    int mAddressFamily;
+
 public:
     int getDomain() const
     {
-        return( AF_INET );
+        return( mAddressFamily );
     }
     virtual socklen_t getAddrSize() const
     {
@@ -410,92 +413,13 @@ public:
     }
 
 protected:
-    bool resolveLocal( const char *host, const char *serv, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mLocalAddr = addr;
-        return( addr->resolve( host, serv, proto ) );
-    }
-    bool resolveLocal( const char *host, int port, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mLocalAddr = addr;
-        return( addr->resolve( host, port, proto ) );
-    }
-    bool resolveLocal( const char *serv, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mLocalAddr = addr;
-        return( addr->resolve( serv, proto ) );
-    }
-    bool resolveLocal( int port, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mLocalAddr = addr;
-        return( addr->resolve( port, proto ) );
-    }
+    bool connect( const char *host, const char *serv );
+    bool connect( const char *host, int port );
 
-    bool resolveRemote( const char *host, const char *serv, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mRemoteAddr = addr;
-        return( addr->resolve( host, serv, proto ) );
-    }
-    bool resolveRemote( const char *host, int port, const char *proto )
-    {
-        SockAddrInet *addr = new SockAddrInet;
-        mRemoteAddr = addr;
-        return( addr->resolve( host, port, proto ) );
-    }
-
-protected:
-    bool bind( const SockAddrInet &addr )
-    {
-        mLocalAddr = new SockAddrInet( addr );
-        return( Socket::bind() );
-    }
-    bool bind( const char *host, const char *serv ) 
-    {
-        if ( !resolveLocal( host, serv, getProtocol() ) )
-            return( false );
-        return( Socket::bind() );
-    }
-    bool bind( const char *host, int port )
-    {
-        if ( !resolveLocal( host, port, getProtocol() ) )
-            return( false );
-        return( Socket::bind() );
-    }
-    bool bind( const char *serv )
-    {
-        if ( !resolveLocal( serv, getProtocol() ) )
-            return( false );
-        return( Socket::bind() );
-    }
-    bool bind( int port )
-    {
-        if ( !resolveLocal( port, getProtocol() ) )
-            return( false );
-        return( Socket::bind() );
-    }
-
-    bool connect( const SockAddrInet &addr )
-    {
-        mRemoteAddr = new SockAddrInet( addr );
-        return( Socket::connect() );
-    }
-    bool connect( const char *host, const char *serv )
-    {
-        if ( !resolveRemote( host, serv, getProtocol() ) )
-            return( false );
-        return( Socket::connect() );
-    }
-    bool connect( const char *host, int port )
-    {
-        if ( !resolveRemote( host, port, getProtocol() ) )
-            return( false );
-        return( Socket::connect() );
-    }
+    bool bind( const char *host, const char *serv );
+    bool bind( const char *host, int port );
+    bool bind( const char *serv );
+    bool bind( int port );
 };
 
 class UnixSocket : virtual public Socket
@@ -591,10 +515,6 @@ public:
 class UdpInetSocket : virtual public UdpSocket, virtual public InetSocket
 {
 public:
-    bool bind( const SockAddrInet &addr ) 
-    {
-        return( InetSocket::bind( addr ) );
-    }
     bool bind( const char *host, const char *serv ) 
     {
         return( InetSocket::bind( host, serv ) );
@@ -612,10 +532,6 @@ public:
         return( InetSocket::bind( port ) );
     }
 
-    bool connect( const SockAddrInet &addr ) 
-    {
-        return( InetSocket::connect( addr ) );
-    }
     bool connect( const char *host, const char *serv )
     {
         return( InetSocket::connect( host, serv ) );
@@ -642,33 +558,7 @@ public:
 
 class UdpInetClient : public UdpInetSocket
 {
-protected:
-    bool bind( const SockAddrInet &addr ) 
-    {
-        return( UdpInetSocket::bind( addr ) );
-    }
-    bool bind( const char *host, const char *serv )
-    {
-        return( UdpInetSocket::bind( host, serv ) );
-    }
-    bool bind( const char *host, int port )
-    {
-        return( UdpInetSocket::bind( host, port ) );
-    }
-    bool bind( const char *serv )
-    {
-        return( UdpInetSocket::bind( serv ) );
-    }
-    bool bind( int port )
-    {
-        return( UdpInetSocket::bind( port ) );
-    }
-
 public:
-    bool connect( const SockAddrInet &addr ) 
-    {
-        return( UdpInetSocket::connect( addr ) );
-    }
     bool connect( const char *host, const char *serv )
     {
         return( UdpInetSocket::connect( host, serv ) );
@@ -697,10 +587,6 @@ public:
 class UdpInetServer : public UdpInetSocket
 {
 public:
-    bool bind( const SockAddrInet &addr ) 
-    {
-        return( UdpInetSocket::bind( addr ) );
-    }
     bool bind( const char *host, const char *serv )
     {
         return( UdpInetSocket::bind( host, serv ) );
@@ -812,18 +698,6 @@ public:
 class TcpInetServer : public TcpInetSocket
 {
 public:
-    bool bind( const char *host, const char *serv )
-    {
-        return( TcpInetSocket::bind( host, serv ) );
-    }
-    bool bind( const char *host, int port )
-    {
-        return( TcpInetSocket::bind( host, port ) );
-    }
-    bool bind( const char *serv )
-    {
-        return( TcpInetSocket::bind( serv ) );
-    }
     bool bind( int port )
     {
         return( TcpInetSocket::bind( port ) );

--- a/src/zm_rtp_ctrl.cpp
+++ b/src/zm_rtp_ctrl.cpp
@@ -279,20 +279,17 @@ int RtpCtrlThread::run()
     UdpInetSocket rtpCtrlServer;
     if ( mRtpSource.getLocalHost() != "" )
     {
-        localAddr.resolve( mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalCtrlPort(), "udp" );
-        if ( !rtpCtrlServer.bind( localAddr ) )
+        if ( !rtpCtrlServer.bind( mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalCtrlPort() ) )
             Fatal( "Failed to bind RTCP server" );
         sendReports = false;
         Debug( 3, "Bound to %s:%d",  mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalCtrlPort() );
     }
     else
     {
-        localAddr.resolve( mRtpSource.getLocalCtrlPort(), "udp" );
-        if ( !rtpCtrlServer.bind( localAddr ) )
+        if ( !rtpCtrlServer.bind( mRtspThread.getAddressFamily() == AF_INET6 ? "::" : "0.0.0.0", mRtpSource.getLocalCtrlPort() ) )
             Fatal( "Failed to bind RTCP server" );
         Debug( 3, "Bound to %s:%d",  mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalCtrlPort() );
-        remoteAddr.resolve( mRtpSource.getRemoteHost().c_str(), mRtpSource.getRemoteCtrlPort(), "udp" );
-        if ( !rtpCtrlServer.connect( remoteAddr ) )
+        if ( !rtpCtrlServer.connect( mRtpSource.getRemoteHost().c_str(), mRtpSource.getRemoteCtrlPort() ) )
             Fatal( "Failed to connect RTCP server" );
         Debug( 3, "Connected to %s:%d",  mRtpSource.getRemoteHost().c_str(), mRtpSource.getRemoteCtrlPort() );
         sendReports = true;

--- a/src/zm_rtp_data.cpp
+++ b/src/zm_rtp_data.cpp
@@ -67,13 +67,17 @@ int RtpDataThread::run()
 
     SockAddrInet localAddr;
     UdpInetServer rtpDataSocket;
-    if ( mRtpSource.getLocalHost() != "" )
-        localAddr.resolve( mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalDataPort(), "udp" );
+    if ( mRtpSource.getLocalHost() != "" ) {
+        if ( !rtpDataSocket.bind( mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalDataPort() ) )
+            Fatal( "Failed to bind RTP server" );
+        Debug( 3, "Bound to %s:%d",  mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalDataPort() );
+    }
     else
-        localAddr.resolve( mRtpSource.getLocalDataPort(), "udp" );
-    if ( !rtpDataSocket.bind( localAddr ) )
-        Fatal( "Failed to bind RTP server" );
-    Debug( 3, "Bound to %s:%d",  mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalDataPort() );
+    {
+        if ( !rtpDataSocket.bind( mRtspThread.getAddressFamily() == AF_INET6 ? "::" : "0.0.0.0", mRtpSource.getLocalDataPort() ) )
+            Fatal( "Failed to bind RTP server" );
+        Debug( 3, "Bound to %s:%d",  mRtpSource.getLocalHost().c_str(), mRtpSource.getLocalDataPort() );
+    }
 
     Select select( 3 );
     select.addReader( &rtpDataSocket );

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -234,7 +234,7 @@ int RtspThread::run()
 
     response.reserve( ZM_NETWORK_BUFSIZ );
 
-    if ( !mRtspSocket.connect( mHost.c_str(), strtol( mPort.c_str(), NULL, 10 ) ) )
+    if ( !mRtspSocket.connect( mHost.c_str(), mPort.c_str() ) )
         Fatal( "Unable to connect RTSP socket" );
     //Select select( 0.25 );
     //select.addReader( &mRtspSocket );
@@ -248,7 +248,7 @@ int RtspThread::run()
     bool authTried = false; 
     if ( mMethod == RTP_RTSP_HTTP )
     {
-        if ( !mRtspSocket2.connect( mHost.c_str(), strtol( mPort.c_str(), NULL, 10 ) ) )
+        if ( !mRtspSocket2.connect( mHost.c_str(), mPort.c_str() ) )
             Fatal( "Unable to connect auxiliary RTSP/HTTP socket" );
         //Select select( 0.25 );
         //select.addReader( &mRtspSocket2 );
@@ -306,7 +306,7 @@ int RtspThread::run()
 				mAuthenticator->checkAuthResponse(response);
 				Debug(2, "Processed 401 response");
 				mRtspSocket.close();
-			    if ( !mRtspSocket.connect( mHost.c_str(), strtol( mPort.c_str(), NULL, 10 ) ) )
+			    if ( !mRtspSocket.connect( mHost.c_str(), mPort.c_str() ) )
 			        Fatal( "Unable to reconnect RTSP socket" );
 			    Debug(2, "connection should be reopened now");
 			}

--- a/src/zm_rtsp.h
+++ b/src/zm_rtsp.h
@@ -137,6 +137,10 @@ public:
     {
         return( mStop );
     }
+    int getAddressFamily ()
+    {
+        return mRtspSocket.getDomain();
+    }
 };
 
 #endif // ZM_RTSP_H

--- a/src/zm_sdp.cpp
+++ b/src/zm_sdp.cpp
@@ -112,7 +112,7 @@ SessionDescriptor::ConnInfo::ConnInfo( const std::string &connInfo ) :
     if ( mNetworkType != "IN" )
         throw Exception( "Invalid SDP network type '"+mNetworkType+"' in connection info '"+connInfo+"'" );
     mAddressType = tokens[1];
-    if ( mAddressType != "IP4" )
+    if ( mAddressType != "IP4" && mAddressType != "IP6" )
         throw Exception( "Invalid SDP address type '"+mAddressType+"' in connection info '"+connInfo+"'" );
     StringVector addressTokens = split( tokens[2], "/" );
     if ( addressTokens.size() < 1 ) 


### PR DESCRIPTION
Monitors with source type 'remote' can now be accessed over IPv6 when using the ZoneMinder RTSP code. This patch uses getaddrinfo(3) now instead of gethostbyname(3) - and changes a lot of networking stuff which **should be tested thoroughly**.

This PR addresses #1151. I would consider marking it **not ready for merge** until other some people tested and reviewed it.