### PR TITLE
Restore former zmswap path behaviour

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -3989,20 +3989,32 @@ void MonitorStream::runStream()
   // 15 is the max length for the swap path suffix, /zmswap-whatever, assuming max 6 digits for monitor id
   const int max_swap_len_suffix = 15; 
 
-  int swap_path_length = strlen(config.path_swap)+1; // +1 for NULL terminator
+  int swap_path_length = strlen(config.path_swap) + 1; // +1 for NULL terminator
+  int subfolder1_length = snprintf(NULL, 0, "/zmswap-m%d", monitor->Id() ) + 1;
+  int subfolder2_length = snprintf(NULL, 0, "/zmswap-q%06d", connkey ) + 1;
+  int total_swap_path_length = swap_path_length + subfolder1_length + subfolder2_length;
 
   if ( connkey && playback_buffer > 0 ) {
 
-    if ( swap_path_length + max_swap_len_suffix > PATH_MAX ) {
-      Error( "Swap Path is too long. %d > %d ", swap_path_length+max_swap_len_suffix, PATH_MAX );
+    if ( total_swap_path_length + max_swap_len_suffix > PATH_MAX ) {
+      Error( "Swap Path is too long. %d > %d ", total_swap_path_length+max_swap_len_suffix, PATH_MAX );
     } else {
-      swap_path = (char *)malloc( swap_path_length+max_swap_len_suffix );
-      Debug( 3, "Checking swap image path %s", config.path_swap );
+      swap_path = (char *)malloc( total_swap_path_length+max_swap_len_suffix );
       strncpy( swap_path, config.path_swap, swap_path_length );
+
+      Debug( 3, "Checking swap path folder: %s", swap_path );
       if ( checkSwapPath( swap_path, false ) ) {
-        snprintf( &(swap_path[swap_path_length]), max_swap_len_suffix, "/zmswap-m%d", monitor->Id() );
+        // Append the subfolder name /zmswap-m{monitor-id} to the end of swap_path
+        int ndx = swap_path_length - 1; // Array index of the NULL terminator
+        snprintf( &(swap_path[ndx]), subfolder1_length, "/zmswap-m%d", monitor->Id() );
+
+        Debug( 4, "Checking swap path subfolder: %s", swap_path );
         if ( checkSwapPath( swap_path, true ) ) {
-          snprintf( &(swap_path[swap_path_length]), max_swap_len_suffix, "/zmswap-q%06d", connkey );
+          // Append the subfolder name /zmswap-q{connection key} to the end of swap_path
+          ndx = swap_path_length+subfolder1_length - 2; // Array index of the NULL terminator
+          snprintf( &(swap_path[ndx]), subfolder2_length, "/zmswap-q%06d", connkey );
+
+          Debug( 4, "Checking swap path subfolder: %s", swap_path );
           if ( checkSwapPath( swap_path, true ) ) {
             buffered_playback = true;
           }

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -4216,9 +4216,6 @@ void MonitorStream::runStream()
   }
   if ( buffered_playback )
   {
-    char swap_path[PATH_MAX] = "";
-
-    snprintf( swap_path, sizeof(swap_path), "%s/zmswap-m%d/zmswap-q%06d", config.path_swap, monitor->Id(), connkey );
     Debug( 1, "Cleaning swap files from %s", swap_path );
     struct stat stat_buf;
     if ( stat( swap_path, &stat_buf ) < 0 )


### PR DESCRIPTION
Commit a9609d2a438a8f5eb5539da9167c4160af8807a6 fixed a memory allocation fault, but it also inadvertently changed the location of where the zmswap jpg files where written to. It also broke zoneminder's ability to delete these files after the fact.

This pr attempts to resolve that. While I have built and tested this on my own machine, please build and test this in your own environment before merging.

What follows is a description of what you should see.

1) Open a live view
2) Inspect your PATH_SWAP folder. It should contain a subfolder called zmswap-m{monitor-id}
3) You should have a subfolder under that called zmswap-q{connection key}
4) Within PATH_SWAP/zmswap-m{monitor-id}/zmswap-q{connection key} you should see lots of jpg files populating while the live stream is open
5) Now close the live stream
6) The folder PATH_SWAP/zmswap-m{monitor-id} should now be empty. Note that zoneminder only deletes the "zmswap-q" subfolder. It leaves the empty "zmswap-m" folder hanging around, ready for the next use.
