### PR TITLE
make cannot write to content dir an error, rather than fatal

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -143,7 +143,7 @@ CORSHeaders();
 // Check for valid content dirs
 if ( !is_writable(ZM_DIR_EVENTS) || !is_writable(ZM_DIR_IMAGES) )
 {
-	Fatal( "Cannot write to content dirs('".ZM_DIR_EVENTS."','".ZM_DIR_IMAGES."').  Check that these exist and are owned by the web account user");
+	Error( "Cannot write to content dirs('".ZM_DIR_EVENTS."','".ZM_DIR_IMAGES."').  Check that these exist and are owned by the web account user");
 }
 
 if ( isset($_REQUEST['view']) )


### PR DESCRIPTION
If under Options the end user enters an invalid path for either the events or images folders, the system is put into a catch 22. A fatal error is presented to the end user, but since it is fatal, the end user cannot proceed to fix the problem.  

I have changed the level of the message from Fatal to an Error. This should allow the end user to navigate to Options and fix the problem.