### PR TITLE
add comment/warning for ZM_SERVER_HOST

### DIFF
--- a/zm.conf.in
+++ b/zm.conf.in
@@ -46,5 +46,9 @@ ZM_DB_USER=@ZM_DB_USER@
 # ZoneMinder database password
 ZM_DB_PASS=@ZM_DB_PASS@
 
-# Host of this machine
+# Do NOT set ZM_SERVER_HOST if you are not using Multi-Server
+# You have been warned
+#
+# The name specified here must have a corresponding entry
+# in the Servers tab under Options
 ZM_SERVER_HOST=


### PR DESCRIPTION
I've read at least three instances of forum users assigning a value to ZM_SERVER_HOST while at the same time not having any intention of using multi-server. This of course breaks their system. This is my attempt to fix stupid.
