### PR TITLE
fix else behaviour by adding braces

### DIFF
--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -42,10 +42,11 @@ VideoStream::MimeData VideoStream::mime_data[] = {
 
 void VideoStream::Initialise( )
 {
-  if ( logDebugging() )
+  if ( logDebugging() ) {
     av_log_set_level( AV_LOG_DEBUG );
-  else
+  } else {
     av_log_set_level( AV_LOG_QUIET );
+  }
 
   av_register_all( );
 #if LIBAVFORMAT_VERSION_CHECK(53, 13, 0, 19, 0)

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -739,8 +739,8 @@ Debug(5, "sendkeepalive %d, timeout %d, now: %d last: %d since: %d", sendKeepali
         {
           if ( buffer[0] == '$' )
           {
-          if ( buffer.size() < 4 )
-            break;
+            if ( buffer.size() < 4 )
+              break;
             unsigned char channel = buffer[1];
             unsigned short len = ntohs( *((unsigned short *)(buffer+2)) );
 


### PR DESCRIPTION
These are minor fixes for compiler warnings that turned up in Yakkety.  