### PR TITLE
Enable local and travis ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
 branches:
   except:
     - modern
+cache: ccache
 addons:
   sauce_connect:
     username: "zoneminder"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -742,3 +742,9 @@ configure_file(
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake)
 
+# Configure CCache if available
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)


### PR DESCRIPTION
On local build use ccache to speed up build if found, and use on travis. My testing shows once cached resulted in a halving time to build on travis from 14mins to 7mins. ffmpeg make down to 232 secs from 640 secs.
