### PR TITLE
Add eslint configuration files extending Google's rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+web/api/lib
+web/skins/classic/js/jquery-1.11.3.js
+web/skins/classic/js/jquery.js
+web/tools/mootools

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+"use strict";
+
+module.exports = {
+  "env": {
+    "browser": true,
+  },
+  "extends": ["google"],
+  "rules": {
+    "brace-style": "off",
+    "camelcase": "off",
+    "comma-dangle": "off",
+    "key-spacing": "off",
+    "max-len": "off",
+    "new-cap": ["error", {
+      capIsNewExceptions: ["Error", "Warning", "Debug", "Polygon_calcArea", "Play", "Stop"],
+      newIsCapExceptionPattern: "^Asset\.."
+    }],
+    "no-array-constructor": "off",
+    "no-caller": "off",
+    "no-new-object": "off",
+    "no-unused-vars": "off",
+    "no-var": "off",
+    "object-curly-spacing": "off",
+    "prefer-rest-params": "off",
+    "quotes": "off",
+    "require-jsdoc": "off",
+    "spaced-comment": "off",
+  },
+};

--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -46,7 +46,7 @@ function logReport( level, message, file, line )
         return;
 
     if ( arguments && arguments.callee && arguments.callee.caller && arguments.callee.caller.name )
-        message += ' - '+arguments.callee.caller.caller.name+'()'; 
+        message += ' - '+arguments.callee.caller.caller.name+'()';
 
     if ( !debugReq )
     {
@@ -115,4 +115,4 @@ window.onerror =
     function( message, url, line )
     {
         logReport( "ERR", message, url, line );
-    }
+    };

--- a/web/js/overlay.js
+++ b/web/js/overlay.js
@@ -84,7 +84,7 @@ var Overlay = new Class({
     showAnimation:function()
     {
         showOverlay();
-        
+
         //console.log( "Showing overlay loading" );
         if ( !this.loading )
         {
@@ -116,7 +116,7 @@ function setupOverlays()
             overlay.getElements('.overlayCloser').each(
                 function( closer )
                 {
-                    closer.addEvent( 'click', function() { overlay.element.hide(); } )   
+                    closer.addEvent( 'click', function() { overlay.element.hide(); } );
                 }
             );
             overlay.overlayShow = function() { overlay.element.show(); };

--- a/web/skins/classic/js/classic.js
+++ b/web/skins/classic/js/classic.js
@@ -33,7 +33,7 @@ var popupSizes = {
     'device':       { 'width': 260, 'height': 150 },
     'devices':      { 'width': 400, 'height': 240 },
     'donate':       { 'width': 500, 'height': 280 },
-    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, minHeight: 540 },
+    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, 'minHeight': 540 },
     'eventdetail':  { 'width': 600, 'height': 220 },
     'events':       { 'width': 960, 'height': 780 },
     'export':       { 'width': 400, 'height': 340 },

--- a/web/skins/classic/js/dark.js
+++ b/web/skins/classic/js/dark.js
@@ -33,7 +33,7 @@ var popupSizes = {
     'device':       { 'width': 260, 'height': 150 },
     'devices':      { 'width': 400, 'height': 240 },
     'donate':       { 'width': 500, 'height': 280 },
-    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, minHeight: 540 },
+    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, 'minHeight': 540 },
     'eventdetail':  { 'width': 600, 'height': 220 },
     'events':       { 'width': 960, 'height': 780 },
     'export':       { 'width': 400, 'height': 340 },

--- a/web/skins/classic/js/flat.js
+++ b/web/skins/classic/js/flat.js
@@ -33,7 +33,7 @@ var popupSizes = {
     'device':       { 'width': 260, 'height': 150 },
     'devices':      { 'width': 400, 'height': 240 },
     'donate':       { 'width': 500, 'height': 280 },
-    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, minHeight: 540 },
+    'event':        { 'addWidth': 108, 'minWidth': 496, 'addHeight': 230, 'minHeight': 540 },
     'eventdetail':  { 'width': 600, 'height': 220 },
     'events':       { 'width': 1080, 'height': 780 },
     'export':       { 'width': 400, 'height': 340 },

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -31,11 +31,11 @@ function checkSize() {
         var h = window.outerHeight;
         var prevH = h;
         if (h > screen.availHeight)
-            h  = screen.availHeight;
+            h = screen.availHeight;
         if (w > screen.availWidth)
-            w  = screen.availWidth;
+            w = screen.availWidth;
         if (w != prevW || h != prevH)
-            window.resizeTo(w,h);
+            window.resizeTo(w, h);
     }
 }
 
@@ -56,7 +56,7 @@ function getPopupSize( tag, width, height )
     if ( popupSize.width && popupSize.height )
     {
         if ( width || height )
-            Warning( "Ignoring passed dimensions "+width+"x"+height+" when getting popup size for tag '"+tag+"'"  );
+            Warning( "Ignoring passed dimensions "+width+"x"+height+" when getting popup size for tag '"+tag+"'" );
         return( popupSize );
     }
     if ( popupSize.addWidth )

--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -25,15 +25,14 @@ function setButtonStates( element )
 
 function addMonitor( element)
 {
-
-	  var form = element.form;
-		var dupParam;
-	  var monitorId=-1;
-	  if (form.addBtn.value == jsTranslatedCloneText)
+    var form = element.form;
+    var dupParam;
+    var monitorId=-1;
+    if (form.addBtn.value == jsTranslatedCloneText)
     {
-	  	// get the value of the first checkbox
-		 for ( var i = 0; i < form.elements.length; i++ )
-		 {
+                 // get the value of the first checkbox
+                 for ( var i = 0; i < form.elements.length; i++ )
+                 {
 				if ( form.elements[i].type == "checkbox" )
 				{
 					if ( form.elements[i].checked )
@@ -42,10 +41,10 @@ function addMonitor( element)
 						break;
 					}
 				}
-			}
-	  }
-	  dupParam = (monitorId == -1 ) ? '': '&dupId='+monitorId;
-    createPopup( '?view=monitor'+dupParam, 'zmMonitor0','monitor' );
+                 }
+    }
+    dupParam = (monitorId == -1 ) ? '': '&dupId='+monitorId;
+    createPopup( '?view=monitor'+dupParam, 'zmMonitor0', 'monitor' );
 }
 
 function editMonitor( element )
@@ -85,8 +84,8 @@ function reloadWindow()
 
 function initPage()
 {
-		jsTranslatedAddText = translatedAddText;
-	  jsTranslatedCloneText = translatedCloneText;
+    jsTranslatedAddText = translatedAddText;
+    jsTranslatedCloneText = translatedCloneText;
     reloadWindow.periodical( consoleRefreshTimeout );
     if ( showVersionPopup )
         createPopup( '?view=version', 'zmVersion', 'version' );

--- a/web/skins/classic/views/js/control.js
+++ b/web/skins/classic/views/js/control.js
@@ -26,7 +26,7 @@ function controlCmd( control, event, xtell, ytell )
         var x = xEvent.page.x - l;
         var y = xEvent.page.y - t;
 
-        if  ( xtell )
+        if ( xtell )
         {
             var xge = parseInt( (x*100)/coords.width );
             if ( xtell == -1 )
@@ -35,7 +35,7 @@ function controlCmd( control, event, xtell, ytell )
                 xge = 2*(50 - xge);
             locParms += "&xge="+xge;
         }
-        if  ( ytell )
+        if ( ytell )
         {
             var yge = parseInt( (y*100)/coords.height );
             if ( ytell == -1 )

--- a/web/skins/classic/views/js/controlcap.js
+++ b/web/skins/classic/views/js/controlcap.js
@@ -19,6 +19,5 @@ function validateForm( form ) {
         return( false );
     }
     return( true );
-
 }
 

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -15,7 +15,7 @@ function changeScale()
     streamScale( scale );
     Cookie.write( 'zmEventScale'+eventData.MonitorId, scale, { duration: 10*365 } );
 
-    /*Stream could be an applet so can't use moo tools*/ 
+    /*Stream could be an applet so can't use moo tools*/
     var streamImg = document.getElementById('evtStream');
     streamImg.style.width = newWidth + "px";
     streamImg.style.height = newHeight + "px";
@@ -25,7 +25,7 @@ function changeReplayMode()
 {
     var replayMode = $('replayMode').get('value');
 
-    Cookie.write( 'replayMode', replayMode, { duration: 10*365 })
+    Cookie.write( 'replayMode', replayMode, { duration: 10*365 });
 
     refreshWindow();
 }
@@ -38,7 +38,7 @@ var lastEventId = 0;
 
 function getCmdResponse( respObj, respText )
 {
-    if ( checkStreamForErrors( "getCmdResponse" ,respObj ) )
+    if ( checkStreamForErrors( "getCmdResponse", respObj ) )
         return;
 
     if ( streamCmdTimer )
@@ -58,7 +58,7 @@ function getCmdResponse( respObj, respText )
         $('rate').addClass( 'hidden' );
         streamPause( false );
     }
-    else 
+    else
     {
         $('modeValue').set( 'text', "Replay" );
         $('rateValue').set( 'text', streamStatus.rate );
@@ -198,9 +198,9 @@ function streamSeek( offset )
 }
 
 function streamQuery()
-{       
+{
     streamReq.send( streamParms+"&command="+CMD_QUERY );
-}       
+}
 
 var slider = null;
 var scroll = null;
@@ -438,7 +438,7 @@ function getFrameResponse( respObj, respText )
         eventData['frames'] = new Object();
 
     eventData['frames'][frame.FrameId] = frame;
-    
+
     loadEventThumb( eventData, frame, respObj.loopback=="true" );
 }
 
@@ -477,7 +477,7 @@ function checkFrames( eventId, frameId, loadImage )
         if ( !$('eventThumb'+fid) )
         {
             var img = new Element( 'img', { 'id': 'eventThumb'+fid, 'src': 'graphics/transparent.gif', 'alt': fid, 'class': 'placeholder' } );
-            img.addEvent( 'click', function () { eventData['frames'][fid] = null; checkFrames( eventId, fid ) } );
+            img.addEvent( 'click', function() { eventData['frames'][fid] = null; checkFrames( eventId, fid ); } );
             frameQuery( eventId, fid, loadImage && (fid == frameId) );
             var imgs = $('eventThumbs').getElements( 'img' );
             var injected = false;
@@ -689,7 +689,7 @@ function drawProgressBar()
             var offset = parseInt((index*eventData.Length)/$$(cells).length);
             $(cell).setProperty( 'title', '+'+secsToTime(offset)+'s' );
             $(cell).removeEvent( 'click' );
-            $(cell).addEvent( 'click', function(){ streamSeek( offset ); } );
+            $(cell).addEvent( 'click', function() { streamSeek( offset ); } );
             barWidth += $(cell).getCoordinates().width;
         }
     );
@@ -730,7 +730,7 @@ function handleClick( event )
     var target = event.target;
     var x = event.page.x - $(target).getLeft();
     var y = event.page.y - $(target).getTop();
-    
+
     if ( event.shift )
         streamPan( x, y );
     else

--- a/web/skins/classic/views/js/group.js
+++ b/web/skins/classic/views/js/group.js
@@ -9,7 +9,6 @@ if ( refreshParent )
 }
 
 function configureButtons( element ) {
-
     if ( canEditGroups ) {
         var form = element.form;
         form.saveBtn.disabled = (element.value == 0);

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -22,7 +22,7 @@ var logTimeout = maxSampleTime;
 var firstLoad = true;
 var initialDisplayLimit = 200;
 var sortReversed = false;
-var filterFields = [ 'Component', 'ServerId', 'Pid', 'Level', 'File', 'Line'];
+var filterFields = ['Component', 'ServerId', 'Pid', 'Level', 'File', 'Line'];
 var options = {};
 
 function buildFetchParms( parms )
@@ -68,7 +68,7 @@ function logResponse( respObj )
                             maxLogTime = log.TimeKey;
                         if ( !minLogTime || log.TimeKey < minLogTime )
                             minLogTime = log.TimeKey;
-                        var row = logTable.push( [ { content: log.DateTime, properties: { style: 'white-space: nowrap' }}, log.Component, log.Server, log.Pid, log.Code, log.Message, log.File, log.Line ] );
+                        var row = logTable.push( [{ content: log.DateTime, properties: { style: 'white-space: nowrap' }}, log.Component, log.Server, log.Pid, log.Code, log.Message, log.File, log.Line] );
                         delete log.Message;
                         row.tr.store( 'log', log );
                         if ( log.Level <= -3 )
@@ -81,7 +81,7 @@ function logResponse( respObj )
                             row.tr.addClass( 'log-dbg' );
                         if ( !firstLoad )
                         {
-                            var color = document.defaultView.getComputedStyle(row.tr,null).getPropertyValue('color');
+                            var color = document.defaultView.getComputedStyle(row.tr, null).getPropertyValue('color');
                             var colorParts = color.match(/^rgb.*\((\d+),\s*(\d+),\s*(\d+)/);
                             rowOrigColor = '#' + parseInt(colorParts[1]).toString(16) + parseInt(colorParts[2]).toString(16) + parseInt(colorParts[3]).toString(16);
                             new Fx.Tween( row.tr, { duration: 10000, transition: Fx.Transitions.Sine } ).start( 'color', '#6495ED', rowOrigColor );
@@ -90,15 +90,15 @@ function logResponse( respObj )
                 );
                 options = respObj.options;
                 updateFilterSelectors();
-                $('lastUpdate').set('text',respObj.updated);
-                $('logState').set('text',respObj.state);
+                $('lastUpdate').set('text', respObj.updated);
+                $('logState').set('text', respObj.state);
                 $('logState').removeClass('ok');
                 $('logState').removeClass('alert');
                 $('logState').removeClass('alarm');
                 $('logState').addClass(respObj.state);
-                $('totalLogs').set('text',respObj.total);
-                $('availLogs').set('text',respObj.available);
-                $('displayLogs').set('text',logCount);
+                $('totalLogs').set('text', respObj.total);
+                $('availLogs').set('text', respObj.available);
+                $('displayLogs').set('text', logCount);
                 if ( firstLoad )
                 {
                     if ( logCount < displayLimit )
@@ -123,7 +123,7 @@ function logResponse( respObj )
         }
     }
     logTimer = fetchNextLogs.delay( logTimeout );
-} 
+}
 
 function refreshLog()
 {
@@ -151,7 +151,7 @@ function clearLog()
     logCount = 0;
     logTimeout = maxSampleTime;
     displayLimit = initialDisplayLimit;
-    $('displayLogs').set('text',logCount);
+    $('displayLogs').set('text', logCount);
     options = {};
     logTable.empty();
 }
@@ -265,12 +265,12 @@ function updateFilterSelectors()
                         selector.options[selector.options.length] = new Option( value, label );
                     }
                 );
-            } 
+            }
             else if ( key == 'ServerId' )
             {
 				Object.each(values,
                     function( value, label )
-                    {   
+                    {
                         selector.options[selector.options.length] = new Option( value, label );
                     }
                 );
@@ -285,7 +285,7 @@ function updateFilterSelectors()
                 );
             }
             if ( filter[key] )
-                selector.set('value',filter[key]);
+                selector.set('value', filter[key]);
         }
     );
 }
@@ -315,13 +315,13 @@ function initPage()
                 if ( sortReversed )
                     startIndex = displayLimit;
                 else
-                    startIndex = 0;;
+                    startIndex = 0;
                 for ( var i = startIndex; logCount > displayLimit; i++ )
                 {
                     rows[i].destroy();
                     logCount--;
                 }
-                $('displayLogs').set('text',logCount);
+                $('displayLogs').set('text', logCount);
             }
         }
     );

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -15,7 +15,7 @@ function Monitor( index, monitorData )
     this.start = function( delay )
     {
         this.streamCmdTimer = this.streamCmdQuery.delay( delay, this );
-    }
+    };
 
     this.setStateClass = function( element, stateClass )
     {
@@ -29,7 +29,7 @@ function Monitor( index, monitorData )
                 element.removeClass( 'idle' );
             element.addClass( stateClass );
         }
-    }
+    };
 
     this.getStreamCmdResponse = function( respObj, respText )
     {
@@ -58,7 +58,7 @@ function Monitor( index, monitorData )
             }
             this.setStateClass( $('monitor'+this.index), stateClass );
 
-            /*Stream could be an applet so can't use moo tools*/ 
+            /*Stream could be an applet so can't use moo tools*/
             stream.className = stateClass;
 
             var isAlarmed = ( this.alarmState == STATE_ALARM || this.alarmState == STATE_ALERT );
@@ -93,15 +93,14 @@ function Monitor( index, monitorData )
             console.error( respObj.message );
             // Try to reload the image stream.
             if ( stream )
-                stream.src = stream.src.replace(/rand=\d+/i,'rand='+Math.floor((Math.random() * 1000000) ));
-
+                stream.src = stream.src.replace(/rand=\d+/i, 'rand='+Math.floor((Math.random() * 1000000) ));
         }
         var streamCmdTimeout = statusRefreshTimeout;
         if ( this.alarmState == STATE_ALARM || this.alarmState == STATE_ALERT )
             streamCmdTimeout = streamCmdTimeout/5;
         this.streamCmdTimer = this.streamCmdQuery.delay( streamCmdTimeout, this );
         this.lastAlarmState = this.alarmState;
-    }
+    };
 
     this.streamCmdQuery = function( resent )
     {
@@ -109,7 +108,7 @@ function Monitor( index, monitorData )
             //console.log( this.connKey+": Resending" );
         //this.streamCmdReq.cancel();
         this.streamCmdReq.send( this.streamCmdParms+"&command="+CMD_QUERY );
-    }
+    };
 
     this.streamCmdReq = new Request.JSON( { url: this.server_url, method: 'get', timeout: AJAX_TIMEOUT, onSuccess: this.getStreamCmdResponse.bind( this ), onTimeout: this.streamCmdQuery.bind( this, true ), link: 'cancel' } );
 
@@ -134,7 +133,7 @@ function changeScale()
         var monitor = monitors[x];
         var newWidth = ( monitorData[x].width * scale ) / SCALE_BASE;
         var newHeight = ( monitorData[x].height * scale ) / SCALE_BASE;
-        /*Stream could be an applet so can't use moo tools*/ 
+        /*Stream could be an applet so can't use moo tools*/
         var streamImg = document.getElementById( 'liveStream'+monitor.id );
         streamImg.style.width = newWidth + "px";
         streamImg.style.height = newHeight + "px";

--- a/web/skins/classic/views/js/onvifprobe.js
+++ b/web/skins/classic/views/js/onvifprobe.js
@@ -31,7 +31,7 @@ function configureButtons( element )
     if(form.elements.namedItem("nextBtn")) {
       form.nextBtn.disabled = (form.probe.selectedIndex==0) ||
                               (form.username == "") || (form.username == null) ||
-                              (form.password  == "") || (form.password == null);
+                              (form.password == "") || (form.password == null);
     }
     if(form.elements.namedItem("saveBtn")) {
       form.saveBtn.disabled = (form.probe.selectedIndex==0);

--- a/web/skins/classic/views/js/state.js
+++ b/web/skins/classic/views/js/state.js
@@ -1,6 +1,5 @@
 function checkState( element )
 {
-
     var form = element.form;
 
     var minIndex = running?2:1;
@@ -23,9 +22,8 @@ function checkState( element )
     if (element.value.toLowerCase() == 'default' )
     {
 	form.saveBtn.disabled = false;
- 	form.deleteBtn.disabled = true;
+        form.deleteBtn.disabled = true;
     }
-
 }
 
 function saveState( element )

--- a/web/skins/classic/views/js/timeline.js
+++ b/web/skins/classic/views/js/timeline.js
@@ -114,10 +114,10 @@ function loadEventImage( imagePath, eid, fid, width, height )
     var imageSrc = $('imageSrc');
     imageSrc.setProperty( 'src', imagePrefix+imagePath );
     imageSrc.removeEvent( 'click' );
-    imageSrc.addEvent( 'click', showEvent.pass( [ eid, fid, width, height ] ) );
+    imageSrc.addEvent( 'click', showEvent.pass( [eid, fid, width, height] ) );
     var eventData = $('eventData');
     eventData.removeEvent( 'click' );
-    eventData.addEvent( 'click', showEvent.pass( [ eid, fid, width, height ] ) );
+    eventData.addEvent( 'click', showEvent.pass( [eid, fid, width, height] ) );
 }
 
 function tlZoomBounds( minTime, maxTime )

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -34,13 +34,13 @@ function changeScale()
 
     Cookie.write( 'zmWatchScale'+monitorId, scale, { duration: 10*365 } );
 
-    /*Stream could be an applet so can't use moo tools*/ 
+    /*Stream could be an applet so can't use moo tools*/
     var streamImg = document.getElementById('liveStream');
     if ( streamImg ) {
         streamImg.style.width = newWidth + "px";
         streamImg.style.height = newHeight + "px";
 
-        streamImg.src = streamImg.src.replace(/scale=\d+/i,'scale='+scale);
+        streamImg.src = streamImg.src.replace(/scale=\d+/i, 'scale='+scale);
     } else {
         console.error("No element found for liveStream.");
     }
@@ -168,7 +168,7 @@ function getStreamCmdResponse( respObj, respText )
                     streamCmdFastRev( false );
             }
         }
-        else 
+        else
         {
             $('modeValue').set( 'text', "Live" );
             $('rate').addClass( 'hidden' );
@@ -210,18 +210,18 @@ function getStreamCmdResponse( respObj, respText )
         }
     }
     else {
-        checkStreamForErrors("getStreamCmdResponse",respObj);//log them
+        checkStreamForErrors("getStreamCmdResponse", respObj);//log them
         // Try to reload the image stream.
         var streamImg = document.getElementById('liveStream');
         if ( streamImg )
-            streamImg.src = streamImg.src.replace(/rand=\d+/i,'rand='+Math.floor((Math.random() * 1000000) ));
+            streamImg.src = streamImg.src.replace(/rand=\d+/i, 'rand='+Math.floor((Math.random() * 1000000) ));
     }
 
     var streamCmdTimeout = statusRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )
         streamCmdTimeout = streamCmdTimeout/5;
     streamCmdTimer = streamCmdQuery.delay( streamCmdTimeout );
-} 
+}
 
 function streamCmdPause( action )
 {
@@ -354,7 +354,7 @@ function streamCmdPan( x, y )
 function streamCmdQuery()
 {
     streamCmdReq.send( streamCmdParms+"&command="+CMD_QUERY );
-}       
+}
 
 var statusCmdParms = "view=request&request=status&entity=monitor&id="+monitorId+"&element[]=Status&element[]=FrameRate";
 var statusCmdReq = new Request.JSON( { url: monitorUrl+thisUrl, method: 'post', data: statusCmdParms, timeout: AJAX_TIMEOUT, link: 'cancel', onSuccess: getStatusCmdResponse } );
@@ -372,18 +372,18 @@ function getStatusCmdResponse( respObj, respText )
         setAlarmState( respObj.monitor.Status );
     }
     else
-        checkStreamForErrors("getStatusCmdResponse",respObj);
+        checkStreamForErrors("getStatusCmdResponse", respObj);
 
     var statusCmdTimeout = statusRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )
         statusCmdTimeout = statusCmdTimeout/5;
     statusCmdTimer = statusCmdQuery.delay( statusCmdTimeout );
-} 
+}
 
 function statusCmdQuery()
 {
     statusCmdReq.send();
-}       
+}
 
 var alarmCmdParms = "view=request&request=alarm&id="+monitorId;
 var alarmCmdReq = new Request.JSON( { url: monitorUrl+thisUrl, method: 'post', timeout: AJAX_TIMEOUT, link: 'cancel', onSuccess: getAlarmCmdResponse, onTimeout: streamCmdQuery } );
@@ -391,7 +391,7 @@ var alarmCmdFirst = true;
 
 function getAlarmCmdResponse( respObj, respText )
 {
-    checkStreamForErrors("getAlarmCmdResponse",respObj);
+    checkStreamForErrors("getAlarmCmdResponse", respObj);
 }
 
 function cmdDisableAlarms()
@@ -477,26 +477,26 @@ function getEventCmdResponse( respObj, respText )
 
                 var cells = row.getElements( 'td' );
 
-                var link = new Element( 'a', { 'href': '#', 'events': { 'click': createEventPopup.pass( [ event.Id, '&trms=1&attr1=MonitorId&op1=%3d&val1='+monitorId+'&page=1', event.Width, event.Height ] ) } });
+                var link = new Element( 'a', { 'href': '#', 'events': { 'click': createEventPopup.pass( [event.Id, '&trms=1&attr1=MonitorId&op1=%3d&val1='+monitorId+'&page=1', event.Width, event.Height] ) } });
                 link.set( 'text', event.Id );
                 link.inject( row.getElement( 'td.colId' ) );
 
-                link = new Element( 'a', { 'href': '#', 'events': { 'click': createEventPopup.pass( [ event.Id, '&trms=1&attr1=MonitorId&op1=%3d&val1='+monitorId+'&page=1', event.Width, event.Height ] ) } });
+                link = new Element( 'a', { 'href': '#', 'events': { 'click': createEventPopup.pass( [event.Id, '&trms=1&attr1=MonitorId&op1=%3d&val1='+monitorId+'&page=1', event.Width, event.Height] ) } });
                 link.set( 'text', event.Name );
                 link.inject( row.getElement( 'td.colName' ) );
 
                 row.getElement( 'td.colTime' ).set( 'text', event.StartTime );
                 row.getElement( 'td.colSecs' ).set( 'text', event.Length );
 
-                link = new Element( 'a', { 'href': '#', 'events': { 'click': createFramesPopup.pass( [ event.Id, event.Width, event.Height ] ) } });
+                link = new Element( 'a', { 'href': '#', 'events': { 'click': createFramesPopup.pass( [event.Id, event.Width, event.Height] ) } });
                 link.set( 'text', event.Frames+'/'+event.AlarmFrames );
                 link.inject( row.getElement( 'td.colFrames' ) );
 
-                link = new Element( 'a', { 'href': '#', 'events': { 'click': createFramePopup.pass( [ event.Id, '0', event.Width, event.Height ] ) } });
+                link = new Element( 'a', { 'href': '#', 'events': { 'click': createFramePopup.pass( [event.Id, '0', event.Width, event.Height] ) } });
                 link.set( 'text', event.AvgScore+'/'+event.MaxScore );
                 link.inject( row.getElement( 'td.colScore' ) );
 
-                link = new Element( 'a', { 'href': '#', 'title': deleteString, 'events': { 'click': function( e ) { deleteEvent( e, event.Id ); }.bind( link ), 'mouseover': highlightRow.pass( row ), 'mouseout': highlightRow.pass( row ) } });
+                link = new Element( 'a', { 'href': '#', 'title': deleteString, 'events': { 'click': function( e ) { deleteEvent( e, event.Id ); }, 'mouseover': highlightRow.pass( row ), 'mouseout': highlightRow.pass( row ) } });
                 link.set( 'text', 'X' );
                 link.inject( row.getElement( 'td.colDelete' ) );
 
@@ -537,7 +537,7 @@ function getEventCmdResponse( respObj, respText )
         }
     }
     else
-        checkStreamForErrors("getEventCmdResponse",respObj);
+        checkStreamForErrors("getEventCmdResponse", respObj);
 
     var eventCmdTimeout = eventsRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )
@@ -581,7 +581,7 @@ function controlCmd( control, event, xtell, ytell )
         var x = xEvent.page.x - l;
         var y = xEvent.page.y - t;
 
-        if  ( xtell )
+        if ( xtell )
         {
             var xge = parseInt( (x*100)/coords.width );
             if ( xtell == -1 )
@@ -590,7 +590,7 @@ function controlCmd( control, event, xtell, ytell )
                 xge = 2*(50 - xge);
             locParms += "&xge="+xge;
         }
-        if  ( ytell )
+        if ( ytell )
         {
             var yge = parseInt( (y*100)/coords.height );
             if ( ytell == -1 )
@@ -614,7 +614,7 @@ function controlCmdImage( x, y )
     controlReq.send( imageControlParms+"&x="+x+"&y="+y );
     if ( streamMode == "single" )
         fetchImage.pass( $('imageFeed').getElement('img') ).delay( 1000 );
-}       
+}
 
 var tempImage = null;
 function fetchImage( streamImage )
@@ -631,7 +631,7 @@ function handleClick( event )
     var target = event.target;
     var x = event.page.x - $(target).getLeft();
     var y = event.page.y - $(target).getTop();
-    
+
     if ( showMode == "events" || !imageControlMode )
     {
         if ( event.shift )
@@ -706,7 +706,7 @@ function initPage()
         streamCmdTimer = streamCmdQuery.delay( (Math.random()+0.1)*statusRefreshTimeout );
         watchdogCheck.pass('stream').periodical(statusRefreshTimeout*2);
     }
- 
+
     eventCmdTimer = eventCmdQuery.delay( (Math.random()+0.1)*statusRefreshTimeout );
     watchdogCheck.pass('event').periodical(eventsRefreshTimeout*2);
 

--- a/web/skins/classic/views/js/zone.js
+++ b/web/skins/classic/views/js/zone.js
@@ -145,7 +145,7 @@ function applyZoneType()
         form.elements['newZone[MaxAlarmPixels]'].disabled = false;
         form.elements['newZone[OverloadFrames]'].disabled = false;
         form.elements['newZone[ExtendAlarmFrames]'].disabled = true;
-        applyCheckMethod(); 
+        applyCheckMethod();
     }
 }
 
@@ -353,7 +353,7 @@ function updateActivePoint( index )
     $('newZone[Points]['+index+'][y]').value = y;
     zone['Points'][index].x = x;
     zone['Points'][index].y = y;
-    var Point =  $('zonePoly').points.getItem(index);
+    var Point = $('zonePoly').points.getItem(index);
     Point.x =x;
     Point.y =y;
     updateArea();
@@ -384,7 +384,7 @@ function delPoint( index )
 
 function limitPointValue( point, loVal, hiVal )
 {
-    point.value = constrainValue(point.value, loVal, hiVal)
+    point.value = constrainValue(point.value, loVal, hiVal);
 }
 
 function updateArea( ) {
@@ -393,7 +393,6 @@ function updateArea( ) {
   var form = $('zoneForm');
   form.elements['newZone[Area]'].value = area;
   if ( form.elements['newZone[Units]'].value == 'Percent' ) {
-
     form.elements['newZone[TempArea]'].value = Math.round( area/monitorArea*100 );
   } else if ( form.elements['newZone[Units]'].value == 'Pixels' ) {
     form.elements['newZone[TempArea]'].value = area;
@@ -411,7 +410,7 @@ function updateX( index )
 
     point.setStyle( 'left', x+'px' );
     zone['Points'][index].x = x;
-    var Point =  $('zonePoly').points.getItem(index);
+    var Point = $('zonePoly').points.getItem(index);
     Point.x = x;
 }
 
@@ -424,7 +423,7 @@ function updateY( index )
 
     point.setStyle( 'top', y+'px' );
     zone['Points'][index].y = y;
-    var Point =  $('zonePoly').points.getItem(index);
+    var Point = $('zonePoly').points.getItem(index);
     Point.y = y;
 }
 
@@ -568,18 +567,18 @@ function getStreamCmdResponse( respObj, respText ) {
                 streamCmdPlay( false );
         }
     } else {
-        checkStreamForErrors("getStreamCmdResponse",respObj);//log them
+        checkStreamForErrors("getStreamCmdResponse", respObj);//log them
         // Try to reload the image stream.
         var streamImg = document.getElementById('liveStream');
         if ( streamImg )
-            streamImg.src = streamImg.src.replace(/rand=\d+/i,'rand='+Math.floor((Math.random() * 1000000) ));
+            streamImg.src = streamImg.src.replace(/rand=\d+/i, 'rand='+Math.floor((Math.random() * 1000000) ));
     }
 
     var streamCmdTimeout = statusRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )
         streamCmdTimeout = streamCmdTimeout/5;
     streamCmdTimer = streamCmdQuery.delay( streamCmdTimeout );
-} 
+}
 
 var streamPause = false;
 
@@ -613,7 +612,7 @@ function streamCmdStop( action ) {
 
 function streamCmdQuery() {
     streamCmdReq.send( streamCmdParms+"&command="+CMD_QUERY );
-}       
+}
 
 var statusCmdParms = "view=request&request=status&entity=monitor&id="+monitorId+"&element[]=Status&element[]=FrameRate";
 var statusCmdReq = new Request.JSON( { url: monitorUrl+thisUrl, method: 'post', data: statusCmdParms, timeout: AJAX_TIMEOUT, link: 'cancel', onSuccess: getStatusCmdResponse } );
@@ -630,13 +629,13 @@ function getStatusCmdResponse( respObj, respText ) {
         setAlarmState( respObj.monitor.Status );
     }
     else
-        checkStreamForErrors("getStatusCmdResponse",respObj);
+        checkStreamForErrors("getStatusCmdResponse", respObj);
 
     var statusCmdTimeout = statusRefreshTimeout;
     if ( alarmState == STATE_ALARM || alarmState == STATE_ALERT )
         statusCmdTimeout = statusCmdTimeout/5;
     statusCmdTimer = statusCmdQuery.delay( statusCmdTimeout );
-} 
+}
 
 function statusCmdQuery() {
     statusCmdReq.send();


### PR DESCRIPTION
According to https://github.com/ZoneMinder/ZoneMinder/wiki/Coding-Standards ZM follows Google's coding standards. In order to start to enforce this for JS I've added eslint configuration files extending their rules.

If this is something core devs are interested in I can also setup travis to enforce this and discuss/fix some of the other rules I've disabled for now. I used the `--fix` option to automatically fix some of the straightforward issues for now.

To test this you will need to run:
```
npm install --g eslint eslint-config-google
eslint .
```