### PR TITLE
fix missing Net::SFTP::Foreign::debug warning

### DIFF
--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -935,10 +935,12 @@ sub uploadArchFile
                 if $Config{ZM_UPLOAD_PORT};
             $sftpOptions{timeout} = $Config{ZM_UPLOAD_TIMEOUT}
                 if $Config{ZM_UPLOAD_TIMEOUT};
-            $sftpOptions{more} = [ '-o'=>'StrictHostKeyChecking=no' ]
+            my @more_ssh_args;
+            push @more_ssh_args, ['-o'=>'StrictHostKeyChecking=no']
 				if ! $Config{ZM_UPLOAD_STRICT};
-            $Net::SFTP::Foreign::debug = -1
+            push @more_ssh_args, ['-v']
                 if $Config{ZM_UPLOAD_DEBUG};
+            $sftpOptions{more} = [@more_ssh_args];
             my $sftp = Net::SFTP::Foreign->new( $Config{ZM_UPLOAD_HOST}, %sftpOptions );
             if ( $sftp->error )
             {


### PR DESCRIPTION
With this commit, Perl no longer complains about a missing debug module, which does not exist in Perl, but I don't currently have an environment set up to test SFTP transfers.

This modification follows the Perl documentation for this module and passes "-v" to the "more" key when Debug is turned on.