### PR TITLE
custom banner text on web console

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -1549,6 +1549,20 @@ our @options =
         category    => "web",
     },
     {
+        name        => "ZM_WEB_CONSOLE_BANNER",
+        default     => "",
+        description => "Arbitrary text message near the top of the console",
+        help        => qqq("
+            Allows the administrator to place an arbitrary text message
+            near the top of the web console. This is useful for the developers
+            to display a message which indicates the running instance of
+            ZoneMinder is a development snapshot, but it can also be used for
+            any other purpose as well.
+        "),
+        type        => $types{string},
+        category    => "web",
+    },
+    {
         name        => "ZM_WEB_RESIZE_CONSOLE",
         default     => "yes",
         description => "Should the console window resize itself to fit",

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,6 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
       <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
+      <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>
       <div id="monitorSummary"><?php echo makePopupLink( '?view=groups', 'zmGroups', 'groups', sprintf( $CLANG['MonitorCount'], count($displayMonitors), zmVlang( $VLANG['Monitor'], count($displayMonitors) ) ).($group?' ('.$group['Name'].')':''), canView( 'Groups' ) ); ?></div>
 <?php
 if ( ZM_OPT_X10 && canView( 'Devices' ) )


### PR DESCRIPTION
This is intended to go into the release after 1.30.0. I thought I'd create the PR now while I am thinking about it.

Each time I package a development snapshot or release candidate into an RPM, I patch the source code during the build to display a disclaimer, to make it obvious to the end user this is not an official release.

This PR allows me to get away from patching the source, and at the same time allow others to put their own custom text near the top of their web console. See screenshot below.

Currently I've statically assigned it to be cantered, H3 html text, because that suits my purposes. If anyone want to add the ability to control things like the font size, boldness, etc I am open to suggestions.

![screenshot from 2016-07-09 13-17-17](https://cloud.githubusercontent.com/assets/5150042/16709489/bd800602-45d7-11e6-8eba-d2ca8f7bb8ca.png)

