### PR TITLE
Align Method description to what it is actually doing

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -905,11 +905,11 @@ $OLANG = array(
 		          "\"loglevel=debug\" Set verbosity of FFmpeg (quiet, panic, fatal, error, warning, info, verbose, debug)"
 	),
         'OPTIONS_RTSPTrans' => array(
-		'Help' => "This sets the lower RTSP Transport Protocol for FFmpeg.~~ ".
-                          "TCP - Use TCP (interleaving within the RTSP control channel) as lower transport protocol.~~".
-                          "UDP - Use UDP as lower transport protocol~~".
-                          "UDP Multicast - Use UDP Multicast as lower transport protocol~~".
-                          "HTTP - Use HTTP tunneling as lower transport protocol, which is useful for passing proxies.~~"
+		'Help' => "This sets the RTSP Transport Protocol for FFmpeg.~~ ".
+                          "TCP - Use TCP (interleaving within the RTSP control channel) as transport protocol.~~".
+                          "UDP - Use UDP as transport protocol. Higher resolution cameras have experienced some 'smearing' while using UDP, if so try TCP~~".
+                          "UDP Multicast - Use UDP Multicast as transport protocol~~".
+                          "HTTP - Use HTTP tunneling as transport protocol, which is useful for passing proxies.~~"
 	),
 	'OPTIONS_LIBVLC' => array(
 		'Help' => "Parameters in this field are passed on to libVLC. Multiple parameters can be separated by ,~~ ".

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -614,6 +614,7 @@ $SLANG = array(
     'Rewind'                => 'Rewind',
     'RotateLeft'            => 'Rotate Left',
     'RotateRight'           => 'Rotate Right',
+    'RTSPTransport'         => 'RTSP Transport Protocol',
     'RunLocalUpdate'        => 'Please run zmupdate.pl to update',
     'RunMode'               => 'Run Mode',
     'Running'               => 'Running',
@@ -902,6 +903,13 @@ $OLANG = array(
 		          "\"allowed_media_types=video\" Set datatype to request fromcam (audio, video, data)~~~~".
 		          "\"reorder_queue_size=nnn\" Set number of packets to buffer for handling of reordered packets~~~~".
 		          "\"loglevel=debug\" Set verbosity of FFmpeg (quiet, panic, fatal, error, warning, info, verbose, debug)"
+	),
+        'OPTIONS_RTSPTrans' => array(
+		'Help' => "This sets the lower RTSP Transport Protocol for FFmpeg.~~ ".
+                          "TCP - Use TCP (interleaving within the RTSP control channel) as lower transport protocol.~~".
+                          "UDP - Use UDP as lower transport protocol~~".
+                          "UDP Multicast - Use UDP Multicast as lower transport protocol~~".
+                          "HTTP - Use HTTP tunneling as lower transport protocol, which is useful for passing proxies.~~"
 	),
 	'OPTIONS_LIBVLC' => array(
 		'Help' => "Parameters in this field are passed on to libVLC. Multiple parameters can be separated by ,~~ ".

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -242,6 +242,13 @@ $rtspMethods = array(
     "rtpRtspHttp" => "RTP/RTSP/HTTP"
 );
 
+$rtspFFMpegMethods = array(
+    "rtpRtsp"     => "TCP",
+    "rtpUni"      => "UDP",
+    "rtpMulti"    => "UDP Multicast",
+    "rtpRtspHttp" => "HTTP Tunnel"
+);
+
 $httpMethods = array(
     "simple"   => "Simple",
     "regexp"   => "Regexp",
@@ -858,7 +865,7 @@ switch ( $tab )
         {
 ?>
       <tr><td><?php echo translate('SourcePath') ?></td><td><input type="text" name="newMonitor[Path]" value="<?php echo validHtmlStr($newMonitor['Path']) ?>" size="36"/></td></tr>
-            <tr><td><?php echo translate('RemoteMethod') ?></td><td><?php echo buildSelect( "newMonitor[Method]", $rtspMethods ); ?></td></tr>
+            <tr><td><?php echo translate('RemoteMethod') ?></td><td><?php echo buildSelect( "newMonitor[Method]", $rtspFFMpegMethods ); ?></td></tr>
       <tr><td><?php echo translate('Options') ?>&nbsp;(<?php echo makePopupLink( '?view=optionhelp&amp;option=OPTIONS_'.strtoupper($newMonitor['Type']), 'zmOptionHelp', 'optionhelp', '?' ) ?>)</td><td><input type="text" name="newMonitor[Options]" value="<?php echo validHtmlStr($newMonitor['Options']) ?>" size="36"/></td></tr>
 <?php
         }

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -865,7 +865,7 @@ switch ( $tab )
         {
 ?>
       <tr><td><?php echo translate('SourcePath') ?></td><td><input type="text" name="newMonitor[Path]" value="<?php echo validHtmlStr($newMonitor['Path']) ?>" size="36"/></td></tr>
-            <tr><td><?php echo translate('RemoteMethod') ?></td><td><?php echo buildSelect( "newMonitor[Method]", $rtspFFMpegMethods ); ?></td></tr>
+            <tr><td><?php echo translate('RemoteMethod') ?>&nbsp;(<?php echo makePopupLink('?view=optionhelp&amp;option=OPTIONS_RTSPTrans', 'zmOptionHelp', 'optionhelp', '?' ) ?>)</td><td><?php echo buildSelect( "newMonitor[Method]", $rtspFFMpegMethods ); ?></td></tr>
       <tr><td><?php echo translate('Options') ?>&nbsp;(<?php echo makePopupLink( '?view=optionhelp&amp;option=OPTIONS_'.strtoupper($newMonitor['Type']), 'zmOptionHelp', 'optionhelp', '?' ) ?>)</td><td><input type="text" name="newMonitor[Options]" value="<?php echo validHtmlStr($newMonitor['Options']) ?>" size="36"/></td></tr>
 <?php
         }


### PR DESCRIPTION
Makes it hard for people to know what they are doing with the descriptions from Remote camera, so changed them to line up with FFmpeg option they are controlling. Does also impact libvlc, but these descriptions are closer also. Only fixing as it annoyed me.