### PR TITLE
use zmMemDetach  instead of  zmMemInvalidate

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -418,7 +418,7 @@ while( 1 )
         foreach my $monitor ( values(%monitors) )
         {
             # Free up any used memory handle
-            zmMemInvalidate( $monitor );
+            zmMemDetach( $monitor );
         }
         loadMonitors();
     }

--- a/scripts/zmwatch.pl.in
+++ b/scripts/zmwatch.pl.in
@@ -89,8 +89,8 @@ while( 1 )
         my $restart = 0;
         # Prevent open handles building up if we have connect to shared memory
         # Many of our error checks below do a next without closing the mem handle.
-        # zmMemInvalidate will just return of nothing is open, so we can just do this here.
-        zmMemInvalidate( $monitor );
+        # zmMemDetach will just return of nothing is open, so we can just do this here.
+        zmMemDetach( $monitor );
         if ( zmMemVerify( $monitor )
              && zmMemRead( $monitor, "shared_data:valid" )
         )
@@ -141,6 +141,7 @@ while( 1 )
             {
                 $command = "zmdc.pl restart zmc -m $monitor->{Id}";
             }
+            zmMemDetach( $monitor ); # Close our file handle to the zmc process we are about to end
             runCommand( $command );
         }
         elsif ( $monitor->{Function} ne 'Monitor' )
@@ -184,7 +185,7 @@ while( 1 )
             } # end if restart
         } # end if check analysis daemon
         # Prevent open handles building up if we have connect to shared memory
-        zmMemInvalidate( $monitor );
+        zmMemDetach( $monitor );
     } # end foreach monitor
     sleep( $Config{ZM_WATCH_CHECK_INTERVAL} );
 } # end while (1)

--- a/scripts/zmx10.pl.in
+++ b/scripts/zmx10.pl.in
@@ -580,7 +580,7 @@ sub loadTasks
                 }
             }
         }
-        zmMemInvalidate( $monitor );
+        zmMemDetach( $monitor );
     }
 }
 


### PR DESCRIPTION
Current behavior of the master branch is (still) leaving file handles open on the mmap files.

To reproduce, simply open a monitor and then hit save. No changes to the monitor are necessary. If zmwatch has run, it will have an open file handle on the corresponding mmap file, and it will not let go if you wait for it.

I noticed the same behavior in zmtrigger. 

Experimentation revealed that replacing zmMemInvalidate with zmMemDetach corrects this. 

zmwatch no longer holds the file handle open, and zmtrigger holds the file open for a period of time up to MONITOR_RELOAD_INTERVAL (5 minutes). Maybe we should make that 60 seconds.

Since all the other cool scripts were doing it, I went ahead and made the same change to zmx10.pl, but I don't have a way to test that.


