### PR TITLE
move jpeg context freeing to a Deinitialise function instead of ~Image

### DIFF
--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -137,7 +137,6 @@ protected:
 	static jpeg_decompress_struct *decodejpg_dcinfo;
 	static struct zm_error_mgr jpg_err;
 
-protected:
 	unsigned int width;
 	unsigned int height;
 	unsigned int pixels;
@@ -150,8 +149,6 @@ protected:
 	int holdbuffer; /* Hold the buffer instead of replacing it with new one */
 	char text[1024];
 
-protected:
-	static void Initialise();
 
 public:
 	Image();
@@ -159,6 +156,8 @@ public:
 	Image( int p_width, int p_height, int p_colours, int p_subpixelorder, uint8_t *p_buffer=0);
 	Image( const Image &p_image );
 	~Image();
+	static void Initialise();
+	static void Deinitialise();
 
 	inline unsigned int Width() const { return( width ); }
 	inline unsigned int Height() const { return( height ); }

--- a/src/zma.cpp
+++ b/src/zma.cpp
@@ -198,6 +198,7 @@ int main( int argc, char *argv[] )
   {
     fprintf( stderr, "Can't find monitor with id of %d\n", id );
   }
+  Image::Deinitialise();
   logTerm();
   zmDbClose();
   return( 0 );

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -357,6 +357,7 @@ int main( int argc, char *argv[] )
   delete [] next_delays;
   delete [] last_capture_times;
 
+  Image::Deinitialise();
   logTerm();
   zmDbClose();
 


### PR DESCRIPTION
These contexts only need to be allocated/deallocated once.  Moving them to a de-init function frees up cpu cycles because we actually do quite a bit of Image object creation/destruction.  

This fixes a memory leak too by freeing the jpeg_compress structures.

Also turn down the logging