### PR TITLE
Error on missing submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ set(zoneminder_VERSION "1.28.109")
 # make API version a minor of ZM version
 set(zoneminder_API_VERSION "${zoneminder_VERSION}.1")
 
+# Make sure the submodules are there
+if( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/.git" )
+message( SEND_ERROR "The git submodules are not available. Please run
+git submodule update --init --recursive")
+endif( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/.git" )
+
 # CMake does not allow out-of-source build if CMakeCache.exists 
 # in the source folder. Abort and notify the user
 if(


### PR DESCRIPTION
Generate an error when the Crud submodule has not been initialized.
I left it plural, because of potential plans for additional submodules, pending peer approval.