### PR TITLE
reload stream on scale change

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -37,9 +37,14 @@ function changeScale()
 
     /*Stream could be an applet so can't use moo tools*/ 
     var streamImg = document.getElementById('liveStream');
-    streamImg.style.width = newWidth + "px";
-    streamImg.style.height = newHeight + "px";
+    if ( streamImg ) {
+        streamImg.style.width = newWidth + "px";
+        streamImg.style.height = newHeight + "px";
 
+        streamImg.src = streamImg.src.replace(/scale=\d+/i,'scale='+scale);
+    } else {
+        console.error("No element found for liveStream.");
+    }
 }
 
 var alarmState = STATE_IDLE;


### PR DESCRIPTION
So at the moment, we just alter the DOM to scale the image, but in fact the stream is the same.

This change causes the image to reload with the new scale parameter.  