### PR TITLE
zm_event: fix overlap in memcpy buffers

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -1121,7 +1121,7 @@ void EventStream::processCommand( const CmdMsg *msg )
 
     DataMsg status_msg;
     status_msg.msg_type = MSG_DATA_EVENT;
-    memcpy( &status_msg.msg_data, &status_data, sizeof(status_msg.msg_data) );
+    memcpy( &status_msg.msg_data, &status_data, sizeof(status_data) );
     if ( sendto( sd, &status_msg, sizeof(status_msg), MSG_DONTWAIT, (sockaddr *)&rem_addr, sizeof(rem_addr) ) < 0 )
     {
         //if ( errno != EAGAIN )


### PR DESCRIPTION
This second instance of memcpy overlap went unnoticed in the first fix.

I suppose the DataMsg structure is used here because the message size is hardcoded in web/ajax/stream.php.