### PR TITLE
Check for the presence of CrudControllerTrait.php instead of .git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ set(zoneminder_VERSION "1.28.109")
 set(zoneminder_API_VERSION "${zoneminder_VERSION}.1")
 
 # Make sure the submodules are there
-if( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/.git" )
+if( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/Lib/CrudControllerTrait.php" )
 message( SEND_ERROR "The git submodules are not available. Please run
 git submodule update --init --recursive")
-endif( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/.git" )
+endif( NOT EXISTS "${CMAKE_SOURCE_DIR}/web/api/app/Plugin/Crud/Lib/CrudControllerTrait.php" )
 
 # CMake does not allow out-of-source build if CMakeCache.exists 
 # in the source folder. Abort and notify the user


### PR DESCRIPTION
Debian build environment auto-strips out certain files, such as .git, as they are not necessary for building. Check for the presence of a required file instead.