### PR TITLE
Add libx264-dev and libmp4v2-dev to build requires to save hassle of

### DIFF
--- a/distros/ubuntu1604/control
+++ b/distros/ubuntu1604/control
@@ -25,7 +25,9 @@ Build-Depends: debhelper (>= 9), dh-systemd, python-sphinx | python3-sphinx, apa
               ,libphp-serialization-perl
               ,libsys-mmap-perl [!hurd-any]
               ,libwww-perl
-              ,libdata-uuid-perl 
+              ,libdata-uuid-perl
+              ,libx264-dev
+              ,libmp4v2-dev
 # Unbundled (dh_linktree):
         ,libjs-jquery
         ,libjs-mootools
@@ -60,7 +62,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
         ,libio-socket-multicast-perl
         ,libdigest-sha-perl
         ,libsys-cpu-perl, libsys-meminfo-perl
-        ,libdata-uuid-perl 
+        ,libdata-uuid-perl
         ,mysql-client | virtual-mysql-client
         ,perl-modules
         ,php5-mysql | php-mysql, php5-gd | php-gd


### PR DESCRIPTION
ensuring they are installed before build.