### PR TITLE
bump minimum version of cmake to 2.8.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Created by mastertheknife (Kfir Itzhak)
 # For more information and installation, see the INSTALL file
 #
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.7)
 project (zoneminder)
 file (STRINGS "version" zoneminder_VERSION)
 # make API version a minor of ZM version


### PR DESCRIPTION
This change is intended to avoid the following issue with older versions of cmake:
https://bugzilla.redhat.com/show_bug.cgi?id=795542

Only the earliest versions of CentOS 6 had a version of cmake older than this which causes me to work around the problem in the rpm spec file. 

cmake 2.8.7 was released in Dec 2011, so I don't believe this change will cause any issues with other distros. However, it does allow me to remove the work around currently implemented in the rpm spec file.