### PR TITLE
Zms socket lock

### DIFF
--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -18,6 +18,10 @@
 //
 
 #include <sys/un.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/file.h>
 
 #include "zm.h"
 #include "zm_mpeg.h"
@@ -290,7 +294,7 @@ void StreamBase::openComms()
 		snprintf( sock_path_lock, sizeof(sock_path_lock), "%s/zms-%06d.lock", config.path_socks, connkey);
 
         lock_fd = open(sock_path_lock, O_CREAT|O_WRONLY, S_IRUSR | S_IWUSR);
-        if (lock_fd <= 0 || flock(lock_fd, LOCK_SH|LOCK_NB) != 0)
+        if (lock_fd <= 0 || flock(lock_fd, LOCK_EX) != 0)
         {
             Error("Unable to lock sock lock file %s: %s", sock_path_lock, strerror(errno) );
 
@@ -299,7 +303,7 @@ void StreamBase::openComms()
         }
         else
         {
-            Debug( 1, "We have obtained a read lock on %s fd: %d", sock_path_lock, lock_fd);
+            Debug( 1, "We have obtained a lock on %s fd: %d", sock_path_lock, lock_fd);
         }
 
 

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -344,8 +344,8 @@ void StreamBase::closeComms()
         }
 		if (lock_fd > 0)
 		{
-			loc_sock_path[0] = '\0';
 			close(lock_fd); //close it rather than unlock it incase it got deleted.
+			unlink(sock_path_lock);
 		}
     }
 }

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -78,6 +78,8 @@ protected:
     struct sockaddr_un loc_addr;
 	char rem_sock_path[PATH_MAX];
     struct sockaddr_un rem_addr;
+	char sock_path_lock[PATH_MAX];
+	int lock_fd;
 
 protected:
     bool paused;
@@ -127,6 +129,7 @@ public:
 
         connkey = 0;
         sd = -1;
+		lock_fd = 0;
         memset( &loc_sock_path, 0, sizeof(loc_sock_path) );
         memset( &loc_addr, 0, sizeof(loc_addr) );
         memset( &rem_sock_path, 0, sizeof(rem_sock_path) );


### PR DESCRIPTION
This puts an exclusive lock around the creation/deletion of the s and w socket files.

This fixes are problem with Chrome.  Chrome hits zms twice when you load the watch page and there is a concurrency problem where the first zms deletes the socket files after the second zms has created them.