### PR TITLE
By default, enable ONVIF discovery support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,9 +133,9 @@ set(ZM_NO_CURL "OFF" CACHE BOOL
     "Set to ON to skip cURL checks and force building ZM without cURL. default: OFF")
 set(ZM_NO_X10 "OFF" CACHE BOOL 
     "Set to ON to build ZoneMinder without X10 support. default: OFF")
-set(ZM_ONVIF "OFF" CACHE BOOL 
+set(ZM_ONVIF "ON" CACHE BOOL 
     "Set to ON to enable basic ONVIF support. This is EXPERIMENTAL and may not 
-    work with all cameras claiming to be ONVIF compliant. default: OFF")
+    work with all cameras claiming to be ONVIF compliant. default: ON")
 set(ZM_PERL_MM_PARMS INSTALLDIRS=vendor NO_PACKLIST=1 NO_PERLLOCAL=1 CACHE STRING 
 	"By default, ZoneMinder's Perl modules are installed into the Vendor folders, 
 	as defined by your installation of Perl. You can change that here. Consult Perl's 

--- a/onvif/scripts/CMakeLists.txt
+++ b/onvif/scripts/CMakeLists.txt
@@ -1,4 +1,9 @@
 # CMakeLists.txt for the ZoneMinder perl scripts.
 
+# If this is an out-of-source build, copy the files we need to the binary directory
+if(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR))
+	file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/zmonvif-probe.pl" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR))
+
 # Install the perl scripts
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zmonvif-probe.pl"  DESTINATION "${CMAKE_INSTALL_FULL_BINDIR}" PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
In an attempt to get our user base to start testing ONVIF discovery support, I'd like to change the default from OFF to ON.

This will have an affect on packaging as multiple new Perl modules will be required. 

What follows is a possibly incomplete list of Debian package names of the new dependencies:
libsoap-wsdl-perl
libdata-dump-perl
libdigest-sha-perl
libio-socket-multicast-perl

I don't recall what the Redhat package names are, but it won't take me long to figure that out.

@connortechnology 
@barjac 
@onlyjob 

Feedback is appreciated.