### PR TITLE
Fixes #1179 Libvlc Live555 Segmentation Fault

### DIFF
--- a/src/zm_remote_camera.cpp
+++ b/src/zm_remote_camera.cpp
@@ -71,7 +71,7 @@ void RemoteCamera::Initialise()
 	}
 
     mNeedAuth = false;
-	mAuthenticator = new Authenticator(username,password);
+	mAuthenticator = new zm::Authenticator(username,password);
 
 	struct addrinfo hints;
 	memset(&hints, 0, sizeof(hints));

--- a/src/zm_remote_camera.h
+++ b/src/zm_remote_camera.h
@@ -50,7 +50,7 @@ protected:
     // fill required fields and set needAuth
     // subsequent requests can set the required authentication header.
     bool mNeedAuth;
-    Authenticator* mAuthenticator;
+    zm::Authenticator* mAuthenticator;
 protected:
 	struct addrinfo *hp;
 

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -306,7 +306,7 @@ int RemoteCameraHttp::GetResponse()
 							std::string Header = header;
 				
 							mAuthenticator->checkAuthResponse(Header);
-							if ( mAuthenticator->auth_method() == AUTH_DIGEST ) {
+							if ( mAuthenticator->auth_method() == zm::AUTH_DIGEST ) {
 								Debug( 2, "Need Digest Authentication" );
 								request = stringtf( "GET %s HTTP/%s\r\n", path.c_str(), config.http_version );
 								request += stringtf( "User-Agent: %s/%s\r\n", config.http_ua, ZM_VERSION );
@@ -750,7 +750,7 @@ Debug(3, "Need more data buffer %d < content length %d", buffer.size(), content_
 							Debug(2, "Checking for digest auth in %s", authenticate_header );
 
                             mAuthenticator->checkAuthResponse(Header);
-                            if ( mAuthenticator->auth_method() == AUTH_DIGEST ) {
+                            if ( mAuthenticator->auth_method() == zm::AUTH_DIGEST ) {
                                 Debug( 2, "Need Digest Authentication" );
                                 request = stringtf( "GET %s HTTP/%s\r\n", path.c_str(), config.http_version );
                                 request += stringtf( "User-Agent: %s/%s\r\n", config.http_ua, ZM_VERSION );

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -203,9 +203,9 @@ RtspThread::RtspThread( int id, RtspMethod method, const std::string &protocol, 
     mNeedAuth = false;
     StringVector parts = split(auth,":");
     if (parts.size() > 1) 
-    	mAuthenticator = new Authenticator(parts[0], parts[1]);
+    	mAuthenticator = new zm::Authenticator(parts[0], parts[1]);
     else
-    	mAuthenticator = new Authenticator(parts[0], "");
+    	mAuthenticator = new zm::Authenticator(parts[0], "");
 }
 
 RtspThread::~RtspThread()

--- a/src/zm_rtsp.h
+++ b/src/zm_rtsp.h
@@ -66,7 +66,7 @@ private:
     // subsequent requests can set the required authentication header.
     bool mNeedAuth;
     int respCode;
-    Authenticator* mAuthenticator;
+    zm::Authenticator* mAuthenticator;
 
 
     std::string mHttpSession;           ///< Only for RTSP over HTTP sessions

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+namespace zm {
+
 Authenticator::Authenticator(std::string &username, std::string password) {
 #ifdef HAVE_GCRYPT_H
     // Special initialisation for libgcrypt
@@ -227,3 +229,5 @@ void Authenticator::checkAuthResponse(std::string &response) {
 		Debug( 2, "Didn't find auth line in %s", authLine.c_str());
 	}
 }
+
+} // namespace zm

--- a/src/zm_rtsp_auth.h
+++ b/src/zm_rtsp_auth.h
@@ -32,6 +32,8 @@
 #include <openssl/md5.h>
 #endif // HAVE_GCRYPT_H || HAVE_LIBCRYPTO
 
+namespace zm { 
+
 enum AuthMethod { AUTH_UNDEFINED = 0, AUTH_BASIC = 1, AUTH_DIGEST = 2 };
 class Authenticator {
 public:
@@ -61,5 +63,7 @@ private:
   std::string quote( std::string src );
 	int nc;
 };
+
+} // namespace zm
 
 #endif // ZM_RTSP_AUTH_H


### PR DESCRIPTION
So this is a constrained implementation of namespace zm to prevent the segmentation fault in Live555. Caused by Authenticator::~Authenticator in both zm and live555 library.
I literally just taught myself namespace so feel free to critique. If anyone has a view on how to namespace the entire project I am happy to implement, but hopefully this is good enough to push on with 1.29.
#1179 