### PR TITLE
when value to be stored is undefined or '', then set the field=NULL

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -792,7 +792,11 @@ function getFormChanges( $values, $newValues, $types=false, $columns=false )
             {
                 if ( !isset($values[$key]) || ($values[$key] != $value) )
                 {
+                    if ( ! isset($value) || $value == '' ) {
+                    $changes[$key] = "$key = NULL";
+                    } else {
                     $changes[$key] = "$key = ".dbEscape(trim($value));
+                   }
                 }
                 break;
             }


### PR DESCRIPTION
This is a solution to mysql5.7 strict mode.  

It is not ideal, as it may cause fields to be set to NULL that are NOT NULL by design.
