### PR TITLE
Travis update to Trusty, add Clang build and up ffmpeg version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev libvlccore-dev libvlc-dev 2>&1 > /dev/null 
 install:
-  - git clone -b n2.8.6 --depth=1 git://source.ffmpeg.org/ffmpeg.git
+  - git clone -b n3.0.0 --depth=1 git://source.ffmpeg.org/ffmpeg.git
   - cd ffmpeg
   - ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx --enable-libvorbis --enable-libtheora 
   - make -j `grep processor /proc/cpuinfo|wc -l` 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev libvlccore-dev libvlc-dev 2>&1 > /dev/null 
 install:
-  - git clone -b n3.0.0 --depth=1 git://source.ffmpeg.org/ffmpeg.git
+  - git clone -b n3.0 --depth=1 git://source.ffmpeg.org/ffmpeg.git
   - cd ffmpeg
   - ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx --enable-libvorbis --enable-libtheora 
   - make -j `grep processor /proc/cpuinfo|wc -l` 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: cpp
+sudo: required
+dist: trusty
 notifications:
   irc: "chat.freenode.net#zoneminder-dev"
 branches:
@@ -24,7 +26,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev libvlccore-dev libvlc-dev libvlccore5 libvlc5 2>&1 > /dev/null 
 install:
-  - git clone -b n2.8.1 --depth=1 git://source.ffmpeg.org/ffmpeg.git
+  - git clone -b n2.8.6 --depth=1 git://source.ffmpeg.org/ffmpeg.git
   - cd ffmpeg
   - ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx --enable-libvorbis --enable-libtheora 
   - make -j `grep processor /proc/cpuinfo|wc -l` 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ env:
     - ZM_BUILDMETHOD=autotools
 compiler:
   - gcc
+  - clang
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev libvlccore-dev libvlc-dev libvlccore5 libvlc5 2>&1 > /dev/null 
+  - sudo apt-get install -y -qq libpolkit-gobject-1-dev zlib1g-dev apache2 mysql-server php5 php5-mysql build-essential libmysqlclient-dev libssl-dev libbz2-dev libpcre3-dev libdbi-perl libarchive-zip-perl libdate-manip-perl libdevice-serialport-perl libmime-perl libwww-perl libdbd-mysql-perl libsys-mmap-perl yasm automake autoconf cmake libjpeg-turbo8-dev apache2-mpm-prefork libapache2-mod-php5 php5-cli libtheora-dev libvorbis-dev libvpx-dev libx264-dev libvlccore-dev libvlc-dev 2>&1 > /dev/null 
 install:
   - git clone -b n2.8.6 --depth=1 git://source.ffmpeg.org/ffmpeg.git
   - cd ffmpeg


### PR DESCRIPTION
Converted to Trusty build environment on Travis, which meant removing libvlc5 and libvlccore5 packages, the new versions of these are dependencies of libvlc-dev and libvlccore-dev.

Updated ffmpeg to 2.8.6.

Added Clang as a compiler option, figured no harm in seeing what warnings it throws.