### PR TITLE
Reload stream when changing scale

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -136,8 +136,11 @@ function changeScale()
         var newHeight = ( monitorData[x].height * scale ) / SCALE_BASE;
         /*Stream could be an applet so can't use moo tools*/ 
         var streamImg = document.getElementById( 'liveStream'+monitor.id );
-        streamImg.style.width = newWidth + "px";
-        streamImg.style.height = newHeight + "px";
+        if ( streamImg ) {
+          streamImg.src = streamImg.src.replace(/rand=\d+/i,'rand='+Math.floor((Math.random() * 1000000) ));
+          streamImg.style.width = newWidth + "px";
+          streamImg.style.height = newHeight + "px";
+        }
     }
     Cookie.write( 'zmMontageScale', scale, { duration: 10*365 } );
 }


### PR DESCRIPTION
When changing the scale, we update the css, but leave the stream at the previous resolution causing us to view a poorly scaled image.  This code will update the src of the stream and cause it to reload.