### PR TITLE
Fix zmc crashing when zones are no good 

### DIFF
--- a/src/zm_zone.cpp
+++ b/src/zm_zone.cpp
@@ -990,12 +990,14 @@ int Zone::Load( Monitor *monitor, Zone **&zones )
     Polygon polygon;
     if ( !ParsePolygonString( Coords, polygon ) ) {
       Error( "Unable to parse polygon string '%s' for zone %d/%s for monitor %s, ignoring", Coords, Id, Name, monitor->Name() );
+      n_zones -= 1;
       continue;
     }
 
     if ( polygon.LoX() < 0 || polygon.HiX() >= (int)monitor->Width() 
        || polygon.LoY() < 0 || polygon.HiY() >= (int)monitor->Height() ) {
       Error( "Zone %d/%s for monitor %s extends outside of image dimensions, (%d,%d), (%d,%d), ignoring", Id, Name, monitor->Name(), polygon.LoX(), polygon.LoY(), polygon.HiX(), polygon.HiY() );
+      n_zones -= 1;
       continue;
     }
 


### PR DESCRIPTION
When the zone data is bogus for some reason like extending outside the bounds of the image, we are skipping the zone, but then still return a zone count that includes the bogus zone.  This decreases the count when we skip the zone.  

With this, zmc no longer crashes.