### PR TITLE
Properly escape postLoginQuery. Fixes #1797

### DIFF
--- a/web/skins/classic/views/js/postlogin.js.php
+++ b/web/skins/classic/views/js/postlogin.js.php
@@ -9,12 +9,14 @@
 ?>
 
 (
-	function () 
+	function ()
 	{
 		// Append '?(GET query)' to URL if the GET query is not empty.
 		var querySuffix = "<?php
-			if (!empty($_POST["postLoginQuery"]))
-				echo "?".$_POST["postLoginQuery"];
+			if (!empty($_POST["postLoginQuery"])) {
+                                parse_str($_POST["postLoginQuery"], $queryParams);
+				echo "?" . http_build_query($queryParams);
+                        }
 			?>";
 
 		var newUrl = thisUrl + querySuffix;

--- a/web/skins/classic/views/login.php
+++ b/web/skins/classic/views/login.php
@@ -6,7 +6,7 @@ xhtmlHeaders(__FILE__, translate('Login') );
 		<form class="center-block" name="loginForm" id="loginForm" method="post" action="<?php echo $_SERVER['PHP_SELF'] ?>">
 			<input type="hidden" name="action" value="login"/>
 			<input type="hidden" name="view" value="postlogin"/>
-			<input type="hidden" name="postLoginQuery" value="<?php echo $_SERVER['QUERY_STRING'] ?>">
+			<input type="hidden" name="postLoginQuery" value="<?php echo htmlspecialchars($_SERVER['QUERY_STRING']) ?>">
 
 			<div id="loginError" class="hidden alarm" role="alert">
 				<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>


### PR DESCRIPTION
I didn't use `urlencode` since it's intended for each parameter after the `=` but in this case we had a whole string.

`htmlspecialchars` was added to the form to ensure that ampersands are properly encoded as `&amp;`