### PR TITLE
prevent the end user from slecting an invalid configuration on the PT…

### DIFF
--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_SWAP) ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -195,7 +195,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% / <?php echo translate('Swap') ?>: <?php echo getDiskPercent(ZM_PATH_SWAP) ?>%</h3>
+      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> / <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>%</h3>
       <h2 id="title"><a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> - <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - <?php echo $run_state ?> <?php echo makePopupLink( '?view=version', 'zmVersion', 'version', '<span class="'.$versionClass.'">v'.ZM_VERSION.'</span>', canEdit( 'System' ) ) ?></h2>
       <div class="clear"></div>
       <h3 id="development"><center><?php echo ZM_WEB_CONSOLE_BANNER ?></center></h3>

--- a/web/skins/classic/views/controlcap.php
+++ b/web/skins/classic/views/controlcap.php
@@ -183,7 +183,7 @@ foreach ( $tabs as $name=>$value )
 ?>
       </ul>
       <div class="clear"></div>
-      <form name="contentForm" id="contentForm" method="post" action="<?php echo $_SERVER['PHP_SELF'] ?>">
+      <form name="contentForm" id="contentForm" method="post" action="<?php echo $_SERVER['PHP_SELF'] ?>" onsubmit="return validateForm( this )">
         <input type="hidden" name="view" value="<?php echo $view ?>"/>
         <input type="hidden" name="tab" value="<?php echo $tab ?>"/>
         <input type="hidden" name="action" value="controlcap"/>

--- a/web/skins/classic/views/js/controlcap.js
+++ b/web/skins/classic/views/js/controlcap.js
@@ -1,0 +1,24 @@
+function validateForm( form ) {
+    var errors = new Array();
+
+    // If "Can Move" is enabled, then the end user must also select at least one of the other check boxes (excluding Can Move Diagonally)
+    if ( form.elements['newControl[CanMove]'].checked ) {
+        if ( !form.elements['newControl[CanMoveCon]'].checked || !form.elements['newControl[CanMoveRel]'].checked || !form.elements['newControl[CanMoveAbs]'].checked || !form.elements['newControl[CanMoveMap]'].checked ) {
+            errors[errors.length] = "In addition to \"Can Move\", you also must select at least one of: \"Can Move Mapped\", \"Can Move Absolute\", \"Can Move Relative\", or \"Can Move Continuous\"";
+        }
+    } else {
+    // Now lets check for the opposite condition. If any of the boxes below Can Move are checked, but Can Move is not checked then signal an error
+
+        if ( form.elements['newControl[CanMoveCon]'].checked || form.elements['newControl[CanMoveRel]'].checked || form.elements['newControl[CanMoveAbs]'].checked || form.elements['newControl[CanMoveMap]'].checked || form.elements['newControl[CanMoveDiag]'].checked ) {
+            errors[errors.length] = "\"Can Move\" must also be selected if any one of the movement types are sleceted";
+        }
+    }
+
+    if ( errors.length ) {
+        alert( errors.join( "\n" ) );
+        return( false );
+    }
+    return( true );
+
+}
+


### PR DESCRIPTION
…Z control configuraion "Move" tab

This pr presents an error message to the end user under the following conditions:
- "Can Move" is checked but none of the other movement types are checked (except Move Diagonally since that is optional)
- Any one or more of the others boxes are checked but "Can Move" is not checked.

This ensures that the underlying Perl script makes the right call to a subroutine name that actually exists.
