### PR TITLE
unlink the mmap file when the monitor object is destroyed

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -674,6 +674,13 @@ Monitor::~Monitor()
     if ( munmap( mem_ptr, mem_size ) < 0 )
       Fatal( "Can't munmap: %s", strerror(errno) );
     close( map_fd );
+
+    char mmap_path[PATH_MAX] = "";
+    snprintf( mmap_path, sizeof(mmap_path), "%s/zm.mmap.%d", config.path_map, id );
+
+    if ( unlink( mmap_path ) < 0 ) {
+        Warning( "Can't unlink '%s': %s", mmap_path, strerror(errno) );
+    }
 #else // ZM_MEM_MAPPED
     struct shmid_ds shm_data;
     if ( shmctl( shm_id, IPC_STAT, &shm_data ) < 0 ) {

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -675,11 +675,13 @@ Monitor::~Monitor()
       Fatal( "Can't munmap: %s", strerror(errno) );
     close( map_fd );
 
-    char mmap_path[PATH_MAX] = "";
-    snprintf( mmap_path, sizeof(mmap_path), "%s/zm.mmap.%d", config.path_map, id );
+    if ( purpose == CAPTURE ) {
+        char mmap_path[PATH_MAX] = "";
+        snprintf( mmap_path, sizeof(mmap_path), "%s/zm.mmap.%d", config.path_map, id );
 
-    if ( unlink( mmap_path ) < 0 ) {
-        Warning( "Can't unlink '%s': %s", mmap_path, strerror(errno) );
+        if ( unlink( mmap_path ) < 0 ) {
+            Warning( "Can't unlink '%s': %s", mmap_path, strerror(errno) );
+        }
     }
 #else // ZM_MEM_MAPPED
     struct shmid_ds shm_data;


### PR DESCRIPTION
Currently, if a monitor’s status is disabled from the web console, ZoneMinder leaves the mmap file hanging around until ZoneMinder is stopped. This presents a potential problem for machines low on memory, since the mmap files usually reside in the ramdisk. This PR resolves that by unlinking the mmap file at the moment the monitor object is destroyed.