### PR TITLE
Set VIDEO_MAX_FRAME if it is not defined

### DIFF
--- a/src/zm_local_camera.h
+++ b/src/zm_local_camera.h
@@ -105,6 +105,11 @@ protected:
   static V4L1Data     v4l1_data;
 #endif // ZM_HAS_V4L1
 
+// Required on systems with v4l1 but without v4l2 headers
+#ifndef VIDEO_MAX_FRAME
+#define VIDEO_MAX_FRAME               32
+#endif
+
 #if HAVE_LIBSWSCALE
   static AVFrame    **capturePictures;
   _AVPIXELFORMAT       imagePixFormat;

--- a/src/zm_local_camera.h
+++ b/src/zm_local_camera.h
@@ -36,6 +36,11 @@
 #include <linux/videodev2.h>
 #endif // HAVE_LINUX_VIDEODEV2_H
 
+// Required on systems with v4l1 but without v4l2 headers
+#ifndef VIDEO_MAX_FRAME
+#define VIDEO_MAX_FRAME               32
+#endif
+
 #include "zm_ffmpeg.h"
 
 //
@@ -104,11 +109,6 @@ protected:
 #if ZM_HAS_V4L1
   static V4L1Data     v4l1_data;
 #endif // ZM_HAS_V4L1
-
-// Required on systems with v4l1 but without v4l2 headers
-#ifndef VIDEO_MAX_FRAME
-#define VIDEO_MAX_FRAME               32
-#endif
 
 #if HAVE_LIBSWSCALE
   static AVFrame    **capturePictures;


### PR DESCRIPTION
@abishai to test

@connortechnology to tell me if this is good place to make this change

From reading, it looks like VIDEO_MAX_FRAME used to be defined in v4l1 headers, but then got moved into v4l2 headers.... so any machine with v4l1 but not v4l2 will not build.