### PR TITLE
Change README documentation link to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ZoneMinder
 
 [![Build Status](https://travis-ci.org/ZoneMinder/ZoneMinder.png)](https://travis-ci.org/ZoneMinder/ZoneMinder) [![Bountysource](https://api.bountysource.com/badge/team?team_id=204&style=bounties_received)](https://www.bountysource.com/teams/zoneminder/issues?utm_source=ZoneMinder&utm_medium=shield&utm_campaign=bounties_received)
 
-All documentation for ZoneMinder is now online at http://www.zoneminder.com/wiki/index.php/Documentation
+All documentation for ZoneMinder is now online at https://zoneminder.readthedocs.org
 
 ## Overview
 


### PR DESCRIPTION
The wiki just ends up linking there