### PR TITLE
Reduce the default API debug level

### DIFF
--- a/web/api/app/Config/core.php.default
+++ b/web/api/app/Config/core.php.default
@@ -31,7 +31,7 @@
  * In production mode, flash messages redirect after a time interval.
  * In development mode, you need to click the flash message to continue.
  */
-	Configure::write('debug', 2);
+	Configure::write('debug', 0);
 
 /**
  * Configure the Error handler used to handle errors for your application. By default


### PR DESCRIPTION
Turn off Cake php debug output to prevent revealing sensitive information in the event of an error