### PR TITLE
add jscalendar as a submodule, modify rpm specfiles

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = web/api/app/Plugin/Crud
 	url = https://github.com/FriendsOfCake/crud.git
 	branch = 3.0
+[submodule "web/tools/jscalendar"]
+	path = web/tools/jscalendar
+	url = https://github.com/virasak/jscalendar

--- a/distros/fedora/CMakeLists.txt
+++ b/distros/fedora/CMakeLists.txt
@@ -9,16 +9,6 @@ configure_file(zoneminder.conf.in ${CMAKE_CURRENT_SOURCE_DIR}/zoneminder.conf @O
 configure_file(zoneminder.tmpfiles.in ${CMAKE_CURRENT_SOURCE_DIR}/zoneminder.tmpfiles @ONLY)
 configure_file(zoneminder.logrotate.in ${CMAKE_CURRENT_SOURCE_DIR}/zoneminder.logrotate @ONLY)
 
-# Download jscalendar & move files into position
-file(DOWNLOAD http://iweb.dl.sourceforge.net/project/jscalendar/jscalendar/1.0/jscalendar-1.0.zip ${CMAKE_CURRENT_SOURCE_DIR}/jscalendar-1.0.zip STATUS download_jsc)
-if(download_jsc EQUAL 0)
-message(STATUS "Jscalander successfully downloaded.  Installing...")
-execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/jscalendar.sh WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} ERROR_VARIABLE unzip_jsc)
-message(STATUS "Status of jscalender script was: ${unzip_jsc}")
-else(download_jsc EQUAL 0)
-message(STATUS "Unable to download optional jscalander. Skipping...")
-endif(download_jsc EQUAL 0)
-
 # Create several empty folders
 file(MAKE_DIRECTORY sock swap zoneminder zoneminder-upload events images temp)
 
@@ -46,7 +36,3 @@ install(FILES ../../misc/zoneminder-tmpfiles.conf DESTINATION /etc/tmpfiles.d RE
 install(FILES redalert.wav DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/zoneminder/www/sounds PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 install(FILES zoneminder.service DESTINATION /usr/lib/systemd/system PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-# Install jscalendar
-if(unzip_jsc STREQUAL "")
-install(DIRECTORY jscalendar-1.0/ DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/zoneminder/www/tools/jscalendar)
-endif(unzip_jsc STREQUAL "")

--- a/distros/fedora/zoneminder.f23.spec
+++ b/distros/fedora/zoneminder.f23.spec
@@ -147,7 +147,7 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%doc AUTHORS COPYING README.md distros/fedora/README.Fedora distros/fedora/README.https distros/fedora/jscalendar-doc
+%doc AUTHORS COPYING README.md distros/fedora/README.Fedora distros/fedora/README.https
 %config %attr(640,root,%{zmgid_final}) /etc/zm/zm.conf
 %config(noreplace) %attr(644,root,root) /etc/httpd/conf.d/zoneminder.conf
 %config(noreplace) /etc/tmpfiles.d/zoneminder.conf

--- a/distros/redhat/CMakeLists.txt
+++ b/distros/redhat/CMakeLists.txt
@@ -15,17 +15,6 @@ else(ZM_TARGET_DISTRO STREQUAL "el7")
 	configure_file(zoneminder.el6.conf.in ${CMAKE_CURRENT_SOURCE_DIR}/zoneminder.el6.conf @ONLY)
 endif(ZM_TARGET_DISTRO STREQUAL "el7")
 
-# Download jscalendar & move files into position
-file(DOWNLOAD http://iweb.dl.sourceforge.net/project/jscalendar/jscalendar/1.0/jscalendar-1.0.zip ${CMAKE_CURRENT_SOURCE_DIR}/jscalendar-1.0.zip LOG jsc_log STATUS download_jsc)
-#message(STATUS "Log of jscalender script was: ${jsc_log}")
-if(download_jsc EQUAL 0)
-	message(STATUS "Jscalander successfully downloaded.  Installing...")
-	execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/jscalendar.sh WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} ERROR_VARIABLE unzip_jsc)
-	message(STATUS "Status of jscalender script was: ${unzip_jsc}")
-else(download_jsc EQUAL 0)
-	message(STATUS "Unable to download optional jscalander. Skipping...")
-endif(download_jsc EQUAL 0)
-
 # Cambozola is now packaged in zmrepo
 # Download cambozola & move files into position
 #file(DOWNLOAD http://www.andywilcock.com/code/cambozola/cambozola-0.931.tar.gz ${CMAKE_CURRENT_SOURCE_DIR}/cambozola-0.931.tar.gz STATUS download_camb)
@@ -69,11 +58,6 @@ else(ZM_TARGET_DISTRO STREQUAL "el7")
 	install(FILES zoneminder.el6.logrotate DESTINATION /etc/logrotate.d RENAME zoneminder PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 	install(FILES zoneminder.sysvinit DESTINATION /etc/rc.d/init.d RENAME zoneminder PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 endif(ZM_TARGET_DISTRO STREQUAL "el7")
-
-# Install jscalendar
-if(unzip_jsc STREQUAL "")
-	install(DIRECTORY jscalendar-1.0/ DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/zoneminder/www/tools/jscalendar)
-endif(unzip_jsc STREQUAL "")
 
 # Install cambozola
 if(untar_camb STREQUAL "")

--- a/distros/redhat/zoneminder.el6.spec
+++ b/distros/redhat/zoneminder.el6.spec
@@ -135,7 +135,7 @@ rm -rf %{_docdir}/%{name}-%{version}
 
 %files
 %defattr(-,root,root,-)
-%doc AUTHORS BUGS ChangeLog COPYING LICENSE NEWS README.md distros/redhat/README.CentOS distros/redhat/README.https distros/redhat/jscalendar-doc
+%doc AUTHORS BUGS ChangeLog COPYING LICENSE NEWS README.md distros/redhat/README.CentOS distros/redhat/README.https
 %doc distros/redhat/local_zoneminder.te
 %config %attr(640,root,%{zmgid_final}) %{_sysconfdir}/zm.conf
 %config(noreplace) %attr(644,root,root) %{_sysconfdir}/httpd/conf.d/zoneminder.conf

--- a/distros/redhat/zoneminder.el7.spec
+++ b/distros/redhat/zoneminder.el7.spec
@@ -142,7 +142,7 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%doc AUTHORS BUGS ChangeLog COPYING LICENSE NEWS README.md distros/redhat/README.Centos7 distros/redhat/README.https distros/redhat/jscalendar-doc
+%doc AUTHORS BUGS ChangeLog COPYING LICENSE NEWS README.md distros/redhat/README.Centos7 distros/redhat/README.https
 %doc distros/redhat/local_zoneminder.te
 %config %attr(640,root,%{zmgid_final}) /etc/zm/zm.conf
 %config(noreplace) %attr(644,root,root) /etc/httpd/conf.d/zoneminder.conf


### PR DESCRIPTION
The ZoneMinder Filter view has an undocumented feature which supports integration of jscalendar:
https://github.com/ZoneMinder/ZoneMinder/blob/master/web/skins/classic/views/filter.php#L135

What this does is popup a small, graphical calendar when clicking in the date field:
![screenshot from 2016-04-20 12-28-06](https://cloud.githubusercontent.com/assets/5150042/14684023/74ee26bc-06f3-11e6-9ed7-78106164b6d1.png)

Previously, I have been adding this support into all the rpms I build. During buildtime, jscalendar would be downloaded and merged into the build root. I'd like to get away from that and instead use a git submodule. This also has the benefit of giving this feature to all ZoneMinder users, rather than just those who use my rpms.