### PR TITLE
1768 fix email tokens for h264 storage

### DIFF
--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -684,16 +684,28 @@ sub substituteTags
         $text =~ s/%EPIM%/$url?view=frame&mid=$event->{MonitorId}&eid=$event->{Id}&fid=$max_alarm_frame->{FrameId}/g;
         if ( $attachments_ref && $text =~ s/%EI1%//g )
         {
-            push( @$attachments_ref,
-                {
-                    type=>"image/jpeg",
-                    path=>sprintf(
-                        "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
-                        getEventPath( $event ),
-                        $first_alarm_frame->{FrameId}
-                    )
-                }
+            my $path_prefix = sprintf(
+                "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d",
+                getEventPath($event),
+                $first_alarm_frame->{FrameId}
             );
+
+            # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
+            if ( -e $path_prefix."-capture.jpg"
+                || ( -e $path_prefix."-video.mp4"
+                    && !system("ffmpeg -v 0 -i ".$path_prefix
+                        ."-video.mp4 -vf 'select=gte(n\\,".$max_alarm_frame."),setpts=PTS-STARTPTS' -f image2 "
+                        .$path_prefix."-capture.jpg"
+                    )
+                )
+            ) {
+                push( @$attachments_ref,
+                    {
+                        type=>"image/jpeg",
+                        path=>$path_prefix."-capture.jpg"
+                    }
+                );
+            }
         }
         if ( $attachments_ref && $text =~ s/%EIM%//g )
         {
@@ -702,16 +714,28 @@ sub substituteTags
                  || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
             )
             {
-                push( @$attachments_ref,
-                    {
-                        type=>"image/jpeg",
-                        path=>sprintf(
-                            "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
-                            getEventPath( $event ),
-                            $max_alarm_frame->{FrameId}
-                        )
-                    }
+                my $path_prefix = sprintf(
+                    "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d",
+                    getEventPath($event),
+                    $max_alarm_frame->{FrameId}
                 );
+
+                # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
+                if ( -e $path_prefix."-capture.jpg"
+                    || ( -e $path_prefix."-video.mp4"
+                        && !system("ffmpeg -v 0 -i ".$path_prefix
+                          ."-video.mp4 -vf 'select=gte(n\\,".$max_alarm_frame."),setpts=PTS-STARTPTS' -f image2 "
+                          .$path_prefix."-capture.jpg"
+                        )
+                    )
+                ) {
+                    push( @$attachments_ref,
+                        {
+                            type=>"image/jpeg",
+                            path=>$path_prefix."-capture.jpg"
+                        }
+                    );
+                }
             }
         }
     }
@@ -1006,4 +1030,3 @@ sub executeCommand
     }
     return( 1 );
 }
-

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -684,25 +684,21 @@ sub substituteTags
         $text =~ s/%EPIM%/$url?view=frame&mid=$event->{MonitorId}&eid=$event->{Id}&fid=$max_alarm_frame->{FrameId}/g;
         if ( $attachments_ref && $text =~ s/%EI1%//g )
         {
-            my $path_prefix = sprintf(
-                "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d",
-                getEventPath($event),
-                $first_alarm_frame->{FrameId}
-            );
+            my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
+                getEventPath($event), $first_alarm_frame->{FrameId});
+            my $video_path =  sprintf("%s/-video.mp4", getEventPath($event));
 
             # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
-            if ( -e $path_prefix."-capture.jpg"
-                || ( -e $path_prefix."-video.mp4"
-                    && !system("ffmpeg -v 0 -i ".$path_prefix
-                        ."-video.mp4 -vf 'select=gte(n\\,".$max_alarm_frame."),setpts=PTS-STARTPTS' -f image2 "
-                        .$path_prefix."-capture.jpg"
+            if ( -e $image_path || ( -e $video_path
+                    && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
+                        .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -f image2 ".$image_path
                     )
                 )
             ) {
                 push( @$attachments_ref,
                     {
                         type=>"image/jpeg",
-                        path=>$path_prefix."-capture.jpg"
+                        path=>$image_path
                     }
                 );
             }
@@ -714,25 +710,21 @@ sub substituteTags
                  || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
             )
             {
-                my $path_prefix = sprintf(
-                    "%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d",
-                    getEventPath($event),
-                    $max_alarm_frame->{FrameId}
-                );
+                my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
+                    getEventPath($event), $max_alarm_frame->{FrameId});
+                my $video_path =  sprintf("%s/-video.mp4", getEventPath($event));
 
                 # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
-                if ( -e $path_prefix."-capture.jpg"
-                    || ( -e $path_prefix."-video.mp4"
-                        && !system("ffmpeg -v 0 -i ".$path_prefix
-                          ."-video.mp4 -vf 'select=gte(n\\,".$max_alarm_frame."),setpts=PTS-STARTPTS' -f image2 "
-                          .$path_prefix."-capture.jpg"
+                if ( -e $image_path || ( -e $video_path
+                        && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
+                            .$max_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -f image2 ".$image_path
                         )
                     )
                 ) {
                     push( @$attachments_ref,
                         {
                             type=>"image/jpeg",
-                            path=>$path_prefix."-capture.jpg"
+                            path=>$image_path
                         }
                     );
                 }

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -686,12 +686,14 @@ sub substituteTags
         {
             my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
                 getEventPath($event), $first_alarm_frame->{FrameId});
-            my $video_path =  sprintf("%s/-video.mp4", getEventPath($event));
+            my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
+
+           Debug("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\," .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path);
 
             # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
             if ( -e $image_path || ( -e $video_path
                     && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                        .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -f image2 ".$image_path
+                        .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
                     )
                 )
             ) {
@@ -712,12 +714,12 @@ sub substituteTags
             {
                 my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
                     getEventPath($event), $max_alarm_frame->{FrameId});
-                my $video_path =  sprintf("%s/-video.mp4", getEventPath($event));
+                my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
 
                 # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
                 if ( -e $image_path || ( -e $video_path
                         && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                            .$max_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -f image2 ".$image_path
+                            .$max_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
                         )
                     )
                 ) {

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -1,4 +1,4 @@
-©#!/usr/bin/perl -wT
+#!/usr/bin/perl -wT
 #
 # ==========================================================================
 #
@@ -434,7 +434,7 @@ sub generateImage
     # check if the image file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
     if ( -e $image_path || ( -e $video_path
             && !system("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
+                .$frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
             )
         ))
     {
@@ -711,7 +711,7 @@ sub substituteTags
         $text =~ s/%EPIM%/$url?view=frame&mid=$event->{MonitorId}&eid=$event->{Id}&fid=$max_alarm_frame->{FrameId}/g;
         if ( $attachments_ref && $text =~ s/%EI1%//g )
         {
-            my path = generateImage( $event->{Id}, $first_alarm_frame->{FrameId} );
+            my $path = generateImage( $event, $first_alarm_frame );
             if ( -e $path ) {
                 push( @$attachments_ref,
                     {
@@ -728,7 +728,7 @@ sub substituteTags
                  || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
             )
             {
-                my path = generateImage( $event->{Id}, $max_alarm_frame->{FrameId} );
+                my $path = generateImage( $event, $max_alarm_frame );
                 if ( -e $path ) {
                     push( @$attachments_ref,
                         {

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -wT
+©#!/usr/bin/perl -wT
 #
 # ==========================================================================
 #
@@ -420,6 +420,33 @@ sub generateVideo
     return( 1 );
 }
 
+sub generateImage
+{
+    my $event = shift;
+    my $frame = shift;
+
+    my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
+        getEventPath($event), $frame->{FrameId});
+    my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
+
+   Debug("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\," .$frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path);
+
+    # check if the image file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
+    if ( -e $image_path || ( -e $video_path
+            && !system("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
+                .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
+            )
+        ))
+    {
+      return( $image_path );
+    } else {
+      return "";
+    }
+}
+
+
+
+
 sub uploadArchFile
 {
     my $filter = shift;
@@ -684,23 +711,12 @@ sub substituteTags
         $text =~ s/%EPIM%/$url?view=frame&mid=$event->{MonitorId}&eid=$event->{Id}&fid=$max_alarm_frame->{FrameId}/g;
         if ( $attachments_ref && $text =~ s/%EI1%//g )
         {
-            my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
-                getEventPath($event), $first_alarm_frame->{FrameId});
-            my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
-
-           Debug("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\," .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path);
-
-            # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
-            if ( -e $image_path || ( -e $video_path
-                    && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                        .$first_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
-                    )
-                )
-            ) {
+            my path = generateImage( $event->{Id}, $first_alarm_frame->{FrameId} );
+            if ( -e $path ) {
                 push( @$attachments_ref,
                     {
                         type=>"image/jpeg",
-                        path=>$image_path
+                        path=>$path
                     }
                 );
             }
@@ -712,21 +728,12 @@ sub substituteTags
                  || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
             )
             {
-                my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
-                    getEventPath($event), $max_alarm_frame->{FrameId});
-                my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
-
-                # check if a frame file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
-                if ( -e $image_path || ( -e $video_path
-                        && !system("ffmpeg -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                            .$max_alarm_frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
-                        )
-                    )
-                ) {
+                my path = generateImage( $event->{Id}, $max_alarm_frame->{FrameId} );
+                if ( -e $path ) {
                     push( @$attachments_ref,
                         {
                             type=>"image/jpeg",
-                            path=>$image_path
+                            path=>$path
                         }
                     );
                 }

--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -420,31 +420,33 @@ sub generateVideo
     return( 1 );
 }
 
+# Returns an image absolute path for given event and frame
+# Optionally an analyse image path may be returned if an analyse image exists
+# If neither capture nor analyse image exists it will try to extract a frame from .mp4 file if exists
+# An empty string is returned if no one from methods above works
 sub generateImage
 {
     my $event = shift;
     my $frame = shift;
+    my $analyse = do { @_ ? shift : 0 }; # don't return analyse image by default
 
-    my $image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg",
-        getEventPath($event), $frame->{FrameId});
+    my $capture_image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-capture.jpg", getEventPath($event), $frame->{FrameId});
+    my $analyse_image_path = sprintf("%s/%0".$Config{ZM_EVENT_IMAGE_DIGITS}."d-analyse.jpg", getEventPath($event), $frame->{FrameId}) if $analyse;
     my $video_path =  sprintf("%s/%d-video.mp4", getEventPath($event), $event->{Id});
-
-   Debug("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\," .$frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path);
+    my $image_path = "";
 
     # check if the image file exists. If the file doesn't exist and we use H264 try to extract it from .mp4 video
-    if ( -e $image_path || ( -e $video_path
-            && !system("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\,"
-                .$frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$image_path
-            )
-        ))
-    {
-      return( $image_path );
-    } else {
-      return "";
+    if ( $analyse && -r $analyse_image_path ) {
+        $image_path = $analyse_image_path;
+    } elsif ( -r $capture_image_path ) {
+        $image_path = $capture_image_path;
+    } elsif ( -e $video_path ) {
+        if ( !system("ffmpeg -y -v 0 -i ".$video_path." -vf 'select=gte(n\\,".$frame->{FrameId}."),setpts=PTS-STARTPTS' -vframes 1 -f image2 ".$capture_image_path) ) {
+            $image_path = $capture_image_path;
+        }
     }
+    return $image_path;
 }
-
-
 
 
 sub uploadArchFile
@@ -650,7 +652,7 @@ sub substituteTags
     }
 
     # Do we need the image information too?
-    my $need_images = $text =~ /%(?:EPI1|EPIM|EI1|EIM)%/;
+    my $need_images = $text =~ /%(?:EPI1|EPIM|EI1|EIM|EI1A|EIMA)%/;
     my $first_alarm_frame;
     my $max_alarm_frame;
     my $max_alarm_score = 0;
@@ -711,7 +713,7 @@ sub substituteTags
         $text =~ s/%EPIM%/$url?view=frame&mid=$event->{MonitorId}&eid=$event->{Id}&fid=$max_alarm_frame->{FrameId}/g;
         if ( $attachments_ref && $text =~ s/%EI1%//g )
         {
-            my $path = generateImage( $event, $first_alarm_frame );
+            my $path = generateImage( $event, $first_alarm_frame);
             if ( -e $path ) {
                 push( @$attachments_ref,
                     {
@@ -728,7 +730,37 @@ sub substituteTags
                  || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
             )
             {
-                my $path = generateImage( $event, $max_alarm_frame );
+                my $path = generateImage( $event, $max_alarm_frame);
+                if ( -e $path ) {
+                    push( @$attachments_ref,
+                        {
+                            type=>"image/jpeg",
+                            path=>$path
+                        }
+                    );
+                }
+            }
+        }
+        if ( $attachments_ref && $text =~ s/%EI1A%//g )
+        {
+            my $path = generateImage( $event, $first_alarm_frame, "analyse" );
+            if ( -e $path ) {
+                push( @$attachments_ref,
+                    {
+                        type=>"image/jpeg",
+                        path=>$path
+                    }
+                );
+            }
+        }
+        if ( $attachments_ref && $text =~ s/%EIMA%//g )
+        {
+            # Don't attach the same image twice
+            if ( !@$attachments_ref
+                 || ($first_alarm_frame->{FrameId} != $max_alarm_frame->{FrameId} )
+            )
+            {
+                my $path = generateImage( $event, $max_alarm_frame, "analyse");
                 if ( -e $path ) {
                     push( @$attachments_ref,
                         {


### PR DESCRIPTION
This is a fix for https://github.com/ZoneMinder/ZoneMinder/issues/1768
If you are using H264-videostorage branch (direct recording of h264 cameras into MP4 format) and in a monitor Storage settings set Save JPEGs in Disabled value, %EI1% and %EIM% email tokens won't work because a jpeg that needs be attached to an email (or a message) just doesn't exist.
I fixed the issue by extracting a frame directly from a .mp4 file on the fly using ffmpeg utility (in zmfilter.pl)
Also two new email tokens were added:
%EI1A% - attach first alarm "analyze" frame (similar to existing %EI1% but analyze frame)
%EIMA% - attach alarm "analyse" frame having max score (similar to existing %EIM% but analyze frame)
