### PR TITLE
store the scale value for watch and event views in a cookie, differen…

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -41,10 +41,14 @@ if ( isset( $_REQUEST['rate'] ) )
     $rate = validInt($_REQUEST['rate']);
 else
     $rate = reScale( RATE_BASE, $event['DefaultRate'], ZM_WEB_DEFAULT_RATE );
-if ( isset( $_REQUEST['scale'] ) )
-    $scale = validInt($_REQUEST['scale']);
-else
-    $scale = reScale( SCALE_BASE, $event['DefaultScale'], ZM_WEB_DEFAULT_SCALE );
+
+if ( isset( $_REQUEST['scale'] ) ) {
+  $scale = validInt($_REQUEST['scale']);
+} else if ( isset( $_COOKIE['zmWatchScale'.$event['MonitorId'] ) ) {
+  $scale = $_COOKIE['zmEventScale'.$event['MonitorId'];
+} else {
+  $scale = reScale( SCALE_BASE, $event['DefaultScale'], ZM_WEB_DEFAULT_SCALE );
+}
 
 $replayModes = array(
     'single' => translate('ReplaySingle'),

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -44,8 +44,8 @@ else
 
 if ( isset( $_REQUEST['scale'] ) ) {
   $scale = validInt($_REQUEST['scale']);
-} else if ( isset( $_COOKIE['zmWatchScale'.$event['MonitorId'] ) ) {
-  $scale = $_COOKIE['zmEventScale'.$event['MonitorId'];
+} else if ( isset( $_COOKIE['zmWatchScale'.$event['MonitorId']] ) ) {
+  $scale = $_COOKIE['zmEventScale'.$event['MonitorId']];
 } else {
   $scale = reScale( SCALE_BASE, $event['DefaultScale'], ZM_WEB_DEFAULT_SCALE );
 }

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -44,7 +44,7 @@ else
 
 if ( isset( $_REQUEST['scale'] ) ) {
   $scale = validInt($_REQUEST['scale']);
-} else if ( isset( $_COOKIE['zmWatchScale'.$event['MonitorId']] ) ) {
+} else if ( isset( $_COOKIE['zmEventScale'.$event['MonitorId']] ) ) {
   $scale = $_COOKIE['zmEventScale'.$event['MonitorId']];
 } else {
   $scale = reScale( SCALE_BASE, $event['DefaultScale'], ZM_WEB_DEFAULT_SCALE );

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -13,7 +13,7 @@ function changeScale()
     var newHeight = ( baseHeight * scale ) / SCALE_BASE;
 
     streamScale( scale );
-    Cookie.write( 'zmEventScale'+eventData.monitorId, scale, { duration: 10*365 } );
+    Cookie.write( 'zmEventScale'+eventData.MonitorId, scale, { duration: 10*365 } );
 
     /*Stream could be an applet so can't use moo tools*/ 
     var streamImg = document.getElementById('evtStream');

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -13,6 +13,7 @@ function changeScale()
     var newHeight = ( baseHeight * scale ) / SCALE_BASE;
 
     streamScale( scale );
+    Cookie.write( 'zmEventScale'+eventData.monitorId, scale, { duration: 10*365 } );
 
     /*Stream could be an applet so can't use moo tools*/ 
     var streamImg = document.getElementById('evtStream');

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -27,6 +27,7 @@ var connKey = '<?php echo $connkey ?>';
 
 var eventData = {
     Id: <?php echo $event['Id'] ?>,
+    MonitorId: <?php echo $event{'MonitorId'] ?>,
     Width: <?php echo $event['Width'] ?>,
     Height: <?php echo $event['Height'] ?>,
     Length: <?php echo $event['Length'] ?>

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -27,7 +27,7 @@ var connKey = '<?php echo $connkey ?>';
 
 var eventData = {
     Id: <?php echo $event['Id'] ?>,
-    MonitorId: <?php echo $event{'MonitorId'] ?>,
+    MonitorId: <?php echo $event['MonitorId'] ?>,
     Width: <?php echo $event['Width'] ?>,
     Height: <?php echo $event['Height'] ?>,
     Length: <?php echo $event['Length'] ?>

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -32,8 +32,7 @@ function changeScale()
     var newWidth = ( monitorWidth * scale ) / SCALE_BASE;
     var newHeight = ( monitorHeight * scale ) / SCALE_BASE;
 
-    // This causes FF3 to kill the stream now, ok with FF2
-    //streamCmdScale( scale );
+    Cookie.write( 'zmWatchScale'+monitorId, scale, { duration: 10*365 } );
 
     /*Stream could be an applet so can't use moo tools*/ 
     var streamImg = document.getElementById('liveStream');

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -44,10 +44,13 @@ else
 
 $showPtzControls = ( ZM_OPT_CONTROL && $monitor->Controllable() && canView( 'Control' ) );
 
-if ( isset( $_REQUEST['scale'] ) )
-    $scale = validInt($_REQUEST['scale']);
-else
-    $scale = reScale( SCALE_BASE, $monitor->DefaultScale, ZM_WEB_DEFAULT_SCALE );
+if ( isset( $_REQUEST['scale'] ) ) {
+  $scale = validInt($_REQUEST['scale']);
+} else if ( isset( $_COOKIE['zmWatchScale'.$mid] ) ) {
+  $scale = $_COOKIE['zmWatchScale'.$mid];
+} else {
+  $scale = reScale( SCALE_BASE, $monitor->DefaultScale, ZM_WEB_DEFAULT_SCALE );
+}
 
 $connkey = generateConnKey();
 


### PR DESCRIPTION
…tiated by monitorId.

Why monitorId?  Because I figure if you are using the scale function, it is likely because your camera is super high def and you want it to always scale.  But you might have older cameras that you don't scale.
