### PR TITLE
Add Debug/Info lines reporting multi-server status

### DIFF
--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -115,6 +115,7 @@ void zmLoadConfig()
 	if ( ! staticConfig.SERVER_ID ) {
 		if ( ! staticConfig.SERVER_NAME.empty() ) {
 
+			Debug( 1, "Fetching ZM_SERVER_ID For Name = %s", staticConfig.SERVER_NAME.c_str() );
 			std::string sql = stringtf("SELECT Id FROM Servers WHERE Name='%s'", staticConfig.SERVER_NAME.c_str() );
 			if ( MYSQL_ROW dbrow = zmDbFetchOne( sql.c_str() ) ) {
 				staticConfig.SERVER_ID = atoi(dbrow[0]);
@@ -124,6 +125,7 @@ void zmLoadConfig()
 
 		} // end if has SERVER_NAME
 	} else if ( staticConfig.SERVER_NAME.empty() ) {
+		Debug( 1, "Fetching ZM_SERVER_NAME For Id = %d", staticConfig.SERVER_ID );
 		std::string sql = stringtf("SELECT Name FROM Servers WHERE Id='%d'", staticConfig.SERVER_ID );
 		
 		if ( MYSQL_ROW dbrow = zmDbFetchOne( sql.c_str() ) ) {
@@ -133,6 +135,11 @@ void zmLoadConfig()
 		}
 	
 	}	
+	if ( ! staticConfig.SERVER_ID ) {
+		Info( "No Server ID or Name specified in config.  Not using Multi-Server Mode." );
+	} else {
+		Info( "Server is %d: using Multi-Server Mode.", staticConfig.SERVER_ID );
+	}
 }
 
 StaticConfig staticConfig;

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -2237,6 +2237,7 @@ int Monitor::LoadRemoteMonitors( const char *protocol, const char *host, const c
         sql += stringtf(" AND Protocol = '%s' and Host = '%s' and Port = '%s' and Path = '%s'", protocol, host, port, path );
     }
 
+	Debug( 1, "Loading Remote Monitors with %s", sql.c_str() );
     MYSQL_RES *result = zmDbFetch( sql.c_str() );
     if ( !result ) {
         Error( "Can't use query result: %s", mysql_error( &dbconn ) );
@@ -2415,6 +2416,7 @@ int Monitor::LoadFileMonitors( const char *file, Monitor **&monitors, Purpose pu
     if ( staticConfig.SERVER_ID ) {
         sql += stringtf( " AND ServerId=%d", staticConfig.SERVER_ID );
     }
+	Debug( 1, "Loading File Monitors with %s", sql.c_str() );
     MYSQL_RES *result = zmDbFetch( sql.c_str() );
     if ( !result )
     {
@@ -2557,6 +2559,7 @@ int Monitor::LoadFfmpegMonitors( const char *file, Monitor **&monitors, Purpose 
     if ( staticConfig.SERVER_ID ) {
         sql += stringtf( " AND ServerId=%d", staticConfig.SERVER_ID );
     }
+	Debug( 1, "Loading FFMPEG Monitors with %s", sql.c_str() );
     MYSQL_RES *result = zmDbFetch( sql.c_str() );
     if ( ! result ) {
         Error( "Cannot load FfmpegMonitors" );

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -2055,9 +2055,9 @@ int Monitor::LoadLocalMonitors( const char *device, Monitor **&monitors, Purpose
         sql += "'";
     }
     if ( staticConfig.SERVER_ID ) {
-Debug( 1, "Server ID %d", staticConfig.SERVER_ID );
         sql += stringtf( " AND ServerId=%d", staticConfig.SERVER_ID );
     }
+	Debug( 1, "Loading Local Monitors with %s", sql.c_str() );
 
     MYSQL_RES *result = zmDbFetch( sql.c_str() );
     if ( !result ) {


### PR DESCRIPTION
Just to help with debugging any cases where monitors seem to be loading on servers where they shouldn't.