### PR TITLE
fix error in calling zmaControl

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -840,10 +840,10 @@ function zmcControl( $monitor, $mode=false ) {
 }
 
 function zmaControl( $monitor, $mode=false ) {
+  if ( !is_array( $monitor ) ) {
+    $monitor = dbFetchOne( "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id=?", NULL, array($monitor) );
+  }
   if ( (!defined('ZM_SERVER_ID')) or ( ZM_SERVER_ID==$monitor['ServerId'] ) ) {
-    if ( !is_array( $monitor ) ) {
-      $monitor = dbFetchOne( "select C.*, M.* from Monitors as M left join Controls as C on (M.ControlId = C.Id ) where M.Id=?", NULL, array($monitor) );
-    }
     if ( !$monitor || $monitor['Function'] == 'None' || $monitor['Function'] == 'Monitor' || $mode == "stop" ) {
       if ( ZM_OPT_CONTROL ) {
         daemonControl( "stop", "zmtrack.pl", "-m ".$monitor['Id'] );
@@ -873,7 +873,7 @@ function zmaControl( $monitor, $mode=false ) {
         daemonControl( "reload", "zma", "-m ".$monitor['Id'] );
       }
     }
-  }
+  } // end if we are on the recording server
 }
 
 function initDaemonStatus() {


### PR DESCRIPTION
zmaControl can take an id #, so need to move the check for local server test down.

I have kept this minimal, to go in 1.30.1, but I intend to really clean this up.

zmaControl should take a hash only, like zmcControl.  