### PR TITLE
remove the if(pages>1) so that the if  >  line always happens

### DIFF
--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -66,13 +66,11 @@ if ( !empty($limit) && $nEvents > $limit )
     $nEvents = $limit;
 }
 $pages = (int)ceil($nEvents/ZM_WEB_EVENTS_PER_PAGE);
-if ( $pages > 1 ) {
-    if ( !empty($page) ) {
-        if ( $page < 0 )
-            $page = 1;
-        if ( $page > $pages )
-            $page = $pages;
-    }
+if ( !empty($page) ) {
+    if ( $page < 0 )
+        $page = 1;
+    if ( $page > $pages )
+        $page = $pages;
 }
 if ( !empty($page) ) {
     $limitStart = (($page-1)*ZM_WEB_EVENTS_PER_PAGE);


### PR DESCRIPTION
So if you are viewing page 2, then change the filter to only have 1 page, you will get no results.

This removes the test for if $pages > 1 so that the if $page > $pages line always happens and $page will get adjusted to the first and only page.