### PR TITLE
Add support for port/socket

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -80,25 +80,29 @@ sub zmDbConnect
     }
     if ( !defined( $dbh ) )
     {
-        my ( $host, $port ) = ( $ZoneMinder::Config::Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
+        my $socket;
+        my ( $host, $portOrSocket ) = ( $ZoneMinder::Config::Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
 
-        if ( defined($port) )
+        if ( defined($portOrSocket) )
         {
-            $dbh = DBI->connect( "DBI:mysql:database=".$ZoneMinder::Config::Config{ZM_DB_NAME}
-                                .";host=".$host
-                                .";port=".$port
-                                , $ZoneMinder::Config::Config{ZM_DB_USER}
-                                , $ZoneMinder::Config::Config{ZM_DB_PASS}
-            );
+            if ( $portOrSocket =~ /^\// )
+            {
+                $socket = ";mysql_socket=".$portOrSocket;
+            }
+            else
+            {
+                $socket = ";host=".$host.";port=".$portOrSocket;
+            }
         }
         else
         {
-            $dbh = DBI->connect( "DBI:mysql:database=".$ZoneMinder::Config::Config{ZM_DB_NAME}
-                                .";host=".$ZoneMinder::Config::Config{ZM_DB_HOST}
-                                , $ZoneMinder::Config::Config{ZM_DB_USER}
-                                , $ZoneMinder::Config::Config{ZM_DB_PASS}
-            );
+            $socket = ";host=".$ZoneMinder::Config::Config{ZM_DB_HOST};
         }
+        $dbh = DBI->connect( "DBI:mysql:database=".$ZoneMinder::Config::Config{ZM_DB_NAME}
+                            .$socket
+                            , $ZoneMinder::Config::Config{ZM_DB_USER}
+                            , $ZoneMinder::Config::Config{ZM_DB_PASS}
+        );
         $dbh->trace( 0 );
     }
     return( $dbh );

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -57,7 +57,6 @@ void zmDbConnect()
         Error( "Can't connect to server: %s", mysql_error( &dbconn ) );
         exit( mysql_errno( &dbconn ) );
       }
-
     }
     else
     {

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -367,12 +367,10 @@ Logger::Level Logger::databaseLevel( Logger::Level databaseLevel )
           my_bool reconnect = 1;
           if ( mysql_options( &mDbConnection, MYSQL_OPT_RECONNECT, &reconnect ) )
             Fatal( "Can't set database auto reconnect option: %s", mysql_error( &mDbConnection ) );
-          std::string::size_type colonIndex = staticConfig.DB_HOST.find( ":/" );
-          if ( colonIndex != std::string::npos )
+          std::string::size_type colonIndex = staticConfig.DB_HOST.find( ":" );
+          if ( colonIndex == std::string::npos )
           {
-            std::string dbHost = staticConfig.DB_HOST.substr( 0, colonIndex );
-            std::string dbPort = staticConfig.DB_HOST.substr( colonIndex+1 );
-            if ( !mysql_real_connect( &mDbConnection, dbHost.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), 0, atoi(dbPort.c_str()), 0, 0 ) )
+            if ( !mysql_real_connect( &mDbConnection, staticConfig.DB_HOST.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, 0, NULL, 0 ) ) 
             {
               Fatal( "Can't connect to database: %s", mysql_error( &mDbConnection ) );
               exit( mysql_errno( &mDbConnection ) );
@@ -380,10 +378,23 @@ Logger::Level Logger::databaseLevel( Logger::Level databaseLevel )
           }
           else
           {
-            if ( !mysql_real_connect( &mDbConnection, staticConfig.DB_HOST.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), 0, 0, 0, 0 ) )
+            std::string dbHost = staticConfig.DB_HOST.substr( 0, colonIndex );
+            std::string dbPortOrSocket = staticConfig.DB_HOST.substr( colonIndex+1 );
+            if ( dbPortOrSocket[0] == '/' )
             {
-              Fatal( "Can't connect to database: %s", mysql_error( &mDbConnection ) );
-              exit( mysql_errno( &mDbConnection ) );
+              if ( !mysql_real_connect( &mDbConnection, NULL, staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, 0, dbPortOrSocket.c_str(), 0 ) )
+              {
+                Fatal( "Can't connect to database: %s", mysql_error( &mDbConnection ) );
+                exit( mysql_errno( &mDbConnection ) );
+              }  
+            }
+            else
+            {
+              if ( !mysql_real_connect( &mDbConnection, dbHost.c_str(), staticConfig.DB_USER.c_str(), staticConfig.DB_PASS.c_str(), NULL, atoi(dbPortOrSocket.c_str()), NULL, 0 ) )
+              {
+                Fatal( "Can't connect to database: %s", mysql_error( &mDbConnection ) );
+                exit( mysql_errno( &mDbConnection ) );
+              }
             }
           }
           unsigned long mysqlVersion = mysql_get_server_version( &mDbConnection );

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -30,8 +30,19 @@ function dbConnect()
 {
     global $dbConn;
 
+	if (strpos(ZM_DB_HOST, ':')) {
+		// Host variable may carry a port or socket.
+		list($host, $portOrSocket) = explode(':', ZM_DB_HOST, 2);
+			if (is_numeric($portOrSocket)) {
+				$socket = ':host='.$host . ';port='.$portOrSocket;
+			} else {
+				$socket = ':unix_socket='.$portOrSocket;
+			}
+	} else {
+		$socket = ':host='.ZM_DB_HOST;
+	}
 	try {
-		$dbConn = new PDO( ZM_DB_TYPE . ':host=' . ZM_DB_HOST . ';dbname='.ZM_DB_NAME, ZM_DB_USER, ZM_DB_PASS );
+		$dbConn = new PDO( ZM_DB_TYPE . $socket . ';dbname='.ZM_DB_NAME, ZM_DB_USER, ZM_DB_PASS );
 		$dbConn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 	} catch(PDOException $ex ) {
 		echo "Unable to connect to ZM db." . $ex->getMessage();


### PR DESCRIPTION
Logic is added to handle specified port / unix file socket for database connections.
For example, the following now all work as expected...
```
ZM_DB_HOST=localhost
ZM_DB_HOST=REMOTE_HOST:1234
ZM_DB_HOST=localhost:/path/to/non-default.sock
```
For the API to work in the same manner, this PR must be merged. https://github.com/ZoneMinder/ZoneMinder/pull/1470

Fixes https://github.com/ZoneMinder/ZoneMinder/issues/901