### PR TITLE
try to reload the image stream on error.

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -205,8 +205,13 @@ function getStreamCmdResponse( respObj, respText )
             $('enableDisableAlarms').removeClass( 'hidden' );
         }
     }
-    else
+    else {
         checkStreamForErrors("getStreamCmdResponse",respObj);//log them
+        // Try to reload the image stream.
+        var streamImg = document.getElementById('liveStream');
+        if ( streamImg )
+            streamImg.src = streamImg.src.replace(/rand=\d+/i,'rand='+Math.floor((Math.random() * 1000000) ));
+    }
 
     var streamCmdTimeout = statusRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )


### PR DESCRIPTION
So when zmc dies, zms dies, and so all the calls to get the fps, etc fail, etc.

This change causes the image to be reloaded when there is an error, so zms will get reloaded and the stream will start up again, and everything will be awesome.