### PR TITLE
quick fix for gcc6

### DIFF
--- a/src/zm_rtp_ctrl.h
+++ b/src/zm_rtp_ctrl.h
@@ -123,7 +123,7 @@ private:
       } sdes;
 
       // BYE
-      struct Bye
+      struct
       {
         uint32_t srcN[];   // list of sources
         // can't express trailing text for reason (what does this mean? it's not even english!)


### PR DESCRIPTION
fixes #1464 

It's a simple struct, I guess if we don't name it the compiler doesn't care about it.  I'm not sure why it needs to be in a struct to begin with.

