### PR TITLE
Added check for SINGLE_IMAGE to ignore socket closed by remote side

### DIFF
--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -192,6 +192,8 @@ int RemoteCameraHttp::ReadData( Buffer &buffer, int bytes_expected )
 
     if ( total_bytes_to_read == 0 )
     {
+      if( mode == SINGLE_IMAGE )
+		  return( 0 );
       // If socket is closed locally, then select will fail, but if it is closed remotely
       // then we have an exception on our socket.. but no data.
       Debug( 3, "Socket closed remotely" );


### PR DESCRIPTION
The issue is that with SINGLE_IMAGE requests, if a Content-Length is not specified in the headers on the response, appropriate behavior is to read until the socket is closed by the camera.  Resolves #1590 