### PR TITLE
zmtrigger - process off+time delay condition

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -504,22 +504,11 @@ sub handleMessage
         Info( "Set monitor to $state\n" );
         if ( $delay )
         {
-            my $action_time = time()+$delay;
             my $action_text = $id."|".( ($state eq "enable")
                                         ? "disable"
                                         : "enable"
-                                      )
-            ;
-            my $action_array = $actions{$action_time};
-            if ( !$action_array )
-            {
-                $action_array = $actions{$action_time} = [];
-            }
-            push( @$action_array, { connection=>$connection,
-                                    message=>$action_text
-                                  }
-            );
-            Debug( "Added timed event '$action_text', expires at $action_time (+$delay secs)\n" );
+                                      );
+             handleDelay($delay, $connection, $action_text);
         }
     }
     elsif ( $action =~ /^(on|off)(?:[ \+](\d+))?$/ )
@@ -534,43 +523,33 @@ sub handleMessage
             zmTriggerEventOn( $monitor, $score, $cause, $text );
             zmTriggerShowtext( $monitor, $showtext ) if defined($showtext);
             Info( "Trigger '$trigger' '$cause'\n" );
+            if ( $delay )
+            {
+                 my $action_text = $id."|cancel";
+                 handleDelay($delay, $connection, $action_text);
+            }
         }
         elsif ( $trigger eq "off" )
         {
-            my $last_event = zmGetLastEvent( $monitor );
-            zmTriggerEventOff( $monitor );
-            zmTriggerShowtext( $monitor, $showtext ) if defined($showtext);
-            Info( "Trigger '$trigger'\n" );
-            # Wait til it's finished
-            while( zmInAlarm( $monitor )
-                   && ($last_event == zmGetLastEvent( $monitor ))
-            )
+            if ( $delay ) 
             {
-                # Tenth of a second
-                usleep( 100000 );
-            }
+                 my $action_text = $id."|off|0|".$cause."|".$text;
+                 handleDelay($delay, $connection, $action_text);
+            } else {
+                my $last_event = zmGetLastEvent( $monitor );
+                zmTriggerEventOff( $monitor );
+                zmTriggerShowtext( $monitor, $showtext ) if defined($showtext);
+                Info( "Trigger '$trigger'\n" );
+                # Wait til it's finished
+                while( zmInAlarm( $monitor )
+                       && ($last_event == zmGetLastEvent( $monitor ))
+                )
+                {
+                    # Tenth of a second
+                    usleep( 100000 );
+                }
             zmTriggerEventCancel( $monitor );
-        }
-        else
-        {
-            Info( "Trigger '$trigger'\n" );
-            zmTriggerEventCancel( $monitor );
-        }
-        if ( $delay )
-        {
-            my $action_time = time()+$delay;
-            #my $action_text = $id."|cancel|0|".$cause."|".$text;
-            my $action_text = $id."|cancel";
-            my $action_array = $actions{$action_time};
-            if ( !$action_array )
-            {
-                $action_array = $actions{$action_time} = [];
             }
-            push( @$action_array, { connection=>$connection,
-                                    message=>$action_text
-                                  }
-            );
-            Debug( "Added timed event '$action_text', expires at $action_time (+$delay secs)\n" );
         }
     }
     elsif( $action eq "cancel" )
@@ -590,5 +569,23 @@ sub handleMessage
     }
 } # end sub handleMessage
 
+sub handleDelay
+{
+    my $delay = shift;
+    my $connection = shift;
+    my $action_text = shift;
+    
+    my $action_time = time()+$delay;
+    my $action_array = $actions{$action_time};
+    if ( !$action_array )
+    {
+        $action_array = $actions{$action_time} = [];
+    }
+    push( @$action_array, { connection=>$connection,
+                            message=>$action_text
+                          }
+    );
+    Debug( "Added timed event '$action_text', expires at $action_time (+$delay secs)\n" );
+}
 1;
 __END__


### PR DESCRIPTION
The time delay effect was not working when the "off" action was specified because zmTriggerEventOff was being called immediately, rather than after the delay.

This PR fixes that. 
The code that handles the delay effect has been moved into its own subroutine.