### PR TITLE
include polygons for the other zones.

### DIFF
--- a/web/skins/classic/css/classic/views/zone.css
+++ b/web/skins/classic/css/classic/views/zone.css
@@ -95,6 +95,9 @@
 }
 .zones polygon {
 	fill-opacity: 0.25;
+  stroke-width: 0;
+}
+.zones polygon.Editing {
 	stroke-width: 2px;
 }
 .Active {

--- a/web/skins/classic/css/dark/views/zone.css
+++ b/web/skins/classic/css/dark/views/zone.css
@@ -95,7 +95,10 @@
 }
 .zones polygon {
 	fill-opacity: 0.25;
-	stroke-width: 2px;
+	stroke-width: 0;
+}
+.zones polygon.Editing {
+  stroke-width: 2px;
 }
 .Active {
 	stroke: #ff0000;

--- a/web/skins/classic/css/flat/views/zone.css
+++ b/web/skins/classic/css/flat/views/zone.css
@@ -95,6 +95,9 @@
 }
 .zones polygon {
 	fill-opacity: 0.25;
+	stroke-width: 0;
+}
+.zones polygon.Editing {
 	stroke-width: 2px;
 }
 .Active {

--- a/web/skins/classic/views/zone.php
+++ b/web/skins/classic/views/zone.php
@@ -75,8 +75,9 @@ if ( !isset($newZone) )
     else
     {
         $zone = array(
-            'Name' => translate('New'),
             'Id' => 0,
+            'Name' => translate('New'),
+            'Type'  =>  'Active',
             'MonitorId' => $monitor->Id(),
             'NumCoords' => 4,
             'Coords' => sprintf( "%d,%d %d,%d, %d,%d %d,%d", $minX, $minY, $maxX, $minY, $maxX, $maxY, $minX, $maxY ),
@@ -232,7 +233,7 @@ if ( count( $other_zones ) ) {
   echo $html;
 }
 ?>
-                  <polygon id="zonePoly" points="<?php echo $zone['AreaCoords'] ?>" class="<?php echo $zone['Type'] ?>"/>
+                  <polygon id="zonePoly" points="<?php echo $zone['AreaCoords'] ?>" class="Editing <?php echo $zone['Type'] ?>"/>
                   Sorry, your browser does not support inline SVG
                 </svg>
             </div>

--- a/web/skins/classic/views/zone.php
+++ b/web/skins/classic/views/zone.php
@@ -217,6 +217,21 @@ xhtmlHeaders(__FILE__, translate('Zone') );
             <div id="imageFrame" style="position: relative; width: <?php echo reScale( $monitor->Width(), $scale ) ?>px; height: <?php echo reScale( $monitor->Height(), $scale ) ?>px;">
                 <?php echo $StreamHTML; ?>
                 <svg id="zoneSVG" class="zones" style="position: absolute; top: 0; left: 0; width: <?php echo reScale( $monitor->Width(), $scale ) ?>px; height: <?php echo reScale( $monitor->Height(), $scale ) ?>px; background: none;">
+<?php
+if ( $zone['Id'] ) {
+  $other_zones = dbFetchAll( 'SELECT * FROM Zones WHERE MonitorId = ? AND Id != ?', NULL, array( $monitor->Id(), $zone['Id'] ) );
+} else {
+  $other_zones = dbFetchAll( 'SELECT * FROM Zones WHERE MonitorId = ?', NULL, array( $monitor->Id() ) );
+}
+if ( count( $other_zones ) ) {
+  $html = '';
+  foreach( $other_zones as $other_zone ) {
+    $other_zone['AreaCoords'] = preg_replace( '/\s+/', ',', $other_zone['Coords'] );
+    $html .= '<polygon id="zonePoly'.$other_zone['Id'].'" points="'. $other_zone['AreaCoords'] .'" class="'. $other_zone['Type'] .'"/>';
+  }
+  echo $html;
+}
+?>
                   <polygon id="zonePoly" points="<?php echo $zone['AreaCoords'] ?>" class="<?php echo $zone['Type'] ?>"/>
                   Sorry, your browser does not support inline SVG
                 </svg>


### PR DESCRIPTION
So this restores the old behaviour by adding svg polygons for the zones.  

I have concerns regarding colours. In 1.29 the editing zone was green.  

In 1.30, we use a css class to assign colour based on the zone type and we got red.  

The Alarm Colour RGB has no effect.  Maybe it should.  