### PR TITLE
unbreak build under FreeBSD 32 bit

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -660,7 +660,7 @@ void Event::AddFrame( Image *image, struct timeval timestamp, int score, Image *
     */
 }
 
-bool EventStream::loadInitialEventData( int monitor_id, time_t event_time )
+bool EventStream::loadInitialEventData( int monitor_id, long event_time )
 {
     static char sql[ZM_SQL_SML_BUFSIZ];
 

--- a/src/zm_event.h
+++ b/src/zm_event.h
@@ -231,7 +231,7 @@ protected:
 protected:
     bool loadEventData( int event_id );
     bool loadInitialEventData( int init_event_id, int init_frame_id );
-    bool loadInitialEventData( int monitor_id, time_t event_time );
+    bool loadInitialEventData( int monitor_id, long event_time );
 
     void checkEventLoaded();
     void processCommand( const CmdMsg *msg );
@@ -254,7 +254,7 @@ public:
         loadInitialEventData( init_event_id, init_frame_id );
         loadMonitor( event_data->monitor_id );
     }
-	void setStreamStart( int monitor_id, time_t event_time )
+	void setStreamStart( int monitor_id, long event_time )
     {
         loadInitialEventData( monitor_id, event_time );
         loadMonitor( monitor_id );


### PR DESCRIPTION
time_t under i386 FreeBSD is int, so we can't compile ZM, as compiler see 2 equal functions here. On x64 and linux time_t is long. Changing time_t to long solves the matter.