### PR TITLE
restore the behaviour where the generated file names are printed to stdout

### DIFF
--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -414,7 +414,7 @@ sub generateVideo
             or Fatal( "Can't execute '$sql': ".$sth->errstr() );
         if ( wantarray() )
         {
-            return( $format, sprintf( "%s/%s", getEventPath( $event ), $output ) );
+            return( $format, $output );
         }
     }
     return( 1 );

--- a/scripts/zmvideo.pl.in
+++ b/scripts/zmvideo.pl.in
@@ -222,6 +222,7 @@ foreach my $event_id ( @event_ids ) {
 	my $video_file = $Event->GenerateVideo( $rate, $fps, $scale,  $size, $overwrite, $format );
 	if ( $video_file ) {
 		push @video_files, $video_file;
+		print( STDOUT $video_file."\n" );
 	}
 } # end foreach event_id
 
@@ -253,9 +254,6 @@ if ( $concat_name ) {
 		Error( "Unable to generate video, check /ffmpeg.log for details");
 		exit(-1);
 	}
-	
+	print( STDOUT $video_file."\n" );
 }
-#unlink $input_file_list;
-#print( STDOUT $event->{MonitorId}.'/'.$event->{Id}.'/'.$video_file."\n" );
-#print( STDOUT $video_file."\n" );
 exit( 0 );


### PR DESCRIPTION
Should fix #1550 and #1542 
