### PR TITLE
Fix event deletion from watch view.  Fixes #1671

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -496,7 +496,7 @@ function getEventCmdResponse( respObj, respText )
                 link.set( 'text', event.AvgScore+'/'+event.MaxScore );
                 link.inject( row.getElement( 'td.colScore' ) );
 
-                link = new Element( 'a', { 'href': '#', 'title': deleteString, 'events': { 'click': function( event ) { deleteEvent( event, event.Id ); }.bind( link ), 'mouseover': highlightRow.pass( row ), 'mouseout': highlightRow.pass( row ) } });
+                link = new Element( 'a', { 'href': '#', 'title': deleteString, 'events': { 'click': function( e ) { deleteEvent( event, event.Id ); }.bind( link ), 'mouseover': highlightRow.pass( row ), 'mouseout': highlightRow.pass( row ) } });
                 link.set( 'text', 'X' );
                 link.inject( row.getElement( 'td.colDelete' ) );
 


### PR DESCRIPTION
The problem is that `event` didn't mean what we wanted it to mean here as it was being redefined as a javascript browser event - not the event in the ZM context.

While this fix does allow event deletion to work, it does cause `event.stop();` (line 434 in watch.js) to error out on the console, where it did not error previously.

Assuming `event.stop` is supposed to stop an event in progress, but I can't find that code anywhere.