### PR TITLE
Related to not found: /usr/lib/cgi-bin/nph-zms

### DIFF
--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -52,7 +52,7 @@ class Monitor {
 			$Server = new Server( $this->{'ServerId'} );
 			$streamSrc = ZM_BASE_PROTOCOL.'://'.$Server->Hostname().ZM_PATH_ZMS;
 		} else {
-			$streamSrc = ZM_BASE_URL.ZM_PATH_ZMS;
+			$streamSrc = ZM_BASE_URL . ZM_BASE_PATH . ZM_PATH_ZMS;
 		}
 
 		$args[] = "monitor=".$this->{'Id'};


### PR DESCRIPTION
When watch.php calls to this address we have a problem because this address is not recognized by the apache server.
http://localhost/cgi-bin/nph-zms?mode=jpeg&scale=100&maxfps=5&buffer=1000&monitor=3&connkey=29272&rand=686800
Also, according to the default configuration the ScriptAlias  was defined like this "/zm/cgi-bin" and the Alias as /zm.
Therefore, we hate to add the ZM_BASE_PATH to the ZM_BASE_URL to create the $streamSrc path.
And also cam be combined with this command to ensure that the problem is solved
sudo ln -s /usr/lib/zoneminder/cgi-bin/nph-zms /usr/lib/cgi-bin/

Related with the issue https://github.com/ZoneMinder/ZoneMinder/issues/563