### PR TITLE
Zm trigger improvements

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/File.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/File.pm
@@ -62,7 +62,10 @@ sub open
     local *sfh;
     #sysopen( *sfh, $conn->{path}, O_NONBLOCK|O_RDONLY ) or croak( "Can't sysopen: $!" );
     #open( *sfh, "<".$conn->{path} ) or croak( "Can't open: $!" );
-    open( *sfh, "+<", $self->{path} ) or croak( "Can't open: $!" );
+    if ( ! open( *sfh, "+<", $self->{path} ) ) {
+		Error( "Can't open file at $$self{path}: $!" );
+		croak( "Can't open file at $$self{path}: $!" );
+	}
     $self->{state} = 'open';
     $self->{handle} = *sfh;
 }
@@ -73,7 +76,7 @@ __END__
 
 =head1 NAME
 
-ZoneMinder::Database - Perl extension for blah blah blah
+ZoneMinder::Trigger::Channel::File - ZOneMinder object for a file based trigger channel
 
 =head1 SYNOPSIS
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Inet.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Inet.pm
@@ -61,12 +61,21 @@ sub open
 {
     my $self = shift;
     local *sfh;
-    my $saddr = sockaddr_in( $self->{port}, INADDR_ANY );
-    socket( *sfh, PF_INET, SOCK_STREAM, getprotobyname('tcp') )
-        or croak( "Can't open socket: $!" );
+    if ( ! socket( *sfh, PF_INET, SOCK_STREAM, getprotobyname('tcp') ) ) {
+        Error( "Can't open socket: $!" );
+        croak( "Can't open socket: $!" );
+	}
     setsockopt( *sfh, SOL_SOCKET, SO_REUSEADDR, 1 );
-    bind( *sfh, $saddr ) or croak( "Can't bind: $!" );
-    listen( *sfh, SOMAXCONN ) or croak( "Can't listen: $!" );
+
+    my $saddr = sockaddr_in( $self->{port}, INADDR_ANY );
+    if ( ! bind( *sfh, $saddr ) ) {
+		Error( "Can't bind to port $$self{port}: $!" );
+		croak( "Can't bind to port $$self{port}: $!" );
+	}
+    if ( ! listen( *sfh, SOMAXCONN ) ) {
+		Error( "Can't listen: $!" );
+		croak( "Can't listen: $!" );
+	}
     $self->{state} = 'open';
     $self->{handle} = *sfh;
 }
@@ -95,7 +104,7 @@ __END__
 
 =head1 NAME
 
-ZoneMinder::Database - Perl extension for blah blah blah
+ZoneMinder::Trigger::Channel::Inet
 
 =head1 SYNOPSIS
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Unix.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Unix.pm
@@ -63,9 +63,18 @@ sub open
     local *sfh;
     unlink( $self->{path} );
     my $saddr = sockaddr_un( $self->{path} );
-    socket( *sfh, PF_UNIX, SOCK_STREAM, 0 ) or croak( "Can't open socket: $!" );
-    bind( *sfh, $saddr ) or croak( "Can't bind: $!" );
-    listen( *sfh, SOMAXCONN ) or croak( "Can't listen: $!" );
+    if ( ! socket( *sfh, PF_UNIX, SOCK_STREAM, 0 ) ) {
+		Error( "Can't open unix socket at $$self{path}: $!" );
+		croak( "Can't open unix socket at $$self{path}: $!" );
+	}
+    if ( ! bind( *sfh, $saddr ) ) {
+		Error( "Can't bind unix socket at $$self{path}: $!" );
+		croak( "Can't bind unix socket at $$self{path}: $!" );
+	}
+    if ( ! listen( *sfh, SOMAXCONN ) ) {
+		Error( "Can't listen: $!" );
+		croak( "Can't listen: $!" );
+	}
     $self->{handle} = *sfh;
 }
 
@@ -93,12 +102,11 @@ __END__
 
 =head1 NAME
 
-ZoneMinder::Database - Perl extension for blah blah blah
+ZoneMinder::Trigger::Channel::Unix - Object for Unix socket channel
 
 =head1 SYNOPSIS
 
-  use ZoneMinder::Database;
-  blah blah blah
+See zmtrigger.pl 
 
 =head1 DESCRIPTION
 

--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -135,14 +135,14 @@ use ZoneMinder::Trigger::Connection;
 my @connections;
 push( @connections,
       ZoneMinder::Trigger::Connection->new(
-        name=>"Chan1",
+        name=>"Chan1 TCP on port 6802",
         channel=>ZoneMinder::Trigger::Channel::Inet->new( port=>6802 ),
         mode=>"rw"
       )
 );
 push( @connections,
       ZoneMinder::Trigger::Connection->new(
-        name=>"Chan2",
+        name=>"Chan2 Unix Socket at " $Config{ZM_PATH_SOCKS}.'/zmtrigger.sock',
         channel=>ZoneMinder::Trigger::Channel::Unix->new(
                     path=>$Config{ZM_PATH_SOCKS}.'/zmtrigger.sock'
                  ),

--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -142,7 +142,7 @@ push( @connections,
 );
 push( @connections,
       ZoneMinder::Trigger::Connection->new(
-        name=>"Chan2 Unix Socket at " $Config{ZM_PATH_SOCKS}.'/zmtrigger.sock',
+        name=>"Chan2 Unix Socket at " . $Config{ZM_PATH_SOCKS}.'/zmtrigger.sock',
         channel=>ZoneMinder::Trigger::Channel::Unix->new(
                     path=>$Config{ZM_PATH_SOCKS}.'/zmtrigger.sock'
                  ),


### PR DESCRIPTION
The use of croak means that the error message will only be seen if the user runs it from a command line.

So we log before croaking.

Ideally failing to open would not be fatal, and zmtrigger.pl could continue on it's other channels.