### PR TITLE
use trim on values when saving.

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -792,7 +792,7 @@ function getFormChanges( $values, $newValues, $types=false, $columns=false )
             {
                 if ( !isset($values[$key]) || ($values[$key] != $value) )
                 {
-                    $changes[$key] = "$key = ".dbEscape($value);
+                    $changes[$key] = "$key = ".dbEscape(trim($value));
                 }
                 break;
             }


### PR DESCRIPTION
Pretty simple, but may have unintended consequences. 

We have this getFormChanges function which we use to build an update sql for various objects.  This trims the values for basic scalar values.  

This is mostly important for cases like the path for a storage area. 