### PR TITLE
zmonvif-probe - fixes syntax error reported on some (older) Perls

### DIFF
--- a/onvif/proxy/lib/WSDiscovery10/Types/ProbeType.pm
+++ b/onvif/proxy/lib/WSDiscovery10/Types/ProbeType.pm
@@ -89,10 +89,11 @@ sub serialize()
   my $ident = ${ $_[0] };
   my $option_ref = $_[1];
   my $attr_str = "";
+  my %attr_hash = %{$Attribs_of{$ident}};
 
-  foreach my $attr (keys %{$Attribs_of{$ident}})
+  foreach my $attr (keys %attr_hash)
   {
-    my $value = %{$Attribs_of{$ident}}{$attr};
+    my $value = $attr_hash{$attr};
     $attr_str .= " $attr=\"$value\"";
   }
   


### PR DESCRIPTION
This fixes the syntax error reported on, presumably older, versions of Perl as reported by @siigna:
```
# ./zmonvif-probe.pl probe
syntax error at /usr/share/perl5/WSDiscovery10/Types/ProbeType.pm line 95, near "}{"
Global symbol "$attr" requires explicit package name at /usr/share/perl5/WSDiscovery10/Types/ProbeType.pm line 96.
Global symbol "$value" requires explicit package name at /usr/share/perl5/WSDiscovery10/Types/ProbeType.pm line 96.
Global symbol "$attr_str" requires explicit package name at /usr/share/perl5/WSDiscovery10/Types/ProbeType.pm line 99.
syntax error at /usr/share/perl5/WSDiscovery10/Types/ProbeType.pm line 102, near "}"
Compilation failed in require at (eval 90) line 2.
        ...propagated at /usr/share/perl/5.14/base.pm line 93.
BEGIN failed--compilation aborted at /usr/share/perl5/WSDiscovery10/Elements/Probe.pm line 18.
Compilation failed in require at (eval 89) line 2.
```

@siigna please test

@altaroca Please review. I chose to spawn a copy of the hash being used, to work around the syntax error. It seemed safe to do so in this subroutine.

