### PR TITLE
fix conditional logic in controlcap.js

### DIFF
--- a/web/skins/classic/views/js/controlcap.js
+++ b/web/skins/classic/views/js/controlcap.js
@@ -3,7 +3,7 @@ function validateForm( form ) {
 
     // If "Can Move" is enabled, then the end user must also select at least one of the other check boxes (excluding Can Move Diagonally)
     if ( form.elements['newControl[CanMove]'].checked ) {
-        if ( !form.elements['newControl[CanMoveCon]'].checked || !form.elements['newControl[CanMoveRel]'].checked || !form.elements['newControl[CanMoveAbs]'].checked || !form.elements['newControl[CanMoveMap]'].checked ) {
+        if ( !(form.elements['newControl[CanMoveCon]'].checked || form.elements['newControl[CanMoveRel]'].checked || form.elements['newControl[CanMoveAbs]'].checked || form.elements['newControl[CanMoveMap]'].checked) ) {
             errors[errors.length] = "In addition to \"Can Move\", you also must select at least one of: \"Can Move Mapped\", \"Can Move Absolute\", \"Can Move Relative\", or \"Can Move Continuous\"";
         }
     } else {


### PR DESCRIPTION
I did not set the logic in this correctly the first time around. Currently the controlcap form will only save when *all four* ptz movement types are checked. Instead, we want the form to save if *at least one* of the movement types are selected.