### PR TITLE
remove the use of empty which on php < 5.5 only supports variables.

### DIFF
--- a/web/skins/classic/includes/control_functions.php
+++ b/web/skins/classic/includes/control_functions.php
@@ -30,7 +30,7 @@ function getControlCommands( $monitor )
     $cmds['PresetGoto'] = "presetGoto";
     $cmds['PresetHome'] = "presetHome";
 
-    if ( !empty($monitor->CanZoom()) )
+    if ( $monitor->CanZoom() )
     {
         if ( $monitor->CanZoomCon() )
             $cmds['ZoomRoot'] = "zoomCon";
@@ -45,7 +45,7 @@ function getControlCommands( $monitor )
         $cmds['ZoomMan'] = "zoomMan";
     }
 
-    if ( !empty($monitor->CanFocus()) )
+    if ( $monitor->CanFocus() )
     {
         if ( $monitor->CanFocusCon() )
             $cmds['FocusRoot'] = "focusCon";
@@ -60,7 +60,7 @@ function getControlCommands( $monitor )
         $cmds['FocusMan'] = "focusMan";
     }
 
-    if ( !empty($monitor->CanIris()) )
+    if ( $monitor->CanIris() )
     {
         if ( $monitor->CanIrisCon() )
             $cmds['IrisRoot'] = "irisCon";
@@ -75,7 +75,7 @@ function getControlCommands( $monitor )
         $cmds['IrisMan'] = "irisMan";
     }
 
-    if ( !empty($monitor->CanWhite()) )
+    if ( $monitor->CanWhite() )
     {
         if ( $monitor->CanWhiteCon() )
             $cmds['WhiteRoot'] = "whiteCon";
@@ -89,7 +89,7 @@ function getControlCommands( $monitor )
         $cmds['WhiteMan'] = "whiteMan";
     }
 
-    if ( !empty($monitor->CanGain()) )
+    if ( $monitor->CanGain() )
     {
         if ( $monitor->CanGainCon() )
             $cmds['GainRoot'] = "gainCon";
@@ -103,7 +103,7 @@ function getControlCommands( $monitor )
         $cmds['GainMan'] = "gainMan";
     }
 
-    if ( !empty($monitor->CanMove()) )
+    if ( $monitor->CanMove() )
     {
         if ( $monitor->CanMoveCon() )
         {


### PR DESCRIPTION
When I switched to using object methods, this broke the use of empty() on php < 5.5.  

These monitor methods should return either a valid value or nothing, so we shouldn't need the empty.