### PR TITLE
handle when window.open fails

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -102,7 +102,12 @@ function getPopupSize( tag, width, height )
 function zmWindow()
 {
     var zmWin = window.open( 'http://www.zoneminder.com', 'ZoneMinder' );
-    zmWin.focus();
+    if ( ! zmWin ) {
+      // if popup blocking is enabled, the popup won't be defined.
+      console.log("Please disable popup blocking.");
+    } else {
+      zmWin.focus();
+    }
 }
 
 function createPopup( url, name, tag, width, height )
@@ -114,7 +119,12 @@ function createPopup( url, name, tag, width, height )
     if ( popupSize.height > 0 )
         popupDimensions += ",height="+popupSize.height;
     var popup = window.open( url, name, popupOptions+popupDimensions );
-    popup.focus();
+    if ( ! popup ) {
+      // if popup blocking is enabled, the popup won't be defined.
+      console.log("Please disable popup blocking.");
+    } else {
+      popup.focus();
+    }
 }
 
 function createEventPopup( eventId, eventFilter, width, height )
@@ -125,7 +135,12 @@ function createEventPopup( eventId, eventFilter, width, height )
     var name = 'zmEvent';
     var popupSize = getPopupSize( 'event', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
-    popup.focus();
+    if ( ! popup ) {
+      // if popup blocking is enabled, the popup won't be defined.
+      console.log("Please disable popup blocking.");
+    } else {
+      popup.focus();
+    }
 }
 
 function createFramesPopup( eventId, width, height )
@@ -134,7 +149,12 @@ function createFramesPopup( eventId, width, height )
     var name = 'zmFrames';
     var popupSize = getPopupSize( 'frames', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
-    popup.focus();
+    if ( ! popup ) {
+      // if popup blocking is enabled, the popup won't be defined.
+      console.log("Please disable popup blocking.");
+    } else {
+      popup.focus();
+    }
 }
 
 function createFramePopup( eventId, frameId, width, height )
@@ -143,7 +163,12 @@ function createFramePopup( eventId, frameId, width, height )
     var name = 'zmFrame';
     var popupSize = getPopupSize( 'frame', width, height );
     var popup = window.open( url, name, popupOptions+",width="+popupSize.width+",height="+popupSize.height );
-    popup.focus();
+    if ( ! popup ) {
+      // if popup blocking is enabled, the popup won't be defined.
+      console.log("Please disable popup blocking.");
+    } else {
+      popup.focus();
+    }
 }
 
 function windowToFront()


### PR DESCRIPTION
There was a post in the forums about this.

When the popup blocker is active the window.open call will fail and popup will not be defined.  

So this PR handles that and logs a more useful message.