### PR TITLE
Partial fix for #1167

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -1044,7 +1044,7 @@ if ( $version )
 		foreach my $patch ( @files ) {
 			my ( $v ) = $patch =~ /^zm_update\-([\d\.]+)\.sql$/;
 			#PP make sure we use version compare 
-			if ( version->parse($v) ge version->parse($version) ) {
+			if ( version->parse('v' . $v) > version->parse('v' . $version) ) {
 				print( "Upgrading DB to $v from $version\n" );
 				patchDB( $dbh, $v );
 				if ( $dbh->errstr() ) {


### PR DESCRIPTION
#1167 found that 1.27 actually parses to 1.270.0, therefore is greater than 1.28.0. By adding 'v' in front of the version number it makes 1.27 into 1.27.0 and therefore the script works as expected. Also I changed ge to > as script was applying the current db version sql again before moving on. i.e. db version 1.27 first action was ```Upgrading DB to 1.27.0 from 1.27```

Worth noting we still need to fix the fact that zmupdate updates the DB version before applying the updates, so when it fails the DB shows as being on current version.

Reset my DB version back to 1.27 and ran zmupdate.pl here is the result.
```
Upgrading database to version 1.28.109
Loading config from DB
Saving config to DB
Upgrading DB to 1.27.99.0 from 1.27

Database successfully upgraded to version 1.27.99.0.
Upgrading DB to 1.28.0 from 1.27

Database successfully upgraded to version 1.28.0.
Upgrading DB to 1.28.1 from 1.27

Database successfully upgraded to version 1.28.1.
Upgrading DB to 1.28.99 from 1.27

Database successfully upgraded to version 1.28.99.
Upgrading DB to 1.28.100 from 1.27

Database successfully upgraded to version 1.28.100.
Upgrading DB to 1.28.101 from 1.27

Database successfully upgraded to version 1.28.101.
Upgrading DB to 1.28.102 from 1.27

Database successfully upgraded to version 1.28.102.
Upgrading DB to 1.28.103 from 1.27

Database successfully upgraded to version 1.28.103.
Upgrading DB to 1.28.104 from 1.27

Database successfully upgraded to version 1.28.104.
Upgrading DB to 1.28.105 from 1.27

Database successfully upgraded to version 1.28.105.
Upgrading DB to 1.28.106 from 1.27

Database successfully upgraded to version 1.28.106.
Upgrading DB to 1.28.107 from 1.27

Database successfully upgraded to version 1.28.107.
Upgrading DB to 1.28.108 from 1.27

Database successfully upgraded to version 1.28.108.
Upgrading DB to 1.28.109 from 1.27

Database successfully upgraded to version 1.28.109.

Database upgrade to version 1.28.109 successful.
```