### PR TITLE
Remove deprecated register_globals from Apache/PHP configs

### DIFF
--- a/distros/debian/apache.conf
+++ b/distros/debian/apache.conf
@@ -1,7 +1,6 @@
 Alias /zm /usr/share/zoneminder/www
 
 <Directory /usr/share/zoneminder/www>
-  php_flag register_globals off
   Options Indexes FollowSymLinks
   <IfModule mod_dir.c>
     DirectoryIndex index.php

--- a/distros/ubuntu1504_cmake_split_packages/apache.conf
+++ b/distros/ubuntu1504_cmake_split_packages/apache.conf
@@ -1,7 +1,6 @@
 Alias /zm /usr/share/zoneminder/www
 
 <Directory /usr/share/zoneminder/www>
-  php_flag register_globals off
   Options Indexes FollowSymLinks
   <IfModule mod_dir.c>
     DirectoryIndex index.php

--- a/distros/ubuntu1604/conf/apache2/zoneminder.conf
+++ b/distros/ubuntu1604/conf/apache2/zoneminder.conf
@@ -8,7 +8,6 @@ ScriptAlias /zm/cgi-bin "/usr/lib/zoneminder/cgi-bin"
 
 Alias /zm /usr/share/zoneminder/www
 <Directory /usr/share/zoneminder/www>
-  php_flag register_globals off
   Options Indexes FollowSymLinks
   <IfModule mod_dir.c>
     DirectoryIndex index.php


### PR DESCRIPTION
register_globals feature has been deprecated as of PHP 5.3.0 and removed as of PHP 5.4.0 - http://php.net/manual/en/security.globals.php

- Debian 7 comes with PHP 5.4.45
- Debian 8 comes with PHP 5.6.20
- Ubuntu 15.04 comes with PHP 5.6.4
- Ubuntu 16.04 comes with PHP 7.0.4

Moreover, if PHP-FPM is used (like in my case), the directive is not recognized at all.