### PR TITLE
Improved WS-Discovery standard compliance

### DIFF
--- a/onvif/modules/lib/WSDiscovery/TransportUDP.pm
+++ b/onvif/modules/lib/WSDiscovery/TransportUDP.pm
@@ -61,16 +61,19 @@ sub _notify_response
 }
 
 sub send_multi() {
-  my ($self, $address, $port, $data) = @_;
+  my ($self, $address, $port, $utf8_string) = @_;
 
   my $destination = $address . ':' . $port;
   my $socket = IO::Socket::Multicast->new(PROTO => 'udp', 
       LocalPort=>$port, PeerAddr=>$destination, ReuseAddr=>1)
       
       or die 'Cannot open multicast socket to ' . ${address} . ':' . ${port};
+
+  my $bytes = $utf8_string;
+  utf8::encode($bytes);
       
   $socket->mcast_ttl(1);
-  $socket->send($data);
+  $socket->send($bytes);
 }
 
 sub receive_multi() {

--- a/onvif/proxy/lib/WSDiscovery10/Elements/Header.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Elements/Header.pm
@@ -1,0 +1,55 @@
+
+package WSDiscovery10::Elements::Header;
+use strict;
+use warnings;
+
+
+__PACKAGE__->_set_element_form_qualified(0);
+
+sub get_xmlns { 'http://schemas.xmlsoap.org/soap/envelope/' };
+
+our $XML_ATTRIBUTE_CLASS;
+undef $XML_ATTRIBUTE_CLASS;
+
+sub __get_attr_class {
+    return $XML_ATTRIBUTE_CLASS;
+}
+
+use Class::Std::Fast::Storable constructor => 'none';
+use base qw(SOAP::WSDL::XSD::Typelib::ComplexType);
+
+Class::Std::initialize();
+
+{ # BLOCK to scope variables
+
+my %Action_of :ATTR(:get<Action>);
+my %MessageID_of :ATTR(:get<MessageID>);
+my %ReplyTo_of :ATTR(:get<ReplyTo>);
+my %To_of :ATTR(:get<To>);
+
+__PACKAGE__->_factory(
+    [ qw( Action MessageID ReplyTo To ) ],
+    {
+        'Action' => \%Action_of,
+        'MessageID' => \%MessageID_of,
+        'ReplyTo' => \%ReplyTo_of,
+        'To' => \%To_of,
+    },
+    {
+        'Action' => 'WSDiscovery10::Elements::Action',
+        'MessageID' => 'WSDiscovery10::Elements::MessageID',
+        'ReplyTo' => 'WSDiscovery10::Elements::ReplyTo',
+        'To' => 'WSDiscovery10::Elements::To',
+    },
+    {
+        'Action' => '',
+        'MessageID' => '',
+        'ReplyTo' => '',
+        'To' => '',
+    }
+);
+
+} # end BLOCK
+
+
+1;

--- a/onvif/proxy/lib/WSDiscovery10/Interfaces/WSDiscovery/WSDiscoveryPort.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Interfaces/WSDiscovery/WSDiscoveryPort.pm
@@ -37,7 +37,7 @@ sub ProbeOp {
             'use'           => 'literal',
             namespace       => 'http://schemas.xmlsoap.org/ws/2004/08/addressing',
             encodingStyle   => '',
-            parts           => [qw(WSDiscovery10::Elements::To WSDiscovery10::Elements::Action)],
+            parts           => [qw( WSDiscovery10::Elements::Header )],
  
         },
         headerfault => {

--- a/onvif/proxy/lib/WSDiscovery10/Interfaces/WSDiscovery/WSDiscoveryPort.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Interfaces/WSDiscovery/WSDiscoveryPort.pm
@@ -34,7 +34,11 @@ sub ProbeOp {
 
         },
         header => {
-            
+            'use'           => 'literal',
+            namespace       => 'http://schemas.xmlsoap.org/ws/2004/08/addressing',
+            encodingStyle   => '',
+            parts           => [qw(WSDiscovery10::Elements::To WSDiscovery10::Elements::Action)],
+ 
         },
         headerfault => {
             

--- a/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
@@ -25,10 +25,10 @@ our $typemap_1 = {
                'ProbeMatches/ProbeMatch/EndpointReference/ReferenceProperties' => 'WSDiscovery10::Types::ReferencePropertiesType',
                'ProbeMatches/ProbeMatch/EndpointReference/PortType' => 'WSDiscovery10::Types::AttributedQName'
                'MessageID' => 'WSDiscovery10::Elements::MessageID',
-               'RelatesTo' => '__SKIP__',
-               'To' => '__SKIP__',
-               'Action' => '__SKIP__',
-               'AppSequence' => '__SKIP__',
+               'RelatesTo' => 'WSDiscovery10::Elements::RelatesTo',
+               'To' => 'WSDiscovery10::Elements::To',
+               'Action' => 'WSDiscovery10::Elements::Action',
+               'AppSequence' => 'WSDiscovery10::Elements::AppSequence',
              };
 ;
 

--- a/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
@@ -23,12 +23,12 @@ our $typemap_1 = {
                'ProbeMatches/ProbeMatch/Types' => 'WSDiscovery10::Types::QNameListType',
                'ProbeMatches/ProbeMatch/EndpointReference' => 'WSDiscovery10::Types::EndpointReferenceType',
                'ProbeMatches/ProbeMatch/EndpointReference/ReferenceProperties' => 'WSDiscovery10::Types::ReferencePropertiesType',
-               'ProbeMatches/ProbeMatch/EndpointReference/PortType' => 'WSDiscovery10::Types::AttributedQName'
-               'MessageID' => 'WSDiscovery10::Elements::MessageID',
-               'RelatesTo' => 'WSDiscovery10::Elements::RelatesTo',
-               'To' => 'WSDiscovery10::Elements::To',
-               'Action' => 'WSDiscovery10::Elements::Action',
-               'AppSequence' => 'WSDiscovery10::Elements::AppSequence',
+               'ProbeMatches/ProbeMatch/EndpointReference/PortType' => 'WSDiscovery10::Types::AttributedQName',
+               'MessageID' => '__SKIP__',
+               'RelatesTo' => '__SKIP__',
+               'To' => '__SKIP__',
+               'Action' => '__SKIP__',
+               'AppSequence' => '__SKIP__',
              };
 ;
 

--- a/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Typemaps/WSDiscovery.pm
@@ -24,6 +24,11 @@ our $typemap_1 = {
                'ProbeMatches/ProbeMatch/EndpointReference' => 'WSDiscovery10::Types::EndpointReferenceType',
                'ProbeMatches/ProbeMatch/EndpointReference/ReferenceProperties' => 'WSDiscovery10::Types::ReferencePropertiesType',
                'ProbeMatches/ProbeMatch/EndpointReference/PortType' => 'WSDiscovery10::Types::AttributedQName'
+               'MessageID' => 'WSDiscovery10::Elements::MessageID',
+               'RelatesTo' => '__SKIP__',
+               'To' => '__SKIP__',
+               'Action' => '__SKIP__',
+               'AppSequence' => '__SKIP__',
              };
 ;
 

--- a/onvif/proxy/lib/WSDiscovery10/Types/ProbeType.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Types/ProbeType.pm
@@ -7,8 +7,10 @@ __PACKAGE__->_set_element_form_qualified(0);
 
 sub get_xmlns { 'http://schemas.xmlsoap.org/ws/2005/04/discovery' };
 
-our $XML_ATTRIBUTE_CLASS;
-undef $XML_ATTRIBUTE_CLASS;
+our $XML_ATTRIBUTE_CLASS = 'WSDiscovery10::Types::ProbeType::_ProbeType::XmlAttr';
+
+#our $XML_ATTRIBUTE_CLASS;
+#undef $XML_ATTRIBUTE_CLASS;
 
 sub __get_attr_class {
     return $XML_ATTRIBUTE_CLASS;
@@ -49,11 +51,55 @@ __PACKAGE__->_factory(
 } # end BLOCK
 
 
+package WSDiscovery10::Types::ProbeType::_ProbeType::XmlAttr;
+#use base qw(SOAP::WSDL::XSD::Typelib::ComplexType);
+use Class::Std::Fast::Storable constructor => 'none', cache => 1;
+use base qw(SOAP::WSDL::XSD::Typelib::Builtin::anySimpleType);
 
 
+{ # BLOCK to scope variables
 
+my %Attribs_of :ATTR(:get<Attribs>);
 
+sub new
+{
+  my $self = pop @{ Class::Std::Fast::OBJECT_CACHE_REF()->{ $_[0] } };
+  $self = bless \(my $o = Class::Std::Fast::ID()), $_[0]
+        if not defined $self;
+        
+  $self->BUILD(${$self}, $_[1]);
 
+  return $self;      
+}
+
+sub BUILD 
+{
+  my ($self, $ident, $arg_ref) = @_;
+
+  $Attribs_of{$ident} = $arg_ref;
+}
+
+# without this no attributes are serialized
+# SOAP::WSDL::XSD::Typelib::CompexType sub serialize_attr()
+
+sub as_bool :BOOLIFY { 1 }
+
+sub serialize() 
+{
+  my $ident = ${ $_[0] };
+  my $option_ref = $_[1];
+  my $attr_str = "";
+
+  foreach my $attr (keys %{$Attribs_of{$ident}})
+  {
+    my $value = %{$Attribs_of{$ident}}{$attr};
+    $attr_str .= " $attr=\"$value\"";
+  }
+  
+  return $attr_str;
+}
+
+} # end BLOCK
 
 1;
 

--- a/onvif/scripts/zmonvif-probe.pl
+++ b/onvif/scripts/zmonvif-probe.pl
@@ -212,7 +212,9 @@ sub discover
 
   $result = $svc_discover->ProbeOp(
     { # WSDiscovery::Types::ProbeType
-      Types => 'http://www.onvif.org/ver10/network/wsdl:NetworkVideoTransmitter http://www.onvif.org/ver10/device/wsdl:Device', # QNameListType
+      xmlattr => { 'xmlns:dn'  => 'http://www.onvif.org/ver10/network/wsdl',
+                   'xmlns:tds' => 'http://www.onvif.org/ver10/device/wsdl', },
+      Types => 'dn:NetworkVideoTransmitter tds:Device', # QNameListType
       Scopes =>  { value => '' },
     },
     WSDiscovery10::Elements::Header->new({


### PR DESCRIPTION
Some small changes to WS-Discovery Probe message for #1346 . As far as I can tell the resulting messages contain all the mandatory elements.
New: dependence on perl module Data::UUID