### PR TITLE
Adjust download file path to swap path to match the file generated.

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -394,7 +394,7 @@ tr.log-dbg td {
         }
 
         $exportFile = "zm-log.$exportExt";
-        $exportPath = "temp/zm-log-$exportKey.$exportExt";
+        $exportPath = ZM_PATH_SWAP."/zm-log-$exportKey.$exportExt";
 
         header( "Pragma: public" );
         header( "Expires: 0" );


### PR DESCRIPTION
I have seen a couple of people mention log export not working, decided to check and sure enough the generated file was changed to ZM_PATH_SWAP, but download path was still /temp.