### PR TITLE
Fix logic when disabling a monitor

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -338,7 +338,9 @@ if ( !empty($action) )
             $monitor = dbFetchOne( "SELECT * FROM Monitors WHERE Id=?", NULL, array($mid) );
 
             $newFunction = validStr($_REQUEST['newFunction']);
-			$newEnabled = isset( $_REQUEST['newEnabled'] ) and $_REQUEST['newEnabled'] != "1" ? "0" : "1";
+            # Because we use a checkbox, it won't get passed in the request. So not being in _REQUEST means 0
+            $newEnabled = ( !isset( $_REQUEST['newEnabled'] ) or $_REQUEST['newEnabled'] != '1' ) ? '0' : '1';
+
             $oldFunction = $monitor['Function'];
             $oldEnabled = $monitor['Enabled'];
             if ( $newFunction != $oldFunction || $newEnabled != $oldEnabled )


### PR DESCRIPTION
So the logic of the old line is flawed due to operator precedence.  $newEnabled ends up being the empty string instead of either 1 or 0.  

This works ok in current zoneminder, but if you turn on strict mysql options, it won't accept the empty string as a boolean value.