### PR TITLE
check snprintf result before use

### DIFF
--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -555,7 +555,8 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
         tid = getpid(); // Process id
 
         char *logPtr = logString;
-        logPtr += snprintf( logPtr, sizeof(logString), "%s %s[%d].%s-%s/%d [", 
+        int rc;
+        rc = snprintf( logPtr, sizeof(logString), "%s %s[%d].%s-%s/%d [", 
                     timeString,
                     mId.c_str(),
                     tid,
@@ -563,6 +564,8 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
                     file,
                     line
                 );
+        if (!(rc < 0 || rc >= sizeof(logString)))
+            logPtr += rc;
         char *syslogStart = logPtr;
 
         va_start( argPtr, fstring );
@@ -571,15 +574,21 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
             unsigned char *data = va_arg( argPtr, unsigned char * );
             int len = va_arg( argPtr, int );
             int i;
-            logPtr += snprintf( logPtr, sizeof(logString)-(logPtr-logString), "%d:", len );
+            rc = snprintf( logPtr, sizeof(logString)-(logPtr-logString), "%d:", len );
+            if (!(rc < 0 || rc >= sizeof(logString)-(logPtr-logString)))
+                logPtr += rc;
             for ( i = 0; i < len; i++ )
             {
-                logPtr += snprintf( logPtr, sizeof(logString)-(logPtr-logString), " %02x", data[i] );
+                rc = snprintf( logPtr, sizeof(logString)-(logPtr-logString), " %02x", data[i] );
+                if (!(rc < 0 || rc >= sizeof(logString)-(logPtr-logString)))
+                    logPtr += rc;
             }
         }
         else
         {
-            logPtr += vsnprintf( logPtr, sizeof(logString)-(logPtr-logString), fstring, argPtr );
+            rc = vsnprintf( logPtr, sizeof(logString)-(logPtr-logString), fstring, argPtr );
+            if (!(rc < 0 || rc >= sizeof(logString)-(logPtr-logString)))
+                logPtr += rc;
         }
         va_end(argPtr);
         char *syslogEnd = logPtr;

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -3170,19 +3170,29 @@ void Monitor::TimestampImage( Image *ts_image, const struct timeval *ts_time ) c
             if ( *s_ptr == '%' )
             {
                 bool found_macro = false;
+                int rc;
                 switch ( *(s_ptr+1) )
                 {
                     case 'N' :
-                        d_ptr += snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%s", name );
+                        rc = snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%s", name );
                         found_macro = true;
+                        if (rc < 0 || rc >= sizeof(label_text)-(d_ptr-label_text))
+                            break;
+                        d_ptr += rc;
                         break;
                     case 'Q' :
-                        d_ptr += snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%s", trigger_data->trigger_showtext );
+                        rc = snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%s", trigger_data->trigger_showtext );
                         found_macro = true;
+                        if (rc < 0 || rc >= sizeof(label_text)-(d_ptr-label_text))
+                            break;
+                        d_ptr += rc;
                         break;
                     case 'f' :
-                        d_ptr += snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%02ld", ts_time->tv_usec/10000 );
+                        rc = snprintf( d_ptr, sizeof(label_text)-(d_ptr-label_text), "%02ld", ts_time->tv_usec/10000 );
                         found_macro = true;
+                        if (rc < 0 || rc >= sizeof(label_text)-(d_ptr-label_text))
+                            break;
+                        d_ptr += rc;
                         break;
                 }
                 if ( found_macro )

--- a/src/zm_signal.cpp
+++ b/src/zm_signal.cpp
@@ -97,15 +97,19 @@ RETSIGTYPE zm_die_handler(int signal)
 
 	char cmd[1024] = "addr2line -e ";
 	char *cmd_ptr = cmd + strlen(cmd);
-	cmd_ptr += snprintf(cmd_ptr, sizeof(cmd) - (cmd_ptr - cmd), "%s", self);
+	int rc;
+	rc = snprintf(cmd_ptr, sizeof(cmd) - (cmd_ptr - cmd), "%s", self);
+	if (!(rc < 0 || rc >= sizeof(cmd) - (cmd_ptr - cmd)))
+		cmd_ptr += rc;
 
 	char **messages = backtrace_symbols(trace, trace_size);
 	// Print the full backtrace
 	for (int i = 0; i < trace_size; i++) {
 		Error("Backtrace %u: %s", i, messages[i]);
-		cmd_ptr +=
-		    snprintf(cmd_ptr, sizeof(cmd) - (cmd_ptr - cmd), " %p",
-			     trace[i]);
+		rc = snprintf(cmd_ptr, sizeof(cmd) - (cmd_ptr - cmd), " %p",
+			 trace[i]);
+		if (!(rc < 0 || rc >= sizeof(cmd) - (cmd_ptr - cmd)))
+			cmd_ptr += rc;
 	}
 	free(messages);
 


### PR DESCRIPTION
When snprintf would result in buffer overflow or other error happens, it returns value larger than specified buffer size or `-1`. If you directly add it to the pointer, bad things will happen.
Have not deeply verified, but some looks exploitable.
