### PR TITLE
Show available PATH_MAP percent on console

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1429,15 +1429,15 @@ function getLoad() {
   return( $load[0] );
 }
 
-function getDiskPercent() {
-  $total = disk_total_space(ZM_DIR_EVENTS);
+function getDiskPercent($path = ZM_DIR_EVENTS) {
+  $total = disk_total_space($path);
   if ( ! $total ) {
-    Error("disk_total_space returned false for " . ZM_DIR_EVENTS );
+    Error("disk_total_space returned false for " . $path );
     return 0;
   }
-  $free = disk_free_space(ZM_DIR_EVENTS);
+  $free = disk_free_space($path);
   if ( ! $free ) {
-    Error("disk_free_space returned false for " . ZM_DIR_EVENTS );
+    Error("disk_free_space returned false for " . $path );
   }
   $space = round(($total - $free) / $total * 100);
   return( $space );

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo ZM_PATH_MAP ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_SWAP) ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_SWAP) ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo ZM_PATH_MAP ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> - <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% - <?php echo ZM_PATH_MAP ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>


### PR DESCRIPTION
Initial commit to show the end user how much swap space (usually /dev/shm these days) is in use.
Note that percent changes after a (auto)refresh such as when zoneminder is stopped/started. This makes it easier for the end user to see how much swap gets consumed the moment zoneminder is started.

I'm open to tweak this if anyone has any suggestions.

I would almost rather see free space in MB, but it was easier to show percent since the function already existed.

The semantic "Swap" is new, and thus not currently part of the existing language files. It will show in English until we get PR's from the various native speakers of other languages.

@kylejohnson Let me know how this affects your web UI pr