### PR TITLE
remove one unlink, add better error reporting to the rest

### DIFF
--- a/scripts/zmdc.pl.in
+++ b/scripts/zmdc.pl.in
@@ -262,8 +262,7 @@ sub run
     killAll( 1 );
 
     socket( SERVER, PF_UNIX, SOCK_STREAM, 0 ) or Fatal( "Can't open socket: $!" );
-#    Fails every time. Does not appear to be necessary.
-#    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
+    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" ) if ( -e main::SOCK_FILE );
     bind( SERVER, $saddr ) or Fatal( "Can't bind to " . main::SOCK_FILE . ": $!" );
     listen( SERVER, SOMAXCONN ) or Fatal( "Can't listen: $!" );
 
@@ -375,8 +374,8 @@ sub run
         .strftime( '%y/%m/%d %H:%M:%S', localtime() )
         ."\n"
     );
-    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
-    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" );
+    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" ) if ( -e main::SOCK_FILE );
+    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" ) if ( -e ZM_PID );
     exit();
 }
 
@@ -761,8 +760,8 @@ sub shutdownAll
         .strftime( '%y/%m/%d %H:%M:%S', localtime() )
         ."\n"
     );
-    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
-    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" );
+    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" ) if ( -e main::SOCK_FILE );
+    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" ) if ( -e ZM_PID );
     close( CLIENT );
     close( SERVER );
     exit();

--- a/scripts/zmdc.pl.in
+++ b/scripts/zmdc.pl.in
@@ -262,7 +262,8 @@ sub run
     killAll( 1 );
 
     socket( SERVER, PF_UNIX, SOCK_STREAM, 0 ) or Fatal( "Can't open socket: $!" );
-    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE );
+#    Fails every time. Does not appear to be necessary.
+#    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
     bind( SERVER, $saddr ) or Fatal( "Can't bind to " . main::SOCK_FILE . ": $!" );
     listen( SERVER, SOMAXCONN ) or Fatal( "Can't listen: $!" );
 
@@ -374,8 +375,8 @@ sub run
         .strftime( '%y/%m/%d %H:%M:%S', localtime() )
         ."\n"
     );
-    unlink( main::SOCK_FILE );
-    unlink( ZM_PID );
+    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
+    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" );
     exit();
 }
 
@@ -760,8 +761,8 @@ sub shutdownAll
         .strftime( '%y/%m/%d %H:%M:%S', localtime() )
         ."\n"
     );
-    unlink( main::SOCK_FILE );
-    unlink( ZM_PID );
+    unlink( main::SOCK_FILE ) or Error( "Unable to unlink " . main::SOCK_FILE .". Error message was: $!" );
+    unlink( ZM_PID ) or Error( "Unable to unlink " . ZM_PID .". Error message was: $!" );
     close( CLIENT );
     close( SERVER );
     exit();


### PR DESCRIPTION
On all the (redhat) systems I test on, the unlink statement I commented out with this pr fails every single time. Commenting it out appears to not have any negative affects. With the recent error reporting added to this statement, it was leaving an error in my logs every time zoneminder was started.

@connortechnology let me know if you agree with this. Alternatively, we could put the unlink statement back in, just without any error reporting.

Those of us who have worked on the project long enough know that "harmless" error messages can cause end users to blame all their problems on this message and respond with "OMG! Why don't you fix it now". Consequently, I'd like to nip this in the bud before it happens.

Note that, while I was researching this, I noticed that the zmtrigger and zmcontrol scripts did not clean up their sock files after zoneminder was started (zmcontrol was even left running). I'm writing this down so I remember to look into this sometime after our next release.



