### PR TITLE
Fix PelcoP checksum calculation

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoP.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoP.pm
@@ -133,8 +133,10 @@ sub sendCmd
 
     my $result = undef;
 
+    # Pelco P protocol checksum is created by XOR'ing the first seven bytes in the message
+    # including the first byte, the STX sync packet
     my $checksum = 0x00;
-    for ( my $i = 1; $i < int(@$cmd); $i++ )
+    for ( my $i = 0; $i < int(@$cmd); $i++ )
     {
         $checksum ^= $cmd->[$i];
     }


### PR DESCRIPTION
Unlike the Pelco D protocol, the STX sync packet should be included in the checksum calculation as defined in the Pelco P protocol definition. This pr fixes that.

https://forums.zoneminder.com/viewtopic.php?f=32&t=23759
