### PR TITLE
Initial commit of github issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+You should only file an issue if you found a bug.  Feature and enhancement requests, general discussions and support questions should occur in one of the following areas:
+
+- The ZoneMinder IRC channel - irc.freenode.net #zoneminder
+- The [ZoneMinder Forum](https://forums.zoneminder.com/)
+
+**Do not post feature or enhancement requests, general discussions or support questions here.**
+
+Make sure you are running the latest version of ZoneMinder before reporting an issue.
+
+**ZoneMinder Version (`zmaudit.pl -v`):**
+
+**Are you using a development snapshot / git checkout?  If so, what is the latest commit? (`git rev-parse HEAD`):**
+
+**Linux Distribution and Version (`cat /etc/os-release` or `cat /etc/redhat-release`):**
+
+**If the issue concerns a camera, provide the make, model, frame rate, resolution and ZoneMinder Source Type:**
+
+**Relevant log lines:**
+```
+log lines here
+```


### PR DESCRIPTION
This is mostly for @knnniggett's sanity, as well as to raise the quality and action-ability of received issues.  All new issues will have the information contained in this file displayed in new issue requests.  

See https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/ and https://github.com/blog/2111-issue-and-pull-request-templates for more information.