### PR TITLE
Adds logic to handle ports / unix socket

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -83,8 +83,25 @@ BEGIN
     close( $CONFIG );
 
     use DBI;
+    my $socket;
+    my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
+    if ( defined($portOrSocket) )
+    {
+        if ( $portOrSocket =~ /^[[:digit:]]+$/m )
+        {
+            $socket = ";host=".$host.";port=".$portOrSocket;
+        }
+        else
+        {
+            $socket = ";mysql_socket=".$portOrSocket;
+        }
+    }
+    else
+    {
+        $socket = ";$host=".$Config{ZM_DB_HOST};
+    }
     my $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
-                           .";host=".$Config{ZM_DB_HOST}
+                           .$socket
                            , $Config{ZM_DB_USER}
                            , $Config{ZM_DB_PASS}
     ) or croak( "Can't connect to db" );

--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -87,13 +87,13 @@ BEGIN
     my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
     if ( defined($portOrSocket) )
     {
-        if ( $portOrSocket =~ /^[[:digit:]]+$/m )
+        if ( $portOrSocket =~ /\// )
         {
-            $socket = ";host=".$host.";port=".$portOrSocket;
+            $socket = ";mysql_socket=".$portOrSocket;
         }
         else
         {
-            $socket = ";mysql_socket=".$portOrSocket;
+            $socket = ";host=".$host.";port=".$portOrSocket;
         }
     }
     else

--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -98,7 +98,7 @@ BEGIN
     }
     else
     {
-        $socket = ";$host=".$Config{ZM_DB_HOST};
+        $socket = ";host=".$Config{ZM_DB_HOST};
     }
     my $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
                            .$socket

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -83,13 +83,13 @@ sub zmDbConnect
         my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
         if ( defined($portOrSocket) )
         {
-            if ( $portOrSocket =~ /^[[:digit:]]+$/g )
+            if ( $portOrSocket =~ /\// )
             {
-                $socket = ";host=".$host.";port=".$portOrSocket;
+                $socket = ";mysql_socket=".$portOrSocket;
             }
             else
             {
-                $socket = ";mysql_socket=".$portOrSocket;
+                $socket = ";host=".$host.";port=".$portOrSocket;
             }
         }
         else

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -79,12 +79,13 @@ sub zmDbConnect
     }
     if ( !defined( $dbh ) )
     {
+        my $socket;
         my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
         if ( defined($portOrSocket) )
         {
-            if ( $portOrSocket =~ /^[[:digit:]]+$/ )
+            if ( $portOrSocket =~ /^[[:digit:]]+$/g )
             {
-                $socket = ";host=".host.";port=".$port;
+                $socket = ";host=".$host.";port=".$portOrSocket;
             }
             else
             {
@@ -93,7 +94,7 @@ sub zmDbConnect
         }
         else
         {
-            $socket = ";host=".$Config{ZM_DB_HOST};
+            $socket = ";$host=".$Config{ZM_DB_HOST};
         }
         $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
                             .$socket

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -79,25 +79,27 @@ sub zmDbConnect
     }
     if ( !defined( $dbh ) )
     {
-        my ( $host, $port ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
-
-        if ( defined($port) )
+        my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
+        if ( defined($portOrSocket) )
         {
-            $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
-                                .";host=".$host
-                                .";port=".$port
-                                , $Config{ZM_DB_USER}
-                                , $Config{ZM_DB_PASS}
-            );
+            if ( $portOrSocket =~ /^[[:digit:]]+$/ )
+            {
+                $socket = ";host=".host.";port=".$port;
+            }
+            else
+            {
+                $socket = ";mysql_socket=".$portOrSocket;
+            }
         }
         else
         {
-            $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
-                                .";host=".$Config{ZM_DB_HOST}
-                                , $Config{ZM_DB_USER}
-                                , $Config{ZM_DB_PASS}
-            );
+            $socket = ";host=".$Config{ZM_DB_HOST};
         }
+        $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
+                            .$socket
+                            , $Config{ZM_DB_USER}
+                            , $Config{ZM_DB_PASS}
+        );
         $dbh->trace( 0 );
     }
     return( $dbh );

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -94,7 +94,7 @@ sub zmDbConnect
         }
         else
         {
-            $socket = ";$host=".$Config{ZM_DB_HOST};
+            $socket = ";host=".$Config{ZM_DB_HOST};
         }
         $dbh = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
                             .$socket

--- a/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
@@ -460,25 +460,29 @@ sub databaseLevel
             {
                 if ( !$this->{dbh} )
                 {
-                    my ( $host, $port ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
+                    my $socket;
+                    my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
 
-                    if ( defined($port) )
+                    if ( defined($portOrSocket) )
                     {
-                        $this->{dbh} = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
-                                                    .";host=".$host
-                                                    .";port=".$port
-                                                    , $Config{ZM_DB_USER}
-                                                    , $Config{ZM_DB_PASS}
-                        );
+                        if ( $portOrSocket =~ /^[[:digit:]]+$/m )
+                        {
+                            $socket = ";host=".$host.";port=".$portOrSocket;
+                        }
+                        else
+                        {
+                            $socket = ";mysql_socket=".$portOrSocket;
+                        }
                     }
                     else
                     {
-                        $this->{dbh} = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
-                                                    .";host=".$Config{ZM_DB_HOST}
-                                                    , $Config{ZM_DB_USER}
-                                                    , $Config{ZM_DB_PASS}
-                        );
+                        $socket = ";$host=".$Config{ZM_DB_HOST};
                     }
+                    $this->{dbh} = DBI->connect( "DBI:mysql:database=".$Config{ZM_DB_NAME}
+                                                 .$socket
+                                                 , $Config{ZM_DB_USER}
+                                                 , $Config{ZM_DB_PASS}
+                    );
                     if ( !$this->{dbh} )
                     {
                         $databaseLevel = NOLOG;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
@@ -465,13 +465,13 @@ sub databaseLevel
 
                     if ( defined($portOrSocket) )
                     {
-                        if ( $portOrSocket =~ /^[[:digit:]]+$/m )
+                        if ( $portOrSocket =~ /\// )
                         {
-                            $socket = ";host=".$host.";port=".$portOrSocket;
+                            $socket = ";mysql_socket=".$portOrSocket;
                         }
                         else
                         {
-                            $socket = ";mysql_socket=".$portOrSocket;
+                            $socket = ";host=".$host.";port=".$portOrSocket;
                         }
                     }
                     else

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -37,12 +37,10 @@ void zmDbConnect()
   my_bool reconnect = 1;
   if ( mysql_options( &dbconn, MYSQL_OPT_RECONNECT, &reconnect ) )
     Fatal( "Can't set database auto reconnect option: %s", mysql_error( &dbconn ) );
-  std::string::size_type colonIndex = staticConfig.DB_HOST.find( ":/" );
-  if ( colonIndex != std::string::npos )
+  std::string::size_type colonIndex = staticConfig.DB_HOST.find( ":" );
+  if ( colonIndex == std::string::npos )
   {
-    std::string dbHost = staticConfig.DB_HOST.substr( 0, colonIndex );
-    std::string dbPort = staticConfig.DB_HOST.substr( colonIndex+1 );
-    if ( !mysql_real_connect( &dbconn, dbHost.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), 0, atoi(dbPort.c_str()), 0, 0 ) )
+    if ( !mysql_real_connect( &dbconn, staticConfig.DB_HOST.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, 0, NULL, 0 ) )
     {
       Error( "Can't connect to server: %s", mysql_error( &dbconn ) );
       exit( mysql_errno( &dbconn ) );
@@ -50,10 +48,23 @@ void zmDbConnect()
   }
   else
   {
-    if ( !mysql_real_connect( &dbconn, staticConfig.DB_HOST.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), 0, 0, 0, 0 ) )
+    std::string dbHost = staticConfig.DB_HOST.substr( 0, colonIndex );
+    std::string dbPortOrSocket = staticConfig.DB_HOST.substr( colonIndex+1 );
+    if ( dbPortOrSocket.find( "/" ) == std::string::npos )
     {
-      Error( "Can't connect to server: %s", mysql_error( &dbconn ) );
-      exit( mysql_errno( &dbconn ) );
+      if ( !mysql_real_connect( &dbconn, dbHost.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, atoi(dbPortOrSocket.c_str()), NULL, 0 ) )
+      {
+        Error( "Can't connect to server: %s", mysql_error( &dbconn ) );
+        exit( mysql_errno( &dbconn ) );
+      }  
+    }
+    else
+    {
+      if ( !mysql_real_connect( &dbconn, dbHost.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, 0, dbPortOrSocket.c_str(), 0 ) )
+      {
+        Error( "Can't connect to server: %s", mysql_error( &dbconn ) );
+        exit( mysql_errno( &dbconn ) );
+      }
     }
   }
   if ( mysql_select_db( &dbconn, staticConfig.DB_NAME.c_str() ) )

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -30,8 +30,20 @@ function dbConnect()
 {
     global $dbConn;
 
+	if (strpos(ZM_DB_HOST, ':')) {
+		// Host variable may carry a port or socket.
+		list($host, $portOrSocket) = explode(':', ZM_DB_HOST, 2);
+			if (is_numeric($portOrSocket)) {
+				$socket = ':host='.$host . ';port='.$portOrSocket;
+			} else {
+				$socket = ':unix_socket='.$portOrSocket;
+			}
+	} else {
+		$socket = ':host='.ZM_DB_HOST;
+	}
+
 	try {
-		$dbConn = new PDO( ZM_DB_TYPE . ':host=' . ZM_DB_HOST . ';dbname='.ZM_DB_NAME, ZM_DB_USER, ZM_DB_PASS );
+		$dbConn = new PDO( ZM_DB_TYPE . $socket . ';dbname='.ZM_DB_NAME, ZM_DB_USER, ZM_DB_PASS );
 		$dbConn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 	} catch(PDOException $ex ) {
 		echo "Unable to connect to ZM db." . $ex->getMessage();


### PR DESCRIPTION
Logic is added to handle ports / unix file sockets for database connection.

For example the following now all work as expected
```
ZM_DB_HOST=localhost
ZM_DB_HOST=REMOTE_HOST:1234
ZM_DB_HOST=localhost:/path/to/non-default.sock
```

Fixes https://github.com/ZoneMinder/ZoneMinder/issues/901