### PR TITLE
Update do_debian_package.sh to let a dev. make quick local mods

### DIFF
--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -37,6 +37,8 @@ if [ "$BRANCH" != "" ]; then
 	git checkout $BRANCH
 	cd ../
 fi;
+# lets leave a hook for local modifications
+read -p "ZoneMinder repo cloned. Press any key to continue..."
 VERSION=`cat zoneminder_release/version`
 if [ $VERSION == "" ]; then
 	exit 1;


### PR DESCRIPTION
Add a read key right after the repo is cloned, so developers can make quick changes in another window and have them incorporated in the build process. If we don't do this, the only way is to do a do_debian, leave the repo at the end, make mods and do_debian again. This little hook lets me make local changes the first time in another terminal window.