### PR TITLE
[Upstream FreeBSD specific patches]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,13 +386,13 @@ find_library(MYSQLCLIENT_LIBRARIES mysqlclient PATH_SUFFIXES mysql)
 if(MYSQLCLIENT_LIBRARIES)
 	set(HAVE_LIBMYSQLCLIENT 1)
 	list(APPEND ZM_BIN_LIBS "${MYSQLCLIENT_LIBRARIES}")
-	find_path(MYSQLCLIENT_INCLUDE_DIR mysql/mysql.h)
+	find_path(MYSQLCLIENT_INCLUDE_DIR mysql.h /usr/local/include/mysql /usr/include/mysql)
 	if(MYSQLCLIENT_INCLUDE_DIR)
 		include_directories("${MYSQLCLIENT_INCLUDE_DIR}")
 		set(CMAKE_REQUIRED_INCLUDES "${MYSQLCLIENT_INCLUDE_DIR}")
 	endif(MYSQLCLIENT_INCLUDE_DIR)
 	mark_as_advanced(FORCE MYSQLCLIENT_LIBRARIES MYSQLCLIENT_INCLUDE_DIR)
-	check_include_file("mysql/mysql.h" HAVE_MYSQL_H)
+	check_include_file("mysql.h" HAVE_MYSQL_H)
 	if(NOT HAVE_MYSQL_H)
 		message(FATAL_ERROR 
                     "ZoneMinder requires MySQL headers - check that MySQL development packages are installed")
@@ -660,11 +660,13 @@ message(STATUS "Using web user: ${ZM_WEB_USER}")
 message(STATUS "Using web group: ${ZM_WEB_GROUP}")
 
 # Check for polkit
-find_package(Polkit)
-if(NOT POLKIT_FOUND)
-	message(FATAL_ERROR 
-            "Running ZoneMinder requires polkit. Building ZoneMinder requires the polkit development package.")
-endif(NOT POLKIT_FOUND)
+if(NOT BSD)
+    find_package(Polkit)
+    if(NOT POLKIT_FOUND)
+        message(FATAL_ERROR
+                "Running ZoneMinder requires polkit. Building ZoneMinder requires the polkit development package.")
+    endif(NOT POLKIT_FOUND)
+endif(NOT BSD)
 
 # Some variables that zm expects
 set(ZM_PID "${ZM_RUNDIR}/zm.pid")

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -1658,11 +1658,9 @@ Image *Image::Highlight( unsigned int n_images, Image *images[], const Rgb thres
       {
         uint8_t *psrc = images[j]->buffer+c;
 
-#ifndef SOLARIS
-        if ( (unsigned)abs((*psrc)-RGB_VAL(ref_colour,c)) >= RGB_VAL(threshold,c) )
-#else
-        if ( (unsigned)std::abs((*psrc)-RGB_VAL(ref_colour,c)) >= RGB_VAL(threshold,c) )
-#endif
+	    unsigned int diff = ((*psrc)-RGB_VAL(ref_colour,c)) > 0 ? (*psrc)-RGB_VAL(ref_colour,c) : RGB_VAL(ref_colour,c) - (*psrc);
+
+	    if (diff >= RGB_VAL(threshold,c))
         {
           count++;
         }

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -31,9 +31,9 @@
 #include <signal.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <libgen.h>
 #ifdef __FreeBSD__
 #include <sys/thr.h>
-#include <libgen.h>
 #endif
 
 bool Logger::smInitialised = false;
@@ -515,8 +515,9 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
     va_list     argPtr;
     struct timeval  timeVal;
 
-    const char * const file = basename(filepath);
-    
+    char *filecopy = strdup(filepath);
+    const char * const file = basename(filecopy);
+
     if ( level < PANIC || level > DEBUG9 )
       Panic( "Invalid logger level %d", level );
 
@@ -630,6 +631,8 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
       //priority |= LOG_DAEMON;
       syslog( priority, "%s [%s]", classString, syslogStart );
     }
+
+    free(filecopy);
 
     if ( level <= FATAL )
     {

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -160,7 +160,7 @@ bool Monitor::MonitorLink::connect()
       return( false );
     }
     mem_ptr = (unsigned char *)shmat( shm_id, 0, 0 );
-    if ( mem_ptr < 0 )
+    if ( mem_ptr < (void *)0 )
     {
       Debug( 3, "Can't shmat link memory: %s", strerror(errno) );
       connected = false;
@@ -194,7 +194,7 @@ bool Monitor::MonitorLink::disconnect()
     connected = false;
 
 #if ZM_MEM_MAPPED
-    if ( mem_ptr > 0 )
+    if ( mem_ptr > (void *)0 )
     {
       msync( mem_ptr, mem_size, MS_ASYNC );
       munmap( mem_ptr, mem_size );
@@ -222,7 +222,7 @@ bool Monitor::MonitorLink::disconnect()
       }
     }
 
-    if ( shmdt( mem_ptr ) < 0 )
+    if ( shmdt( mem_ptr ) < (void *)0 )
     {
       Debug( 3, "Can't shmdt: %s", strerror(errno) );
       return( false );
@@ -558,7 +558,7 @@ bool Monitor::connect() {
     exit( -1 );
   }
   mem_ptr = (unsigned char *)shmat( shm_id, 0, 0 );
-  if ( mem_ptr < 0 )
+  if ( mem_ptr < (void *)0 )
   {
     Error( "Can't shmat: %s", strerror(errno));
     exit( -1 );

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -222,7 +222,7 @@ bool Monitor::MonitorLink::disconnect()
       }
     }
 
-    if ( shmdt( mem_ptr ) < (void *)0 )
+    if ( shmdt( mem_ptr ) < 0 )
     {
       Debug( 3, "Can't shmdt: %s", strerror(errno) );
       return( false );

--- a/src/zmf.cpp
+++ b/src/zmf.cpp
@@ -331,7 +331,7 @@ int main( int argc, char *argv[] )
     Debug( 1, "Got image, writing to %s", path );
 
     FILE *fd = 0;
-    if ( (fd = fopen( path, "w" )) < (void *)0 )
+    if ( (fd = fopen( path, "w" )) == NULL )
     {
       Error( "Can't fopen '%s': %s", path, strerror(errno) );
       exit( -1 );

--- a/src/zmf.cpp
+++ b/src/zmf.cpp
@@ -331,7 +331,7 @@ int main( int argc, char *argv[] )
     Debug( 1, "Got image, writing to %s", path );
 
     FILE *fd = 0;
-    if ( (fd = fopen( path, "w" )) < 0 )
+    if ( (fd = fopen( path, "w" )) < (void *)0 )
     {
       Error( "Can't fopen '%s': %s", path, strerror(errno) );
       exit( -1 );


### PR DESCRIPTION
- Remove usage of abs() . This one fixes https://github.com/ZoneMinder/ZoneMinder/issues/1530
- Switch to POSIX basename() FreeBSD project deprecates GNU functions if POSIX analogs available. Function was entirely removed in HEAD.
- cmake patch to remove polkit check for FreeBSD and provide more paths for mysql header lookup.
- fix llvm400 specific errors See https://github.com/ZoneMinder/ZoneMinder/issues/1760