### PR TITLE
Record h264 video without analysis

### DIFF
--- a/src/zm_camera.h
+++ b/src/zm_camera.h
@@ -80,7 +80,7 @@ public:
 	virtual int PreCapture()=0;
 	virtual int Capture( Image &image )=0;
 	virtual int PostCapture()=0;
-        virtual int CaptureAndRecord( Image &image, bool recording, char* event_directory)=0;
+        virtual int CaptureAndRecord( Image &image, int recording, char* event_directory)=0;
 };
 
 #endif // ZM_CAMERA_H

--- a/src/zm_curl_camera.cpp
+++ b/src/zm_curl_camera.cpp
@@ -311,7 +311,7 @@ int cURLCamera::PostCapture()
     return( 0 );
 }
 
-int cURLCamera::CaptureAndRecord( Image &image, bool recording, char* event_directory )
+int cURLCamera::CaptureAndRecord( Image &image, int recording, char* event_directory )
 {
     // Nothing to do here
     return( 0 );

--- a/src/zm_curl_camera.h
+++ b/src/zm_curl_camera.h
@@ -79,7 +79,7 @@ public:
 	int PreCapture();
 	int Capture( Image &image );
 	int PostCapture();
-	int CaptureAndRecord( Image &image, bool recording, char* event_directory);
+	int CaptureAndRecord( Image &image, int recording, char* event_directory);
 
 
 	size_t data_callback(void *buffer, size_t size, size_t nmemb, void *userdata);

--- a/src/zm_ffmpeg_camera.h
+++ b/src/zm_ffmpeg_camera.h
@@ -86,7 +86,7 @@ public:
 	int PrimeCapture();
 	int PreCapture();
 	int Capture( Image &image );
-        int CaptureAndRecord( Image &image, bool recording, char* event_directory );
+        int CaptureAndRecord( Image &image, int recording, char* event_directory );
 	int PostCapture();
 };
 

--- a/src/zm_file_camera.h
+++ b/src/zm_file_camera.h
@@ -46,7 +46,7 @@ public:
 	int PreCapture();
 	int Capture( Image &image );
 	int PostCapture();
-        int CaptureAndRecord( Image &image, bool recording, char* event_directory ) {return(0);};
+        int CaptureAndRecord( Image &image, int recording, char* event_directory ) {return(0);};
 };
 
 #endif // ZM_FILE_CAMERA_H

--- a/src/zm_libvlc_camera.cpp
+++ b/src/zm_libvlc_camera.cpp
@@ -212,7 +212,7 @@ int LibvlcCamera::Capture( Image &image )
 }
 
 // Should not return -1 as cancels capture. Always wait for image if available.
-int LibvlcCamera::CaptureAndRecord( Image &image, bool recording, char* event_directory )
+int LibvlcCamera::CaptureAndRecord( Image &image, int recording, char* event_directory )
 {
     while(!mLibvlcData.newImage.getValueImmediate())
         mLibvlcData.newImage.getUpdatedValue(1);

--- a/src/zm_libvlc_camera.h
+++ b/src/zm_libvlc_camera.h
@@ -70,7 +70,7 @@ public:
 	int PrimeCapture();
 	int PreCapture();
 	int Capture( Image &image );
-        int CaptureAndRecord( Image &image, bool recording, char* event_directory );
+        int CaptureAndRecord( Image &image, int recording, char* event_directory );
 	int PostCapture();
 };
 

--- a/src/zm_local_camera.h
+++ b/src/zm_local_camera.h
@@ -138,7 +138,7 @@ public:
 	int PreCapture();
 	int Capture( Image &image );
 	int PostCapture();
-    	int CaptureAndRecord( Image &image, bool recording, char* event_directory ) {return(0);};
+    	int CaptureAndRecord( Image &image, int recording, char* event_directory ) {return(0);};
 
 	static bool GetCurrentSettings( const char *device, char *output, int version, bool verbose );
 };

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -382,6 +382,10 @@ public:
 	{
 		return( embed_exif );
 	}
+	inline bool RecordOnly()
+	{
+		return ( function == RECORD && GetOptVideoWriter() == 2 );
+	}
 
 	unsigned int Width() const { return( width ); }
 	unsigned int Height() const { return( height ); }

--- a/src/zm_remote_camera.h
+++ b/src/zm_remote_camera.h
@@ -73,7 +73,7 @@ public:
 	virtual int PreCapture() = 0;
 	virtual int Capture( Image &image ) = 0;
 	virtual int PostCapture() = 0;
-    	virtual int CaptureAndRecord( Image &image, bool recording, char* event_directory )=0;
+    	virtual int CaptureAndRecord( Image &image, int recording, char* event_directory )=0;
 };
 
 #endif // ZM_REMOTE_CAMERA_H

--- a/src/zm_remote_camera_http.h
+++ b/src/zm_remote_camera_http.h
@@ -58,7 +58,7 @@ public:
 	int PreCapture();
 	int Capture( Image &image );
 	int PostCapture();
-    	int CaptureAndRecord( Image &image, bool recording, char* event_directory ) {return(0);};
+    	int CaptureAndRecord( Image &image, int recording, char* event_directory ) {return(0);};
 };
 
 #endif // ZM_REMOTE_CAMERA_HTTP_H

--- a/src/zm_remote_camera_rtsp.h
+++ b/src/zm_remote_camera_rtsp.h
@@ -79,7 +79,7 @@ public:
 	int PreCapture();
 	int Capture( Image &image );
 	int PostCapture();
-    	int CaptureAndRecord( Image &image, bool recording, char* event_directory ) {return(0);};
+    	int CaptureAndRecord( Image &image, int recording, char* event_directory ) {return(0);};
 };
 
 #endif // ZM_REMOTE_CAMERA_RTSP_H


### PR DESCRIPTION
This pull request disables frame decoding if monitor type == RECORD and h264 passthrough recording is enabled. This brings down CPU load to 1-2% compared to 40-50% for Full HD streams on my processor. To do so:
- I changed CaptureAndRecord in zm_ffmpeg_camera
- I changed the protoype to "int recording" instead of "bool recording" in Camera::CaptureAndRecord and patched all subclasses
- If recording == 2 in CaptureAndRecord, it means to disable frame decoding
- Patched CheckSignal to always return true if frame decoding is disabled or else no events would be created

Not sure if it would be best to add an explicit option to disable frame decoding or if type==RECORD and h264 passthrough enabled is enough.
