### PR TITLE
fix 'soc' issue under FreeBSD

### DIFF
--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -323,7 +323,11 @@ void StreamBase::openComms()
 
         strncpy( loc_addr.sun_path, loc_sock_path, sizeof(loc_addr.sun_path) );
         loc_addr.sun_family = AF_UNIX;
-        if ( bind( sd, (struct sockaddr *)&loc_addr, strlen(loc_addr.sun_path)+sizeof(loc_addr.sun_family)) < 0 )
+#ifdef __FreeBSD__		
+        if ( bind( sd, (struct sockaddr *)&loc_addr, strlen(loc_addr.sun_path)+sizeof(loc_addr.sun_family) + 1) < 0 )
+#else
+		if ( bind( sd, (struct sockaddr *)&loc_addr, strlen(loc_addr.sun_path)+sizeof(loc_addr.sun_family)) < 0 )
+#endif
         {
             Fatal( "Can't bind: %s", strerror(errno) );
         }


### PR DESCRIPTION
Hack :(
On FreeBSD sock files created without ending 'k', so they are not cleared at all.
https://github.com/ZoneMinder/ZoneMinder/issues/1424
I don't know why it's happening and I've got a little help from BSD folks. Maybe you can suggest better solution?