### PR TITLE
add option to show monitor ID on console

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -1565,6 +1565,16 @@ our @options =
         category    => "web",
     },
     {
+        name        => "ZM_WEB_ID_ON_CONSOLE",
+        default     => "no",
+        description => "Should the console list the monitor id",
+        help        => qqq("Some find it useful to have the id always visible
+            on the console. This option will add a column listing it.
+        "),
+        type        => $types{boolean},
+        category    => "web",
+    },
+    {
         name        => "ZM_WEB_POPUP_ON_ALARM",
         default     => "yes",
         description => "Should the monitor window jump to the top if an alarm occurs",

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -184,7 +184,7 @@ $versionClass = (ZM_DYN_DB_VERSION&&(ZM_DYN_DB_VERSION!=ZM_VERSION))?'errorText'
 
 $left_columns = 3;
 if ( count($servers) ) $left_columns += 1;
-if ( ZM_WEB_ID_ON_CONSOLE ) ) $left_columns += 1;
+if ( ZM_WEB_ID_ON_CONSOLE ) $left_columns += 1;
 
 xhtmlHeaders( __FILE__, translate('Console') );
 ?>

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -182,6 +182,9 @@ $seqDownFile = getSkinFile( 'graphics/seq-d.gif' );
 
 $versionClass = (ZM_DYN_DB_VERSION&&(ZM_DYN_DB_VERSION!=ZM_VERSION))?'errorText':'';
 
+$left_columns = 3;
+if ( count($servers) ) $left_columns += 1;
+if ( ZM_WEB_ID_ON_CONSOLE ) ) $left_columns += 1;
 
 xhtmlHeaders( __FILE__, translate('Console') );
 ?>
@@ -241,6 +244,9 @@ else
       <table id="consoleTable" cellspacing="0">
         <thead>
           <tr>
+<?php if ( ZM_WEB_ID_ON_CONSOLE ) { ?>
+            <th class="colId"><?php echo translate('Id') ?></th>
+<?php } ?>
             <th class="colName"><?php echo translate('Name') ?></th>
             <th class="colFunction"><?php echo translate('Function') ?></th>
 <?php if ( count($servers) ) { ?>
@@ -269,7 +275,7 @@ if ( canEdit('Monitors') )
         </thead>
         <tfoot>
           <tr>
-            <td class="colLeftButtons" colspan="<?php echo count($servers) ? 4 : 3 ?>">
+            <td class="colLeftButtons" colspan="<?php echo $left_columns ?>">
               <input type="button" value="<?php echo translate('Refresh') ?>" onclick="location.reload(true);"/>
           <input type="button" name="addBtn" value="<?php echo translate('AddNewMonitor') ?>" onclick="addMonitor( this )"/>
               <!-- <?php echo makePopupButton( '?view=monitor', 'zmMonitor0', 'monitor', translate('AddNewMonitor'), (canEdit( 'Monitors' ) && !$user['MonitorIds']) ) ?> -->
@@ -315,6 +321,9 @@ foreach( $displayMonitors as $monitor )
         $fclass .= " disabledText";
     $scale = max( reScale( SCALE_BASE, $monitor['DefaultScale'], ZM_WEB_DEFAULT_SCALE ), SCALE_BASE );
 ?>
+<?php if ( ZM_WEB_ID_ON_CONSOLE ) { ?>
+            <td class="colId"><?php echo makePopupLink( '?view=watch&amp;mid='.$monitor['Id'], 'zmWatch'.$monitor['Id'], array( 'watch', reScale( $monitor['Width'], $scale ), reScale( $monitor['Height'], $scale ) ), $monitor['Id'], $running && ($monitor['Function'] != 'None') && canView( 'Stream' ) ) ?></td>
+<?php } ?>
             <td class="colName"><?php echo makePopupLink( '?view=watch&amp;mid='.$monitor['Id'], 'zmWatch'.$monitor['Id'], array( 'watch', reScale( $monitor['Width'], $scale ), reScale( $monitor['Height'], $scale ) ), $monitor['Name'], $running && ($monitor['Function'] != 'None') && canView( 'Stream' ) ) ?></td>
             <td class="colFunction"><?php echo makePopupLink( '?view=function&amp;mid='.$monitor['Id'], 'zmFunction', 'function', '<span class="'.$fclass.'">'.translate('Fn'.$monitor['Function']).( empty($monitor['Enabled']) ? ', disabled' : '' ) .'</span>', canEdit( 'Monitors' ) ) ?></td>
 <?php if ( count($servers) ) { ?>


### PR DESCRIPTION
add the ZM_WEB_ID_ON_CONSOLE option and use it to show the ID column on the console

I set the default to off to maintain old behaviour.  Whether someone wants this will depend a lot of user preference. I find it very useful for one server, and not at all for another.

Feel free to not merge until 1.31.