### PR TITLE
Control fixes

### DIFF
--- a/web/includes/control_functions.php
+++ b/web/includes/control_functions.php
@@ -9,7 +9,7 @@ function buildControlCommand( $monitor )
         $slow = 0.9; // Threshold for slow speed/timeouts
         $turbo = 0.9; // Threshold for turbo speed
 
-        if ( preg_match( '/^([a-z]+)([A-Z][a-z]+)([A-Z][a-z]+)+$/', $_REQUEST['control'], $matches ) )
+        if ( preg_match( '/^([a-z]+)([A-Z][a-z]+)([A-Za-z]+)+$/', $_REQUEST['control'], $matches ) )
         {
             $command = $matches[1];
             $mode = $matches[2];
@@ -278,6 +278,8 @@ function buildControlCommand( $monitor )
                     }
                 }
             }
+        } else {
+          Error("Invalid control parameter: " . $_REQUEST['control'] );
         }
     }
     elseif ( isset($_REQUEST['x']) && isset($_REQUEST['y']) )

--- a/web/skins/classic/includes/control_functions.php
+++ b/web/skins/classic/includes/control_functions.php
@@ -253,7 +253,7 @@ function controlPanTilt( $monitor, $cmds )
       <div class="arrowBtn upLeftBtn<?php echo $hasDiag?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveUpLeft'] ?>',event,-1,-1)"></div>
       <div class="arrowBtn upBtn<?php echo $hasTilt?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveUp'] ?>',event,0,-1)"></div>
       <div class="arrowBtn upRightBtn<?php echo $hasDiag?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveUpRight'] ?>',event,1,-1)"></div>
-      <div class="arrowBtn leftBtn<?php echo $hasPan?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveLeft'] ?>',event,1,0)"></div>
+      <div class="arrowBtn leftBtn<?php echo $hasPan?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveLeft'] ?>',event,-1,0)"></div>
       <div class="arrowBtn centerBtn" onclick="controlCmd('<?php echo $cmds['Center'] ?>')"></div>
       <div class="arrowBtn rightBtn<?php echo $hasPan?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveRight'] ?>',event,1,0)"></div>
       <div class="arrowBtn downLeftBtn<?php echo $hasDiag?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveDownLeft'] ?>',event,-1,1)"></div>


### PR DESCRIPTION
I have verified these problems and the fixes.

See the following for the source of these and discussion. I will cutnpaste here as well.

https://forums.zoneminder.com/viewtopic.php?f=9&t=25241

The following was posted by cenzo188:

I noticed a couple of problems with control of PTZ cameras. I have an Axis 213 running using the Axis API v2 script that came with ZM.
The diagonal arrows didn't work even though diagonal movement is supported by the script.
This I fixed in /usr/share/zoneminder/www/include/control_functions.php line 12:

Code: Select all
-if ( preg_match( '/^([a-z]+)([A-Z][a-z]+)([A-Z][a-z]+)+$/', $_REQUEST['control'], $matches ) )
+if ( preg_match( '/^([a-z]+)([A-Z][a-z]+)([A-Za-z]+)+$/', $_REQUEST['control'], $matches ) )

The regex is intended to match the different parts of the movement command. For example if the command is "moveRelUpLeft", it should match the command "move", the mode "Rel", and the direction "UpLeft" in order to break that command up into pansteps and tiltsteps. Instead, the regex only matched "move", "Rel", and "Left", resulting in a missing mandatory --tiltstep argument.
The new regex matches "UpLeft" (and the other directions) as it should.

Also, the left arrow worked backwards. Clicking near the base of the arrow produced a large movement, while clicking near the tip produced a small movement. This problem was in /usr/share/zoneminder/www/skins/classic/includes/control_functions.php line 256:

Code: Select all
-<div class="arrowBtn leftBtn<?php echo $hasPan?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveLeft'] ?>',event,1,0)"></div>
+<div class="arrowBtn leftBtn<?php echo $hasPan?'':' invisible' ?>" onclick="controlCmd('<?php echo $cmds['MoveLeft'] ?>',event,-1,0)"></div>

Just a 1 where there should have been a -1.

I hope these fixes are of use to somebody.

I would also like to get mapped movement working. I've seen multiple references that suggest that when mapped movement is supported, the camera can moved by clicking on the image. However, clicking on the image just zooms it in. I have "can move mapped" checked. I looked through my config and couldn't find a relevant option.
Has that feature been removed from ZM?
