### PR TITLE
When use warnings is on and there is a null value in the monitor data…

### DIFF
--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -417,6 +417,7 @@ sub toPreset
     # ip addresses, ports, usernames, etc. with generic placeholders
     if (!$noregex) {
         foreach (@data) {
+            next if ! $_;
             s/\b(?:\d{1,3}\.){3}\d{1,3}\b/<ip-address>/; # ip address
             s/<ip-address>:(6553[0-5]|655[0-2]\d|65[0-4]\d\d|6[0-4]\d{3}|[1-5]\d{4}|[1-9]\d{0,3}|0)$/<ip-address>:<port>/; # tcpip port
             s/\/\/.*:.*@/\/\/<username>:<pwd>@/; # user & pwd preceding an ip address


### PR DESCRIPTION
… it causes warnings.  So add skip if $_ is not defined.