### PR TITLE
Add human filesize to the event filesize column 

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2137,7 +2137,14 @@ function folder_size($dir) {
     foreach (glob(rtrim($dir, '/').'/*', GLOB_NOSORT) as $each) {
         $size += is_file($each) ? filesize($each) : folderSize($each);
     }
-    return $size;
+    //return $size . ' bytes';
+    return human_filesize($size);
 } // end function folder_size
+
+function human_filesize($bytes, $decimals = 2) {
+  $sz = 'BKMGTP';
+  $factor = floor((strlen($bytes) - 1) / 3);
+  return sprintf("%.{$decimals}f", $bytes / pow(1024, $factor)) . @$sz[$factor];
+}
 
 ?>


### PR DESCRIPTION
Instead of showing the size in bytes without punctuation, shows the size in 2 decimal places with notation in human format (b, K, M, G).