### PR TITLE
use debian control file to auto-install deps

### DIFF
--- a/docs/installationguide/ubuntu.rst
+++ b/docs/installationguide/ubuntu.rst
@@ -294,13 +294,11 @@ Harder Way: Build Package From Source
 	chmod a+x do_debian_package.sh
 
 
-**Step 2:** Install some core dependencies
+**Step 2:** Update the system
 
 ::
 
 	sudo apt-get update
-
-	sudo apt-get install git cmake pbuilder debhelper sphinx-common apache2-dev dh-linktree dh-systemd libavcodec-ffmpeg-dev libavformat-ffmpeg-dev libswscale-ffmpeg-dev libavutil-ffmpeg-dev libavdevice-ffmpeg-dev libbz2-dev libdate-manip-perl libdbd-mysql-perl libgcrypt-dev libcurl4-gnutls-dev libgnutls-openssl-dev libjpeg-dev libmysqlclient-dev libpcre3-dev libphp-serialization-perl libpolkit-gobject-1-dev libsys-mmap-perl libv4l-dev libvlc-dev libjs-mootools mysql-server apache2 libapache2-mod-php5 gdebi
 
 
 **Step 3** Create the package

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -52,6 +52,10 @@ else
 ln -sf distros/ubuntu1504_cmake debian
 fi;
 
+# Auto-install all ZoneMinder's depedencies using the Debian control file
+sudo apt-get install devscripts equivs
+sudo mk-build-deps -ir ./debian/control
+
 if [ -z `hostname -d` ] ; then
     AUTHOR="`getent passwd $USER | cut -d ':' -f 5 | cut -d ',' -f 1` <`whoami`@`hostname`.local>"
 else


### PR DESCRIPTION
This updates the do_debian_package.sh script to auto-install all ZoneMinder's dependencies using the debian control file. Readthedocs documentation is updated accordingly.

I want to test this myself before merging. Others are welcome to test too.

