### PR TITLE
remove $result from onvif error message

### DIFF
--- a/onvif/scripts/zmonvif-probe.pl
+++ b/onvif/scripts/zmonvif-probe.pl
@@ -106,7 +106,7 @@ sub interpret_messages
     my $result = deserialize_message($svc_discover, $response);
     if(not $result) {
       if($verbose) {
-        print "Error deserializing message:\n" . $result . "\n";
+        print "Error deserializing message. No message returned from deserializer.\n";
       }
       next;
     }


### PR DESCRIPTION
This PR removes the $result variable from the error message, thus fixing the following warning returned from the script:
```
Use of uninitialized value $result in concatenation (.) or string at /bin/zmonvif-probe.pl line 109.
Error deserializing message:
```

At this point in the script, we have already established that $result is false, which means it won't contain anything interesting. Therefore, removing $result from the message seems to be the best approach.

