### PR TITLE
Fix check that API user is enabled

### DIFF
--- a/web/api/app/Controller/AppController.php
+++ b/web/api/app/Controller/AppController.php
@@ -91,7 +91,7 @@ class AppController extends Controller {
       if( ! $this->Session->Read('user.Username') ) {
         throw new UnauthorizedException(__('Not Authenticated'));
         return;
-      } else if ( ! $this->Session->Read('user.Username') ) {
+      } else if ( ! $this->Session->Read('user.Enabled') ) {
         throw new UnauthorizedException(__('User is not enabled'));
         return;
       }


### PR DESCRIPTION
While implementing #1827, I saw that there were two identical conditions in `beforeFilter` and I suspect the second one was supposed to be checking `user.Enabled` instead of both checking `user.Username`.

Without this fix disabled users can still use the API.