### PR TITLE
Fixed apache documentroot, and fixed permissions for "/" in the project's Dockerfile

### DIFF
--- a/utils/docker/apache-vhost
+++ b/utils/docker/apache-vhost
@@ -1,12 +1,14 @@
 <VirtualHost *:80>
-        DocumentRoot /usr/local/share/zoneminder
+        DocumentRoot /usr/local/share/zoneminder/www
         DirectoryIndex index.php
 
         ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+        <Directory />
+                Require all granted
+        </Directory>
         <Directory "/usr/lib/cgi-bin">
                 AllowOverride None
                 Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-		require all granted
+                Require all granted
         </Directory>
-
 </VirtualHost>


### PR DESCRIPTION
This PR addresses #1747 by fixing the following two issues:

1. Documentroot was broken, so location was updated.
2. Apache was throwing a 403 because permissions were not set for "/".

