### PR TITLE
Fix grant

### DIFF
--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -29,9 +29,9 @@ if [ "$1" = "configure" ]; then
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
                     # This creates the user.
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables, alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables, alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost;" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 fi
 
                 # Ensure zoneminder is stopped

--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -29,7 +29,7 @@ if [ "$1" = "configure" ]; then
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
                     # This creates the user.
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else
                     echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 fi

--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -10,7 +10,7 @@ if [ "$1" = "configure" ]; then
 	chown www-data:root /var/log/zm
 	chown www-data:www-data /var/lib/zm
 	if [ -z "$2" ]; then
-        chown www-data:www-data -R /var/cache/zoneminder
+        chown www-data:www-data /var/cache/zoneminder /var/cache/zoneminder/*
 	fi
 
     # Do this every time the package is installed or upgraded

--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -3,52 +3,51 @@
 set -e
 
 if [ "$1" = "configure" ]; then
-	if [ -e "/etc/init.d/mysql" ]; then 
-		#
-		# Get mysql started if it isn't
-		#
-		if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
-				invoke-rc.d mysql start
-		fi
-		if $(/etc/init.d/mysql status >/dev/null 2>&1); then
-			mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
-			# test if database if already present...
-			if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
-				cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
-				echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
-			fi
 
-			invoke-rc.d zoneminder stop || true
-			zmupdate.pl --nointeractive
-			zmupdate.pl --nointeractive -f
+    . /etc/zm/zm.conf
 
-		else
-			echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
-		fi
-	else 
-		echo 'mysql not found, assuming remote server.'
-	fi
-	chown www-data:www-data /var/log/zm
-	chown www-data:www-data /var/lib/zm/
+    # The logs can contain passwords, etc... so by setting group root, only www-data can read them, not people in the www-data group.
+	chown www-data:root /var/log/zm
+	chown www-data:www-data /var/lib/zm
 	if [ -z "$2" ]; then
-			chown www-data:www-data -R /var/cache/zoneminder
+        chown www-data:www-data -R /var/cache/zoneminder
 	fi
-fi
-# Ensure zoneminder is stopped...
-if [ -x "/etc/init.d/zoneminder" ]; then
-        if invoke-rc.d zoneminder status ; then
-                invoke-rc.d zoneminder stop || exit $?
+
+    # Do this every time the package is installed or upgraded
+
+    if [ "$ZM_DB_HOST" = "localhost" ]; then
+        if [ -e "/etc/init.d/mysql" ]; then 
+            #
+            # Get mysql started if it isn't
+            #
+            if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                    invoke-rc.d mysql start
+            fi
+            if $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
+                # test if database if already present...
+                if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
+                    cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+                    # This creates the user.
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                else
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                fi
+
+                # Ensure zoneminder is stopped
+                invoke-rc.d zoneminder stop || true
+                zmupdate.pl --nointeractive
+                zmupdate.pl --nointeractive -f
+                invoke-rc.d zoneminder start || true
+            else
+                echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+            fi
+        else 
+            echo 'mysql not found, assuming remote server.'
         fi
-fi
-
-if [ "$1" = "configure" ]; then
-	if [ -z "$2" ]; then
-		chown www-data:www-data /var/log/zm
-		chown www-data:www-data /var/lib/zm/
-		chown www-data:www-data -R /var/cache/zoneminder
     else
-		chown www-data:www-data /var/log/zm
-		zmupdate.pl
-	fi
+        echo "Not doing database upgrade due to remote db server ($ZM_DB_HOST)"
+    fi
+
 fi
 #DEBHELPER#

--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -15,11 +15,12 @@ if [ "$1" = "configure" ]; then
 			# test if database if already present...
 			if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
 				cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
-				echo 'grant lock tables, alter,select,insert,update,delete on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+				echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
 			fi
 
 			invoke-rc.d zoneminder stop || true
 			zmupdate.pl --nointeractive
+			zmupdate.pl --nointeractive -f
 
 		else
 			echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'

--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -29,9 +29,9 @@ if [ "$1" = "configure" ]; then
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
                     # This creates the user.
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables, alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables, alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost;" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 fi
 
                 # Ensure zoneminder is stopped

--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -3,11 +3,52 @@
 set -e
 
 if [ "$1" = "configure" ]; then
-		chown www-data:root /var/log/zm
-		chown www-data:www-data /var/lib/zm
-		if [ -z "$2" ]; then
-			chown www-data:www-data -R /var/cache/zoneminder
+	if [ -e "/etc/init.d/mysql" ]; then 
+		#
+		# Get mysql started if it isn't
+		#
+		if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
+				invoke-rc.d mysql start
 		fi
+		if $(/etc/init.d/mysql status >/dev/null 2>&1); then
+			mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
+			# test if database if already present...
+			if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
+				cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+				echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+			fi
+
+			invoke-rc.d zoneminder stop || true
+			zmupdate.pl --nointeractive
+			zmupdate.pl --nointeractive -f
+
+		else
+			echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+		fi
+	else 
+		echo 'mysql not found, assuming remote server.'
+	fi
+	chown www-data:www-data /var/log/zm
+	chown www-data:www-data /var/lib/zm/
+	if [ -z "$2" ]; then
+			chown www-data:www-data -R /var/cache/zoneminder
+	fi
+fi
+# Ensure zoneminder is stopped...
+if [ -x "/etc/init.d/zoneminder" ]; then
+        if invoke-rc.d zoneminder status ; then
+                invoke-rc.d zoneminder stop || exit $?
+        fi
+fi
+
+if [ "$1" = "configure" ]; then
+	if [ -z "$2" ]; then
+		chown www-data:www-data /var/log/zm
+		chown www-data:www-data /var/lib/zm/
+		chown www-data:www-data -R /var/cache/zoneminder
+    else
+		chown www-data:www-data /var/log/zm
+	fi
 fi
 
 #DEBHELPER#

--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -10,7 +10,7 @@ if [ "$1" = "configure" ]; then
     chown www-data:root /var/log/zm
     chown www-data:www-data /var/lib/zm
     if [ -z "$2" ]; then
-        chown www-data:www-data -R /var/cache/zoneminder
+        chown www-data:www-data /var/cache/zoneminder /var/cache/zoneminder/*
     fi
 
     # Do this every time the package is installed or upgraded

--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -3,52 +3,51 @@
 set -e
 
 if [ "$1" = "configure" ]; then
-	if [ -e "/etc/init.d/mysql" ]; then 
-		#
-		# Get mysql started if it isn't
-		#
-		if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
-				invoke-rc.d mysql start
-		fi
-		if $(/etc/init.d/mysql status >/dev/null 2>&1); then
-			mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
-			# test if database if already present...
-			if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
-				cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
-				echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
-			fi
 
-			invoke-rc.d zoneminder stop || true
-			zmupdate.pl --nointeractive
-			zmupdate.pl --nointeractive -f
+    . /etc/zm/zm.conf
 
-		else
-			echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
-		fi
-	else 
-		echo 'mysql not found, assuming remote server.'
-	fi
-	chown www-data:www-data /var/log/zm
-	chown www-data:www-data /var/lib/zm/
-	if [ -z "$2" ]; then
-			chown www-data:www-data -R /var/cache/zoneminder
-	fi
-fi
-# Ensure zoneminder is stopped...
-if [ -x "/etc/init.d/zoneminder" ]; then
-        if invoke-rc.d zoneminder status ; then
-                invoke-rc.d zoneminder stop || exit $?
+    # The logs can contain passwords, etc... so by setting group root, only www-data can read them, not people in the www-data group
+    chown www-data:root /var/log/zm
+    chown www-data:www-data /var/lib/zm
+    if [ -z "$2" ]; then
+        chown www-data:www-data -R /var/cache/zoneminder
+    fi
+
+    # Do this every time the package is installed or upgraded
+
+    if [ "$ZM_DB_HOST" = "localhost" ]; then
+        if [ -e "/etc/init.d/mysql" ]; then 
+            #
+            # Get mysql started if it isn't
+            #
+            if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                    invoke-rc.d mysql start
+            fi
+            if $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
+                # test if database if already present...
+                if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
+                    cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+                    # This creates the user.
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                else
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                fi
+
+                # Ensure zoneminder is stopped
+                invoke-rc.d zoneminder stop || true
+                zmupdate.pl --nointeractive
+                zmupdate.pl --nointeractive -f
+                invoke-rc.d zoneminder start || true
+            else
+                echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+            fi
+        else 
+            echo 'mysql not found, assuming remote server.'
         fi
-fi
-
-if [ "$1" = "configure" ]; then
-	if [ -z "$2" ]; then
-		chown www-data:www-data /var/log/zm
-		chown www-data:www-data /var/lib/zm/
-		chown www-data:www-data -R /var/cache/zoneminder
-    else
-		chown www-data:www-data /var/log/zm
-	fi
+    else 
+        echo "Not doing database upgrade due to remote db server ($ZM_DB_HOST)"
+    fi
 fi
 
 #DEBHELPER#

--- a/distros/ubuntu1504/zoneminder.postinst
+++ b/distros/ubuntu1504/zoneminder.postinst
@@ -2,9 +2,11 @@
 
 set -e
 
-. /etc/zm/zm.conf
-
 if [ "$1" = "configure" ]; then
+
+    . /etc/zm/zm.conf
+
+    # The logs can contain passwords, etc... so by setting group root, only www-data can read them, not people in the www-data group
     chown www-data:root /var/log/zm
     chown www-data:www-data /var/lib/zm
     if [ -z "$2" ]; then
@@ -12,36 +14,42 @@ if [ "$1" = "configure" ]; then
     fi
 
 	# Do this every time the package is installed or upgraded
-	# Test for database presence to avoid failure of zmupdate.pl
-
-    # Ensure zoneminder is stopped
-    deb-systemd-invoke stop zoneminder.service || exit $?
 
 	if [ "$ZM_DB_HOST" = "localhost" ]; then
-        #
-        # Get mysql started if it isn't
-        #
-        if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
-                invoke-rc.d mysql start
-        fi
-        if $(/etc/init.d/mysql status >/dev/null 2>&1); then
-            mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
-            # test if database if already present...
-            if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
-                cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
-                # This creates the user.
-                echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
-            else
-                echo 'grant lock tables, create, index, alter on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+
+        if [ -e "/etc/init.d/mysql" ]; then
+
+            #
+            # Get mysql started if it isn't
+            #
+            if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                deb-systemd-invoke start mysql.service || exit $?
             fi
 
-            invoke-rc.d zoneminder stop || true
-            zmupdate.pl --nointeractive
-            zmupdate.pl --nointeractive -f
+            if $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
+                # test if database if already present...
+                if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
+                    cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+                    # This creates the user.
+                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                else
+                    echo 'grant lock tables, alter,select,insert,update,deletecreate, index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                fi
 
+                # Ensure zoneminder is stopped
+                deb-systemd-invoke stop zoneminder.service || exit $?
+                zmupdate.pl --nointeractive
+                zmupdate.pl --nointeractive -f
+                deb-systemd-invoke start zoneminder.service || exit $?
+
+            else
+                echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+            fi
         else
-            echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+            echo 'mysql not found, assuming remote server.'
         fi
+
     else
 		echo "Not doing database upgrade due to remote db server ($ZM_DB_HOST)"
     fi

--- a/distros/ubuntu1504/zoneminder.postinst
+++ b/distros/ubuntu1504/zoneminder.postinst
@@ -32,9 +32,9 @@ if [ "$1" = "configure" ]; then
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
                     # This creates the user.
-                    echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo 'grant lock tables,alter,select,insert,update,delete,create,index on $ZM_DB_NAME.* to '$ZM_DB_USER'@localhost identified by "$ZM_DB_PASS";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else
-                    echo 'grant lock tables, alter,select,insert,update,deletecreate, index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo 'grant lock tables,alter,select,insert,update,delete,create,index on $ZM_DB_NAME.* to '$ZM_DB_USER'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 fi
 
                 # Ensure zoneminder is stopped

--- a/distros/ubuntu1504/zoneminder.postinst
+++ b/distros/ubuntu1504/zoneminder.postinst
@@ -10,7 +10,7 @@ if [ "$1" = "configure" ]; then
     chown www-data:root /var/log/zm
     chown www-data:www-data /var/lib/zm
     if [ -z "$2" ]; then
-        chown www-data:www-data -R /var/cache/zoneminder
+        chown www-data:www-data /var/cache/zoneminder /var/cache/zoneminder/*
     fi
 
 	# Do this every time the package is installed or upgraded

--- a/distros/ubuntu1504/zoneminder.postinst
+++ b/distros/ubuntu1504/zoneminder.postinst
@@ -32,9 +32,9 @@ if [ "$1" = "configure" ]; then
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
                     # This creates the user.
-                    echo 'grant lock tables,alter,select,insert,update,delete,create,index on $ZM_DB_NAME.* to '$ZM_DB_USER'@localhost identified by "$ZM_DB_PASS";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables,alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else
-                    echo 'grant lock tables,alter,select,insert,update,delete,create,index on $ZM_DB_NAME.* to '$ZM_DB_USER'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+                    echo "grant lock tables,alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost;" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 fi
 
                 # Ensure zoneminder is stopped

--- a/distros/ubuntu1504/zoneminder.postinst
+++ b/distros/ubuntu1504/zoneminder.postinst
@@ -5,11 +5,11 @@ set -e
 . /etc/zm/zm.conf
 
 if [ "$1" = "configure" ]; then
-		chown www-data:root /var/log/zm
-		chown www-data:www-data /var/lib/zm
-		if [ -z "$2" ]; then
-			chown www-data:www-data -R /var/cache/zoneminder
-		fi
+    chown www-data:root /var/log/zm
+    chown www-data:www-data /var/lib/zm
+    if [ -z "$2" ]; then
+        chown www-data:www-data -R /var/cache/zoneminder
+    fi
 
 	# Do this every time the package is installed or upgraded
 	# Test for database presence to avoid failure of zmupdate.pl
@@ -18,12 +18,33 @@ if [ "$1" = "configure" ]; then
     deb-systemd-invoke stop zoneminder.service || exit $?
 
 	if [ "$ZM_DB_HOST" = "localhost" ]; then
-		echo 'grant lock tables, create, index, alter on zm.* to 'zmuser'@localhost identified by "zmpass";' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
-		# Run the ZoneMinder update tool
-		zmupdate.pl --nointeractive
-	else
+        #
+        # Get mysql started if it isn't
+        #
+        if ! $(/etc/init.d/mysql status >/dev/null 2>&1); then
+                invoke-rc.d mysql start
+        fi
+        if $(/etc/init.d/mysql status >/dev/null 2>&1); then
+            mysqladmin --defaults-file=/etc/mysql/debian.cnf -f reload
+            # test if database if already present...
+            if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
+                cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+                # This creates the user.
+                echo 'grant lock tables, alter,select,insert,update,delete,create,index on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+            else
+                echo 'grant lock tables, create, index, alter on zm.* to 'zmuser'@localhost;' | mysql --defaults-file=/etc/mysql/debian.cnf mysql
+            fi
+
+            invoke-rc.d zoneminder stop || true
+            zmupdate.pl --nointeractive
+            zmupdate.pl --nointeractive -f
+
+        else
+            echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
+        fi
+    else
 		echo "Not doing database upgrade due to remote db server ($ZM_DB_HOST)"
- 	fi;
+    fi
 
 fi
 


### PR DESCRIPTION
I'm still doing some testing/further updates.

This PR adds code to the debian, ubuntu1204 and ubuntu1504 package dirs to do the following:
if the db is local, then check for the zm database and create it if it exists.  Also create the user with the required schema privileges.  Otherwise grant the required privileges to the user without specifying password (otherwise it will create a new user). 
Then run zmupdate.pl

I know debian has decided to go a different way with this stuff, but I don't think we have to do what debian says. I think this will make installs/updates much easier for the average user.

Thoughts?