### PR TITLE
do not set maxfps fields during onvif probe

### DIFF
--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -242,8 +242,9 @@ else if($_REQUEST['step'] == "2")
        // copy technical details
        $monitor['Width']  = $profile['Width'];
        $monitor['Height'] = $profile['Height'];
-       $monitor['MaxFPS'] = $profile['MaxFPS'];
-       $monitor['AlarmMaxFPS'] = $profile['AlarmMaxFPS'];
+// The maxfps fields do not work for ip streams. Can re-enable if that is fixed.
+//       $monitor['MaxFPS'] = $profile['MaxFPS'];
+//       $monitor['AlarmMaxFPS'] = $profile['AlarmMaxFPS'];
        $monitor['Path'] = $profile['Path'];
 //       $sourceDesc = htmlspecialchars(serialize($monitor));
        $sourceDesc = base64_encode(serialize($monitor));


### PR DESCRIPTION
fixes #1350 

The maxfps fields do not work for ip streams. Consequently, we should not set these fields during an onvif probe.

This commit is basically a work around until the bigger issue of the maxfps fields is fixed.