### PR TITLE
Prevent zmtrigger from crashing when memory handles change

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -135,14 +135,14 @@ use ZoneMinder::Trigger::Connection;
 my @connections;
 push( @connections,
       ZoneMinder::Trigger::Connection->new(
-        name=>"Chan1 TCP on port 6802",
+        name=>"Chan1",
         channel=>ZoneMinder::Trigger::Channel::Inet->new( port=>6802 ),
         mode=>"rw"
       )
 );
 push( @connections,
       ZoneMinder::Trigger::Connection->new(
-        name=>"Chan2 Unix Socket at " . $Config{ZM_PATH_SOCKS}.'/zmtrigger.sock',
+        name=>"Chan2",
         channel=>ZoneMinder::Trigger::Channel::Unix->new(
                     path=>$Config{ZM_PATH_SOCKS}.'/zmtrigger.sock'
                  ),
@@ -197,6 +197,7 @@ my %spawned_connections;
 my %monitors;
 
 my $monitor_reload_time = 0;
+my $needsReload = 0;
 
 $! = undef;
 my $rin = '';
@@ -312,49 +313,52 @@ while( 1 )
     my @out_messages;
     foreach my $monitor ( values(%monitors) )
     {
-        my ( $state, $last_event )
-            = zmMemRead( $monitor,
-                         [ "shared_data:state",
-                           "shared_data:last_event"
-                         ]
-        );
+        my $memVerified = 1;
+        if ( !zmMemRead($monitor, "shared_data:valid")  ) {
+            zmMemInvalidate($monitor);
+            $memVerified = zmMemVerify($monitor);
+        }
 
-        #print( "$monitor->{Id}: S:$state, LE:$last_event\n" );
-        #print( "$monitor->{Id}: mS:$monitor->{LastState}, mLE:$monitor->{LastEvent}\n" );
-        if ( $state == STATE_ALARM
-             || $state == STATE_ALERT
-        ) # In alarm state
-        {
-            if ( !defined($monitor->{LastEvent})
-                 || ($last_event != $monitor->{LastEvent})
-            ) # A new event
-            {
+        if ($memVerified) {
+            my ( $state, $last_event )
+                = zmMemRead( $monitor,
+                             [ "shared_data:state",
+                               "shared_data:last_event"
+                             ]
+            );
+
+            #print( "$monitor->{Id}: S:$state, LE:$last_event\n" );
+            #print( "$monitor->{Id}: mS:$monitor->{LastState}, mLE:$monitor->{LastEvent}\n" );
+            if ( $state == STATE_ALARM
+                 || $state == STATE_ALERT
+            ) { # In alarm state
+                if ( !defined($monitor->{LastEvent})
+                     || ($last_event != $monitor->{LastEvent})
+                ) { # A new event
+                    push( @out_messages, $monitor->{Id}."|on|".time()."|".$last_event );
+                } else { # The same one as last time, so ignore it
+                    # Do nothing
+                }
+            } elsif ( ($state == STATE_IDLE
+                     && $monitor->{LastState} != STATE_IDLE
+                    )
+                    || ($state == STATE_TAPE
+                        && $monitor->{LastState} != STATE_TAPE
+                       )
+            ) { # Out of alarm state
+                push( @out_messages, $monitor->{Id}."|off|".time()."|".$last_event );
+            }
+            elsif ( defined($monitor->{LastEvent})
+                    && ($last_event != $monitor->{LastEvent})
+            ) { # We've missed a whole event
                 push( @out_messages, $monitor->{Id}."|on|".time()."|".$last_event );
+                push( @out_messages, $monitor->{Id}."|off|".time()."|".$last_event );
             }
-            else # The same one as last time, so ignore it
-            {
-                # Do nothing
-            }
+            $monitor->{LastState} = $state;
+            $monitor->{LastEvent} = $last_event;
+        } else { # Our attempt to verify the memory handle failed. We should reload the monitors.
+            $needsReload = 1;
         }
-        elsif ( ($state == STATE_IDLE
-                 && $monitor->{LastState} != STATE_IDLE
-                )
-                || ($state == STATE_TAPE
-                    && $monitor->{LastState} != STATE_TAPE
-                   )
-        ) # Out of alarm state
-        {
-            push( @out_messages, $monitor->{Id}."|off|".time()."|".$last_event );
-        }
-        elsif ( defined($monitor->{LastEvent})
-                && ($last_event != $monitor->{LastEvent})
-        ) # We've missed a whole event
-        {
-            push( @out_messages, $monitor->{Id}."|on|".time()."|".$last_event );
-            push( @out_messages, $monitor->{Id}."|off|".time()."|".$last_event );
-        }
-        $monitor->{LastState} = $state;
-        $monitor->{LastEvent} = $last_event;
     }
     foreach my $connection ( @out_connections )
     {
@@ -412,7 +416,7 @@ while( 1 )
     }
 
     # If necessary reload monitors
-    if ( (time() - $monitor_reload_time) > MONITOR_RELOAD_INTERVAL )
+    if ( $needsReload || ((time() - $monitor_reload_time) > MONITOR_RELOAD_INTERVAL ))
     {
         foreach my $monitor ( values(%monitors) )
         {
@@ -420,6 +424,7 @@ while( 1 )
             zmMemInvalidate( $monitor );
         }
         loadMonitors();
+        $needsReload = 0;
     }
 }
 Info( "Trigger daemon exiting\n" );


### PR DESCRIPTION
Possible fix for #545 

When a monitor is created, deleted, or edited from the web console on a running system, the memory handles change. Zmtrigger is unaware of this change and proceeds to read the memory handle from the previous, now invalid, handle. This is my current theory to the cause of zmtigger crashing, or becoming unresponsive, over time.

This commit borrows on the idea from @pliablepixels . It attempts to detect when this condition occurs and remedy it by deleting the old and then recreating a new memory handle for the monitor in question.

Note that I have yet to experience this particular issue on my system, so I cannot verify this does indeed resolve the issue. Needs verification from someone who can duplicate this issue.
