### PR TITLE
fix permissions on zm.conf in deb pkg scripts

### DIFF
--- a/distros/ubuntu1204/rules
+++ b/distros/ubuntu1204/rules
@@ -58,8 +58,10 @@ override_dh_auto_install:
 
 override_dh_fixperms:
 	dh_fixperms
-	## 637685
-	chmod -c o-r $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
+	#
+	# As requested by the Debian Webapps Policy Manual §3.2.1
+	chown root:www-data debian/zoneminder-core/etc/zm/zm.conf
+	chmod 640 debian/zoneminder-core/etc/zm/zm.conf
 
 override_dh_installinit:
 	dh_installinit --no-start

--- a/distros/ubuntu1204/rules
+++ b/distros/ubuntu1204/rules
@@ -60,8 +60,8 @@ override_dh_fixperms:
 	dh_fixperms
 	#
 	# As requested by the Debian Webapps Policy Manual §3.2.1
-	chown root:www-data debian/zoneminder-core/etc/zm/zm.conf
-	chmod 640 debian/zoneminder-core/etc/zm/zm.conf
+	chown root:www-data $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
+	chmod 640 $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
 
 override_dh_installinit:
 	dh_installinit --no-start

--- a/distros/ubuntu1604/rules
+++ b/distros/ubuntu1604/rules
@@ -58,8 +58,10 @@ override_dh_auto_install:
 
 override_dh_fixperms:
 	dh_fixperms
-	## 637685
-	chmod -c o-r $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
+	#
+	# As requested by the Debian Webapps Policy Manual §3.2.1
+	chown root:www-data debian/zoneminder-core/etc/zm/zm.conf
+	chmod 640 debian/zoneminder-core/etc/zm/zm.conf
 
 override_dh_installinit:
 	dh_installinit --no-start

--- a/distros/ubuntu1604/rules
+++ b/distros/ubuntu1604/rules
@@ -60,8 +60,8 @@ override_dh_fixperms:
 	dh_fixperms
 	#
 	# As requested by the Debian Webapps Policy Manual §3.2.1
-	chown root:www-data debian/zoneminder-core/etc/zm/zm.conf
-	chmod 640 debian/zoneminder-core/etc/zm/zm.conf
+	chown root:www-data $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
+	chmod 640 $(CURDIR)/debian/zoneminder/etc/zm/zm.conf
 
 override_dh_installinit:
 	dh_installinit --no-start


### PR DESCRIPTION
Was troubleshooting the following non-fatal error during installation of deb packages created by packpack:
```
$sudo gdebi zoneminder_1.30.2-17_amd64.deb
Reading package lists... Done
Building dependency tree        
Reading state information... Done
Building data structures... Done 
Building data structures... Done 

video camera security and surveillance solution
 ZoneMinder is intended for use in single or multi-camera video security
 applications, including commercial or home CCTV, theft prevention and child
 or family member or home monitoring and other care scenarios. It
 supports capture, analysis, recording, and monitoring of video data coming
 from one or more video or network cameras attached to a Linux system.
 ZoneMinder also support web and semi-automatic control of Pan/Tilt/Zoom
 cameras using a variety of protocols. It is suitable for use as a home
 video security system and for commercial or professional video security
 and surveillance. It can also be integrated into a home automation system
 via X.10 or other protocols.
Do you want to install the software package? [y/N]:y
Selecting previously unselected package zoneminder.
(Reading database ... 84980 files and directories currently installed.)
Preparing to unpack zoneminder_1.30.2-17_amd64.deb ...
Unpacking zoneminder (1.30.2-17) ...
Setting up zoneminder (1.30.2-17) ...
Stopping ZoneMinder: Can't open config file '/etc/zm/zm.conf': Permission denied at /usr/share/perl5/ZoneMinder/Config.pm line 129.
BEGIN failed--compilation aborted at /usr/share/perl5/ZoneMinder/Config.pm line 129.
Compilation failed in require at /usr/share/perl5/ZoneMinder.pm line 33.
BEGIN failed--compilation aborted at /usr/share/perl5/ZoneMinder.pm line 33.
Compilation failed in require at /usr/bin/zmdc.pl line 65.
BEGIN failed--compilation aborted at /usr/bin/zmdc.pl line 65.
Zoneminder already stopped
```
It turned out the  debian rules file was incorrectly setting permissions on zm.conf during the build.

This pr changes the rules file to set the permissions to allow the www-data group to read the file. This also matches what is currently in this rules file: https://github.com/ZoneMinder/ZoneMinder/blob/master/distros/ubuntu1504_cmake_split_packages/rules#L118

