### PR TITLE
Implement CSRF Mitigation

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -346,6 +346,26 @@ our @options = (
     category    => "system",
   },
   {
+    name        => "ZM_ENABLE_CSRF_MAGIC",
+    default     => "no",
+    description => "Enable csrf-magic library",
+    help        => qqq("
+      CSRF stands for Cross-Site Request Forgery which, under specific
+      circumstances, can allow an attacker to perform any task your
+      ZoneMinder user account has permission to perform. To accomplish
+      this, the attacker must write a very specific web page and get
+      you to navigate to it, while you are logged into the ZoneMinder
+      web console at the same time. Enabling ZM_ENABLE_CSRF_MAGIC will
+      help mitigate these kinds of attackes. Be warned this feature
+      is experimental and may cause problems, particularly with the API.
+      If you find a false positive and can document how to reproduce it,
+      then please report it. This feature defaults to OFF currently due to
+      its experimental nature.
+    "),
+    type        => $types{boolean},
+    category    => "system",
+  },
+  {
     name        => "ZM_OPT_USE_API",
     default     => "yes",
     description => "Enable ZoneMinder APIs",

--- a/web/includes/csrf/LICENSE.txt
+++ b/web/includes/csrf/LICENSE.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2008-2013, Edward Z. Yang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/web/includes/csrf/NEWS.txt
+++ b/web/includes/csrf/NEWS.txt
@@ -1,0 +1,69 @@
+
+                            [[     news     ]]
+
+1.0.4 released 2013-07-17
+
+  [SECURITY FIXES]
+
+    - When secret key was not explicitly set, it was not being used
+      by the csrf_hash() function.  Thanks sparticvs for reporting.
+
+  [FEATURES]
+
+    - The default 'CSRF check failed' page now offers a handy 'Try
+      again' button, which resubmits the form.
+
+  [BUG FIXES]
+
+    - The fix for 1.0.3 inadvertantly turned off XMLHttpRequest
+      overloading for all browsers; it has now been fixed to only
+      apply to IE.
+
+1.0.3 released 2012-01-31
+
+ [BUG FIXES]
+
+    - Internet Explorer 8 adds support for XMLHttpRequest.prototype,
+      but this support is broken for method overloading.  We
+      explicitly disable JavaScript overloading for Internet Explorer.
+      Thanks Kelly Lu for reporting. <lubird@gmail.com>
+
+    - A global declaration was omitted, resulting in a variable
+      not being properly introduced in PHP 5.3.  Thanks Whitney Beck for
+      reporting. <whitney.a.beck@gmail.com>
+
+1.0.2 released 2009-03-08
+
+ [SECURITY FIXES]
+
+    - Due to a typo, csrf-magic accidentally treated the secret key
+      as always present.  This means that there was a possible CSRF
+      attack against users without any cookies.  No attacks in the
+      wild were known at the time of this release.  Thanks Jakub
+      Vrána for reporting.
+
+1.0.1 released 2008-11-02
+
+ [NEW FEATURES]
+
+    - Support for composite tokens; this also fixes a bug with using
+      IP-based tokens for users with cookies disabled.
+
+    - Native support cookie tokens; use csrf_conf('cookie', $name) to
+      specify the name of a cookie that the CSRF token should be
+      placed in.  This is useful if you have a Squid cache, and need
+      to configure it to ignore this token.
+
+    - Tips/tricks section in README.txt.
+
+    - There is now a two hour expiration time on all tokens.  This
+      can be modified using csrf_conf('expires', $seconds).
+
+    - ClickJacking protection using an iframe breaker.  Disable with
+      csrf_conf('frame-breaker', false).
+
+ [BUG FIXES]
+
+    - CsrfMagic.send() incorrectly submitted GET requests twice,
+      once without the magic token and once with the token.  Reported
+      by Kelly Lu <lubird@gmail.com>.

--- a/web/includes/csrf/README.txt
+++ b/web/includes/csrf/README.txt
@@ -1,0 +1,160 @@
+
+                            [[  csrf-magic  ]]
+
+Add the following line to the top of all web-accessible PHP pages. If you have
+a common file included by everything, put it there.
+
+    include_once '/path/to/csrf-magic.php';
+
+Do it, test it, then forget about it. csrf-magic is protecting you if nothing
+bad happens. Read on if you run into problems.
+
+
+                             TABLE OF CONTENTS
+                          + ------------------- +
+                            1. TIPS AND TRICKS
+                            2. AJAX
+                            3. CONFIGURE
+                            4. THANKS
+                            5. FOOTNOTES
+                          + ------------------- +
+
+
+1.  TIPS AND TRICKS
+
+    * If your JavaScript and AJAX is persistently getting errors, check the
+      AJAX section below on how to fix.
+
+    * The CSS overlay protection makes it impossible to display your website
+      in frame/iframe elements.  You can disable it with
+      csrf_conf('frame-breaker', false) in your csrf_startup() function.
+
+    * csrf-magic will start a session.  To disable, use csrf_conf('auto-session',
+      false) in your csrf_startup() function.
+
+    * The default error message is a little user unfriendly.  Write your own
+      function which outputs an error message and set csrf_conf('callback',
+      'myCallbackFunction') in your csrf_startup() function.
+
+    * Make sure csrf_conf('secret', 'ABCDEFG') has something random in it.  If
+      the directory csrf-magic.php is in is writable, csrf-magic will generate
+      a secret key for you in the csrf-secret.php file.
+
+    * Remember you can use auto_prepend to include csrf-magic.php on all your
+      pages.  You may want to create a stub file which you can include that
+      includes csrf-magic.php as well as performs configuration.
+
+    * The default expiration time for tokens is two hours. If you expect your
+      users to need longer to fill out forms, be sure to enable double
+      submission when the token is invalid.
+
+
+2.  AJAX
+
+csrf-magic has the ability to dynamically rewrite AJAX requests which use
+XMLHttpRequest.  However, due to the invasiveness of this procedure, it is
+not enabled by default.  You can enable it by adding this code before you
+include csrf-magic.php.
+
+    function csrf_startup() {
+        csrf_conf('rewrite-js', '/web/path/to/csrf-magic.js');
+    }
+    // include_once '/path/to/csrf-magic.php';
+
+(Be sure to place csrf-magic.js somewhere web accessible).
+
+The default method CSRF Magic uses to rewrite AJAX requests will
+only work for browsers with support for XmlHttpRequest.prototype (this excludes
+all versions of Internet Explorer).  See this page for more information:
+http://stackoverflow.com/questions/664315/internet-explorer-8-prototypes-and-xmlhttprequest
+
+However, csrf-magic.js will
+automatically detect and play nice with the following JavaScript frameworks:
+
+    * jQuery
+    * Prototype
+    * MooTools
+    * Ext
+    * Dojo
+
+(Note 2013-07-16: It has been a long time since this manual support has
+been updated, and some JavaScript libraries have placed their copies of XHR
+in local variables in closures, which makes it difficult for us to monkey-patch
+it in automatically.)
+
+To rewrite your own JavaScript library to use csrf-magic.js, you should modify
+your function that generates XMLHttpRequest to have this at the end:
+
+    return new CsrfMagic(xhrObject);
+
+With whatever xhrObject may be. If you have literal instances of XMLHttpRequest
+in your code, find and replace ''new XMLHttpRequest'' with ''new CsrfMagic''
+(CsrfMagic will automatically instantiate an XMLHttpRequest object in a
+cross-platform manner as necessary).
+
+If you don't want csrf-magic monkeying around with your XMLHttpRequest object,
+you can manually rewrite your AJAX code to include the variable. The important
+information is stored in the global variables csrfMagicName and csrfMagicToken.
+CsrfMagic.process may also be of interest, as it takes one parameter, a
+querystring, and prepends the CSRF token to the value.
+
+
+3.  CONFIGURE
+
+csrf-magic has some configuration options that you can set inside the
+csrf_startup() function. They are described in csrf-magic.php, and you can
+set them using the convenience function csrf_conf($name, $value).
+
+For example, this is a recommended configuration:
+
+    /**
+     * This is a function that gets called if a csrf check fails. csrf-magic will
+     * then exit afterwards.
+     */
+    function my_csrf_callback() {
+        echo "You're doing bad things young man!";
+    }
+
+    function csrf_startup() {
+
+        // While csrf-magic has a handy little heuristic for determining whether
+        // or not the content in the buffer is HTML or not, you should really
+        // give it a nudge and turn rewriting *off* when the content is
+        // not HTML. Implementation details will vary.
+        if (isset($_POST['ajax'])) csrf_conf('rewrite', false);
+
+        // This is a secret value that must be set in order to enable username
+        // and IP based checks. Don't show this to anyone. A secret id will
+        // automatically be generated for you if the directory csrf-magic.php
+        // is placed in is writable.
+        csrf_conf('secret', 'ABCDEFG123456');
+
+        // This enables JavaScript rewriting and will ensure your AJAX calls
+        // don't stop working.
+        csrf_conf('rewrite-js', '/csrf-magic.js');
+
+        // This makes csrf-magic call my_csrf_callback() before exiting when
+        // there is a bad csrf token. This lets me customize the error page.
+        csrf_conf('callback', 'my_csrf_callback');
+
+        // While this is enabled by default to boost backwards compatibility,
+        // for security purposes it should ideally be off. Some users can be
+        // NATted or have dialup addresses which rotate frequently. Cookies
+        // are much more reliable.
+        csrf_conf('allow-ip', false);
+
+    }
+
+    // Finally, include the library
+    include_once '/path/to/csrf-magic.php';
+
+Configuration gets stored in the $GLOBALS['csrf'] array.
+
+
+4.  THANKS
+
+My thanks to Chris Shiflett, for unintentionally inspiring the idea, as well
+as telling me the original variant of the Bob and Mallory story,
+and the Django CSRF Middleware authors, who thought up of this before me.
+Gareth Heyes suggested using the frame-breaker option to protect against
+CSS overlay attacks.

--- a/web/includes/csrf/csrf-magic.js
+++ b/web/includes/csrf/csrf-magic.js
@@ -1,0 +1,191 @@
+/**
+ * @file
+ *
+ * Rewrites XMLHttpRequest to automatically send CSRF token with it. In theory
+ * plays nice with other JavaScript libraries, needs testing though.
+ */
+
+// Here are the basic overloaded method definitions
+// The wrapper must be set BEFORE onreadystatechange is written to, since
+// a bug in ActiveXObject prevents us from properly testing for it.
+CsrfMagic = function(real) {
+    // try to make it ourselves, if you didn't pass it
+    if (!real) try { real = new XMLHttpRequest; } catch (e) {;}
+    if (!real) try { real = new ActiveXObject('Msxml2.XMLHTTP'); } catch (e) {;}
+    if (!real) try { real = new ActiveXObject('Microsoft.XMLHTTP'); } catch (e) {;}
+    if (!real) try { real = new ActiveXObject('Msxml2.XMLHTTP.4.0'); } catch (e) {;}
+    this.csrf = real;
+    // properties
+    var csrfMagic = this;
+    real.onreadystatechange = function() {
+        csrfMagic._updateProps();
+        return csrfMagic.onreadystatechange ? csrfMagic.onreadystatechange() : null;
+    };
+    csrfMagic._updateProps();
+}
+
+CsrfMagic.prototype = {
+
+    open: function(method, url, async, username, password) {
+        if (method == 'POST') this.csrf_isPost = true;
+        // deal with Opera bug, thanks jQuery
+        if (username) return this.csrf_open(method, url, async, username, password);
+        else return this.csrf_open(method, url, async);
+    },
+    csrf_open: function(method, url, async, username, password) {
+        if (username) return this.csrf.open(method, url, async, username, password);
+        else return this.csrf.open(method, url, async);
+    },
+
+    send: function(data) {
+        if (!this.csrf_isPost) return this.csrf_send(data);
+        prepend = csrfMagicName + '=' + csrfMagicToken + '&';
+    //    XXX: Removed to eliminate 'Refused to set unsafe header "Content-length" ' errors in modern browsers
+    //    if (this.csrf_purportedLength === undefined) {
+    //        this.csrf_setRequestHeader("Content-length", this.csrf_purportedLength + prepend.length);
+    //        delete this.csrf_purportedLength;
+    //    }
+        delete this.csrf_isPost;
+        return this.csrf_send(prepend + data);
+    },
+    csrf_send: function(data) {
+        return this.csrf.send(data);
+    },
+
+    setRequestHeader: function(header, value) {
+        // We have to auto-set this at the end, since we don't know how long the
+        // nonce is when added to the data.
+        if (this.csrf_isPost && header == "Content-length") {
+            this.csrf_purportedLength = value;
+            return;
+        }
+        return this.csrf_setRequestHeader(header, value);
+    },
+    csrf_setRequestHeader: function(header, value) {
+        return this.csrf.setRequestHeader(header, value);
+    },
+
+    abort: function() {
+        return this.csrf.abort();
+    },
+    getAllResponseHeaders: function() {
+        return this.csrf.getAllResponseHeaders();
+    },
+    getResponseHeader: function(header) {
+        return this.csrf.getResponseHeader(header);
+    } // ,
+}
+
+// proprietary
+CsrfMagic.prototype._updateProps = function() {
+    this.readyState = this.csrf.readyState;
+    if (this.readyState == 4) {
+        this.responseText = this.csrf.responseText;
+        this.responseXML  = this.csrf.responseXML;
+        this.status       = this.csrf.status;
+        this.statusText   = this.csrf.statusText;
+    }
+}
+CsrfMagic.process = function(base) {
+    if(typeof base == 'object') {
+        base[csrfMagicName] = csrfMagicToken;
+        return base;
+    }
+    var prepend = csrfMagicName + '=' + csrfMagicToken;
+    if (base) return prepend + '&' + base;
+    return prepend;
+}
+// callback function for when everything on the page has loaded
+CsrfMagic.end = function() {
+    // This rewrites forms AGAIN, so in case buffering didn't work this
+    // certainly will.
+    forms = document.getElementsByTagName('form');
+    for (var i = 0; i < forms.length; i++) {
+        form = forms[i];
+        if (form.method.toUpperCase() !== 'POST') continue;
+        if (form.elements[csrfMagicName]) continue;
+        var input = document.createElement('input');
+        input.setAttribute('name',  csrfMagicName);
+        input.setAttribute('value', csrfMagicToken);
+        input.setAttribute('type',  'hidden');
+        form.appendChild(input);
+    }
+}
+
+// Sets things up for Mozilla/Opera/nice browsers
+// We very specifically match against Internet Explorer, since they haven't
+// implemented prototypes correctly yet.
+if (window.XMLHttpRequest && window.XMLHttpRequest.prototype && '\v' != 'v') {
+    var x = XMLHttpRequest.prototype;
+    var c = CsrfMagic.prototype;
+
+    // Save the original functions
+    x.csrf_open = x.open;
+    x.csrf_send = x.send;
+    x.csrf_setRequestHeader = x.setRequestHeader;
+
+    // Notice that CsrfMagic is itself an instantiatable object, but only
+    // open, send and setRequestHeader are necessary as decorators.
+    x.open = c.open;
+    x.send = c.send;
+    x.setRequestHeader = c.setRequestHeader;
+} else {
+    // The only way we can do this is by modifying a library you have been
+    // using. We support YUI, script.aculo.us, prototype, MooTools,
+    // jQuery, Ext and Dojo.
+    if (window.jQuery) {
+        // jQuery didn't implement a new XMLHttpRequest function, so we have
+        // to do this the hard way.
+        jQuery.csrf_ajax = jQuery.ajax;
+        jQuery.ajax = function( s ) {
+            if (s.type && s.type.toUpperCase() == 'POST') {
+                s = jQuery.extend(true, s, jQuery.extend(true, {}, jQuery.ajaxSettings, s));
+                if ( s.data && s.processData && typeof s.data != "string" ) {
+                    s.data = jQuery.param(s.data);
+                }
+                s.data = CsrfMagic.process(s.data);
+            }
+            return jQuery.csrf_ajax( s );
+        }
+    }
+    if (window.Prototype) {
+        // This works for script.aculo.us too
+        Ajax.csrf_getTransport = Ajax.getTransport;
+        Ajax.getTransport = function() {
+            return new CsrfMagic(Ajax.csrf_getTransport());
+        }
+    }
+    if (window.MooTools) {
+        Browser.csrf_Request = Browser.Request;
+        Browser.Request = function () {
+            return new CsrfMagic(Browser.csrf_Request());
+        }
+    }
+    if (window.YAHOO) {
+        // old YUI API
+        YAHOO.util.Connect.csrf_createXhrObject = YAHOO.util.Connect.createXhrObject;
+        YAHOO.util.Connect.createXhrObject = function (transaction) {
+            obj = YAHOO.util.Connect.csrf_createXhrObject(transaction);
+            obj.conn = new CsrfMagic(obj.conn);
+            return obj;
+        }
+    }
+    if (window.Ext) {
+        // Ext can use other js libraries as loaders, so it has to come last
+        // Ext's implementation is pretty identical to Yahoo's, but we duplicate
+        // it for comprehensiveness's sake.
+        Ext.lib.Ajax.csrf_createXhrObject = Ext.lib.Ajax.createXhrObject;
+        Ext.lib.Ajax.createXhrObject = function (transaction) {
+            obj = Ext.lib.Ajax.csrf_createXhrObject(transaction);
+            obj.conn = new CsrfMagic(obj.conn);
+            return obj;
+        }
+    }
+    if (window.dojo) {
+        // NOTE: this doesn't work with latest dojo
+        dojo.csrf__xhrObj = dojo._xhrObj;
+        dojo._xhrObj = function () {
+            return new CsrfMagic(dojo.csrf__xhrObj());
+        }
+    }
+}

--- a/web/includes/csrf/csrf-magic.php
+++ b/web/includes/csrf/csrf-magic.php
@@ -1,0 +1,405 @@
+<?php
+
+/**
+ * @file
+ *
+ * csrf-magic is a PHP library that makes adding CSRF-protection to your
+ * web applications a snap. No need to modify every form or create a database
+ * of valid nonces; just include this file at the top of every
+ * web-accessible page (or even better, your common include file included
+ * in every page), and forget about it! (There are, of course, configuration
+ * options for advanced users).
+ *
+ * This library is PHP4 and PHP5 compatible.
+ */
+
+// CONFIGURATION:
+
+/**
+ * By default, when you include this file csrf-magic will automatically check
+ * and exit if the CSRF token is invalid. This will defer executing
+ * csrf_check() until you're ready.  You can also pass false as a parameter to
+ * that function, in which case the function will not exit but instead return
+ * a boolean false if the CSRF check failed. This allows for tighter integration
+ * with your system.
+ */
+$GLOBALS['csrf']['defer'] = false;
+
+/**
+ * This is the amount of seconds you wish to allow before any token becomes
+ * invalid; the default is two hours, which should be more than enough for
+ * most websites.
+ */
+$GLOBALS['csrf']['expires'] = 7200;
+
+/**
+ * Callback function to execute when there's the CSRF check fails and
+ * $fatal == true (see csrf_check). This will usually output an error message
+ * about the failure.
+ */
+$GLOBALS['csrf']['callback'] = 'csrf_callback';
+
+/**
+ * Whether or not to include our JavaScript library which also rewrites
+ * AJAX requests on this domain. Set this to the web path. This setting only works
+ * with supported JavaScript libraries in Internet Explorer; see README.txt for
+ * a list of supported libraries.
+ */
+$GLOBALS['csrf']['rewrite-js'] = false;
+
+/**
+ * A secret key used when hashing items. Please generate a random string and
+ * place it here. If you change this value, all previously generated tokens
+ * will become invalid.
+ */
+$GLOBALS['csrf']['secret'] = '';
+// nota bene: library code should use csrf_get_secret() and not access
+// this global directly
+
+/**
+ * Set this to false to disable csrf-magic's output handler, and therefore,
+ * its rewriting capabilities. If you're serving non HTML content, you should
+ * definitely set this false.
+ */
+$GLOBALS['csrf']['rewrite'] = true;
+
+/**
+ * Whether or not to use IP addresses when binding a user to a token. This is
+ * less reliable and less secure than sessions, but is useful when you need
+ * to give facilities to anonymous users and do not wish to maintain a database
+ * of valid keys.
+ */
+$GLOBALS['csrf']['allow-ip'] = true;
+
+/**
+ * If this information is available, use the cookie by this name to determine
+ * whether or not to allow the request. This is a shortcut implementation
+ * very similar to 'key', but we randomly set the cookie ourselves.
+ */
+$GLOBALS['csrf']['cookie'] = '__csrf_cookie';
+
+/**
+ * If this information is available, set this to a unique identifier (it
+ * can be an integer or a unique username) for the current "user" of this
+ * application. The token will then be globally valid for all of that user's
+ * operations, but no one else. This requires that 'secret' be set.
+ */
+$GLOBALS['csrf']['user'] = false;
+
+/**
+ * This is an arbitrary secret value associated with the user's session. This
+ * will most probably be the contents of a cookie, as an attacker cannot easily
+ * determine this information. Warning: If the attacker knows this value, they
+ * can easily spoof a token. This is a generic implementation; sessions should
+ * work in most cases.
+ *
+ * Why would you want to use this? Lets suppose you have a squid cache for your
+ * website, and the presence of a session cookie bypasses it. Let's also say
+ * you allow anonymous users to interact with the website; submitting forms
+ * and AJAX. Previously, you didn't have any CSRF protection for anonymous users
+ * and so they never got sessions; you don't want to start using sessions either,
+ * otherwise you'll bypass the Squid cache. Setup a different cookie for CSRF
+ * tokens, and have Squid ignore that cookie for get requests, for anonymous
+ * users. (If you haven't guessed, this scheme was(?) used for MediaWiki).
+ */
+$GLOBALS['csrf']['key'] = false;
+
+/**
+ * The name of the magic CSRF token that will be placed in all forms, i.e.
+ * the contents of <input type="hidden" name="$name" value="CSRF-TOKEN" />
+ */
+$GLOBALS['csrf']['input-name'] = '__csrf_magic';
+
+/**
+ * Set this to false if your site must work inside of frame/iframe elements,
+ * but do so at your own risk: this configuration protects you against CSS
+ * overlay attacks that defeat tokens.
+ */
+$GLOBALS['csrf']['frame-breaker'] = true;
+
+/**
+ * Whether or not CSRF Magic should be allowed to start a new session in order
+ * to determine the key.
+ */
+$GLOBALS['csrf']['auto-session'] = true;
+
+/**
+ * Whether or not csrf-magic should produce XHTML style tags.
+ */
+$GLOBALS['csrf']['xhtml'] = true;
+
+// FUNCTIONS:
+
+// Don't edit this!
+$GLOBALS['csrf']['version'] = '1.0.4';
+
+/**
+ * Rewrites <form> on the fly to add CSRF tokens to them. This can also
+ * inject our JavaScript library.
+ */
+function csrf_ob_handler($buffer, $flags) {
+    // Even though the user told us to rewrite, we should do a quick heuristic
+    // to check if the page is *actually* HTML. We don't begin rewriting until
+    // we hit the first <html tag.
+    static $is_html = false;
+    if (!$is_html) {
+        // not HTML until proven otherwise
+        if (stripos($buffer, '<html') !== false) {
+            $is_html = true;
+        } else {
+            return $buffer;
+        }
+    }
+    $tokens = csrf_get_tokens();
+    $name = $GLOBALS['csrf']['input-name'];
+    $endslash = $GLOBALS['csrf']['xhtml'] ? ' /' : '';
+    $input = "<input type='hidden' name='$name' value=\"$tokens\"$endslash>";
+    $buffer = preg_replace('#(<form[^>]*method\s*=\s*["\']post["\'][^>]*>)#i', '$1' . $input, $buffer);
+    if ($GLOBALS['csrf']['frame-breaker']) {
+        $buffer = str_ireplace('</head>', '<script type="text/javascript">if (top != self) {top.location.href = self.location.href;}</script></head>', $buffer);
+    }
+    if ($js = $GLOBALS['csrf']['rewrite-js']) {
+        $buffer = str_ireplace(
+            '</head>',
+            '<script type="text/javascript">'.
+                'var csrfMagicToken = "'.$tokens.'";'.
+                'var csrfMagicName = "'.$name.'";</script>'.
+            '<script src="'.$js.'" type="text/javascript"></script></head>',
+            $buffer
+        );
+        $script = '<script type="text/javascript">CsrfMagic.end();</script>';
+        $buffer = str_ireplace('</body>', $script . '</body>', $buffer, $count);
+        if (!$count) {
+            $buffer .= $script;
+        }
+    }
+    return $buffer;
+}
+
+/**
+ * Checks if this is a post request, and if it is, checks if the nonce is valid.
+ * @param bool $fatal Whether or not to fatally error out if there is a problem.
+ * @return True if check passes or is not necessary, false if failure.
+ */
+function csrf_check($fatal = true) {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') return true;
+    csrf_start();
+    $name = $GLOBALS['csrf']['input-name'];
+    $ok = false;
+    $tokens = '';
+    do {
+        if (!isset($_POST[$name])) break;
+        // we don't regenerate a token and check it because some token creation
+        // schemes are volatile.
+        $tokens = $_POST[$name];
+        if (!csrf_check_tokens($tokens)) break;
+        $ok = true;
+    } while (false);
+    if ($fatal && !$ok) {
+        $callback = $GLOBALS['csrf']['callback'];
+        if (trim($tokens, 'A..Za..z0..9:;,') !== '') $tokens = 'hidden';
+        $callback($tokens);
+        exit;
+    }
+    return $ok;
+}
+
+/**
+ * Retrieves a valid token(s) for a particular context. Tokens are separated
+ * by semicolons.
+ */
+function csrf_get_tokens() {
+    $has_cookies = !empty($_COOKIE);
+
+    // $ip implements a composite key, which is sent if the user hasn't sent
+    // any cookies. It may or may not be used, depending on whether or not
+    // the cookies "stick"
+    $secret = csrf_get_secret();
+    if (!$has_cookies && $secret) {
+        // :TODO: Harden this against proxy-spoofing attacks
+        $IP_ADDRESS = (isset($_SERVER['IP_ADDRESS']) ? $_SERVER['IP_ADDRESS'] : $_SERVER['REMOTE_ADDR']);
+        $ip = ';ip:' . csrf_hash($IP_ADDRESS);
+    } else {
+        $ip = '';
+    }
+    csrf_start();
+
+    // These are "strong" algorithms that don't require per se a secret
+    if (session_id()) return 'sid:' . csrf_hash(session_id()) . $ip;
+    if ($GLOBALS['csrf']['cookie']) {
+        $val = csrf_generate_secret();
+        setcookie($GLOBALS['csrf']['cookie'], $val);
+        return 'cookie:' . csrf_hash($val) . $ip;
+    }
+    if ($GLOBALS['csrf']['key']) return 'key:' . csrf_hash($GLOBALS['csrf']['key']) . $ip;
+    // These further algorithms require a server-side secret
+    if (!$secret) return 'invalid';
+    if ($GLOBALS['csrf']['user'] !== false) {
+        return 'user:' . csrf_hash($GLOBALS['csrf']['user']);
+    }
+    if ($GLOBALS['csrf']['allow-ip']) {
+        return ltrim($ip, ';');
+    }
+    return 'invalid';
+}
+
+function csrf_flattenpost($data) {
+    $ret = array();
+    foreach($data as $n => $v) {
+        $ret = array_merge($ret, csrf_flattenpost2(1, $n, $v));
+    }
+    return $ret;
+}
+function csrf_flattenpost2($level, $key, $data) {
+    if(!is_array($data)) return array($key => $data);
+    $ret = array();
+    foreach($data as $n => $v) {
+        $nk = $level >= 1 ? $key."[$n]" : "[$n]";
+        $ret = array_merge($ret, csrf_flattenpost2($level+1, $nk, $v));
+    }
+    return $ret;
+}
+
+/**
+ * @param $tokens is safe for HTML consumption
+ */
+function csrf_callback($tokens) {
+    // (yes, $tokens is safe to echo without escaping)
+    header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+    $data = '';
+    foreach (csrf_flattenpost($_POST) as $key => $value) {
+        if ($key == $GLOBALS['csrf']['input-name']) continue;
+        $data .= '<input type="hidden" name="'.htmlspecialchars($key).'" value="'.htmlspecialchars($value).'" />';
+    }
+    echo "<html><head><title>CSRF check failed</title></head>
+        <body>
+        <p>CSRF check failed. Your form session may have expired, or you may not have
+        cookies enabled.</p>
+        <form method='post' action=''>$data<input type='submit' value='Try again' /></form>
+        <p>Debug: $tokens</p></body></html>
+";
+}
+
+/**
+ * Checks if a composite token is valid. Outward facing code should use this
+ * instead of csrf_check_token()
+ */
+function csrf_check_tokens($tokens) {
+    if (is_string($tokens)) $tokens = explode(';', $tokens);
+    foreach ($tokens as $token) {
+        if (csrf_check_token($token)) return true;
+    }
+    return false;
+}
+
+/**
+ * Checks if a token is valid.
+ */
+function csrf_check_token($token) {
+    if (strpos($token, ':') === false) return false;
+    list($type, $value) = explode(':', $token, 2);
+    if (strpos($value, ',') === false) return false;
+    list($x, $time) = explode(',', $token, 2);
+    if ($GLOBALS['csrf']['expires']) {
+        if (time() > $time + $GLOBALS['csrf']['expires']) return false;
+    }
+    switch ($type) {
+        case 'sid':
+            return $value === csrf_hash(session_id(), $time);
+        case 'cookie':
+            $n = $GLOBALS['csrf']['cookie'];
+            if (!$n) return false;
+            if (!isset($_COOKIE[$n])) return false;
+            return $value === csrf_hash($_COOKIE[$n], $time);
+        case 'key':
+            if (!$GLOBALS['csrf']['key']) return false;
+            return $value === csrf_hash($GLOBALS['csrf']['key'], $time);
+        // We could disable these 'weaker' checks if 'key' was set, but
+        // that doesn't make me feel good then about the cookie-based
+        // implementation.
+        case 'user':
+            if (!csrf_get_secret()) return false;
+            if ($GLOBALS['csrf']['user'] === false) return false;
+            return $value === csrf_hash($GLOBALS['csrf']['user'], $time);
+        case 'ip':
+            if (!csrf_get_secret()) return false;
+            // do not allow IP-based checks if the username is set, or if
+            // the browser sent cookies
+            if ($GLOBALS['csrf']['user'] !== false) return false;
+            if (!empty($_COOKIE)) return false;
+            if (!$GLOBALS['csrf']['allow-ip']) return false;
+            $IP_ADDRESS = (isset($_SERVER['IP_ADDRESS']) ? $_SERVER['IP_ADDRESS'] : $_SERVER['REMOTE_ADDR']);
+            return $value === csrf_hash($IP_ADDRESS, $time);
+    }
+    return false;
+}
+
+/**
+ * Sets a configuration value.
+ */
+function csrf_conf($key, $val) {
+    if (!isset($GLOBALS['csrf'][$key])) {
+        trigger_error('No such configuration ' . $key, E_USER_WARNING);
+        return;
+    }
+    $GLOBALS['csrf'][$key] = $val;
+}
+
+/**
+ * Starts a session if we're allowed to.
+ */
+function csrf_start() {
+    if ($GLOBALS['csrf']['auto-session'] && !session_id()) {
+        session_start();
+    }
+}
+
+/**
+ * Retrieves the secret, and generates one if necessary.
+ */
+function csrf_get_secret() {
+    if ($GLOBALS['csrf']['secret']) return $GLOBALS['csrf']['secret'];
+    $dir = dirname(__FILE__);
+    $file = $dir . '/csrf-secret.php';
+    $secret = '';
+    if (file_exists($file)) {
+        include $file;
+        return $secret;
+    }
+    if (is_writable($dir)) {
+        $secret = csrf_generate_secret();
+        $fh = fopen($file, 'w');
+        fwrite($fh, '<?php $secret = "'.$secret.'";' . PHP_EOL);
+        fclose($fh);
+        return $secret;
+    }
+    return '';
+}
+
+/**
+ * Generates a random string as the hash of time, microtime, and mt_rand.
+ */
+function csrf_generate_secret($len = 32) {
+    $r = '';
+    for ($i = 0; $i < $len; $i++) {
+        $r .= chr(mt_rand(0, 255));
+    }
+    $r .= time() . microtime();
+    return sha1($r);
+}
+
+/**
+ * Generates a hash/expiry double. If time isn't set it will be calculated
+ * from the current time.
+ */
+function csrf_hash($value, $time = null) {
+    if (!$time) $time = time();
+    return sha1(csrf_get_secret() . $value . $time) . ',' . $time;
+}
+
+// Load user configuration
+if (function_exists('csrf_startup')) csrf_startup();
+// Initialize our handler
+if ($GLOBALS['csrf']['rewrite'])     ob_start('csrf_ob_handler');
+// Perform check
+if (!$GLOBALS['csrf']['defer'])      csrf_check();

--- a/web/includes/csrf/csrf-magic.php
+++ b/web/includes/csrf/csrf-magic.php
@@ -23,7 +23,7 @@
  * a boolean false if the CSRF check failed. This allows for tighter integration
  * with your system.
  */
-$GLOBALS['csrf']['defer'] = false;
+$GLOBALS['csrf']['defer'] = true;
 
 /**
  * This is the amount of seconds you wish to allow before any token becomes

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2143,4 +2143,8 @@ function folder_size($dir) {
     return $size;
 } // end function folder_size
 
+function csrf_startup() {
+    csrf_conf('rewrite-js', 'includes/csrf/csrf-magic.js');
+}
+
 ?>

--- a/web/index.php
+++ b/web/index.php
@@ -147,6 +147,7 @@ else
 
 require_once( 'includes/lang.php' );
 require_once( 'includes/functions.php' );
+require_once( 'includes/csrf/csrf-magic.php' );
 
 # Add Cross domain access headers
 CORSHeaders();

--- a/web/index.php
+++ b/web/index.php
@@ -170,6 +170,11 @@ if ( isset($_REQUEST['action']) )
 foreach ( getSkinIncludes( 'skin.php' ) as $includeFile )
     require_once $includeFile;
 
+# The only variable we really need to set is action. The others are informal.
+isset($view) || $view = NULL;
+isset($request) || $request = NULL;
+isset($action) || $action = NULL;
+
 if ( ZM_ENABLE_CSRF_MAGIC && $action != 'login' ) {
     Debug("Calling csrf_check with the following values: \$request = \"$request\", \$view = \"$view\", \$action = \"$action\"");
     csrf_check();

--- a/web/index.php
+++ b/web/index.php
@@ -170,6 +170,11 @@ if ( isset($_REQUEST['action']) )
 foreach ( getSkinIncludes( 'skin.php' ) as $includeFile )
     require_once $includeFile;
 
+if ( ZM_ENABLE_CSRF_MAGIC && $action != 'login' ) {
+    Debug("Calling csrf_check with the following values: \$request = \"$request\", \$view = \"$view\", \$action = \"$action\"");
+    csrf_check();
+}
+
 require_once( 'includes/actions.php' );
 
 # If I put this here, it protects all views and popups, but it has to go after actions.php because actions.php does the actual logging in.


### PR DESCRIPTION
Add csrf-magic library to zoneminder, and integrate into zoneminder web forms.
https://github.com/ezyang/csrf-magic

What this library does is generate a token, which is based off the users php session id. If the token submitted with the form does not match the token generated when index.php was first loaded, then the web server returns http 403 with the message "CSRF check failed. Your form session may have expired, or you may not have cookies enabled." You will know it, if you trigger the csrf prevention.


I have given this some testing, and it appears to work. However, ideally every form submit or save button in ZoneMinder should be tested to verify there are no false triggers.
