### PR TITLE
Fix out-of-source building failing because pod2man

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -26,9 +26,10 @@ configure_file(zm.in "${CMAKE_CURRENT_BINARY_DIR}/zm" @ONLY)
 #configure_file(zmeventdump.in zmeventdump @ONLY)
 
 # Generate man files for the perl scripts destined for the bin folder
-file(GLOB perlscripts RELATIVE "${CMAKE_CURRENT_BINARY_DIR}" "*.pl")
+file(GLOB perlscripts "*.pl")
 FOREACH(PERLSCRIPT ${perlscripts})
-    POD2MAN(${CMAKE_CURRENT_SOURCE_DIR}/${PERLSCRIPT} zoneminder-${PERLSCRIPT} 8)
+    get_filename_component(PERLSCRIPTNAME ${PERLSCRIPT} NAME)
+    POD2MAN(${PERLSCRIPT} zoneminder-${PERLSCRIPTNAME} 8)
 ENDFOREACH(PERLSCRIPT ${perlscripts})
 
 # Install the perl scripts


### PR DESCRIPTION
Hello,

Building the master branch out-of-source on CentOS6 with cmake 2.8.12 fails when creating the pod files.

For example:
```
FATALERRORCould not find pod file /home/kfir/ZoneMinder/scripts/../../scripts/zmvideo.pl to generate man page
CMake Error at cmake/Modules/Pod2Man.cmake:56 (ADD_CUSTOM_TARGET):
  add_custom_target called with invalid target name
  "man-zoneminder-../../scripts/zmvideo.pl".  Target names may not contain a
  slash.  Use ADD_CUSTOM_COMMAND to generate files.  Set
  CMAKE_BACKWARDS_COMPATIBILITY to 2.2 or lower to skip this check.
Call Stack (most recent call first):
  scripts/CMakeLists.txt:31 (POD2MAN)
```
There are actually two errors here:
1) POD2MAN fails to find the files because the path is incorrect.
2) CMake complains the target name contains a slash.

The fix is to use absolute paths (remove the RELATIVE parameter when globbing), and to create target names that do not contain slashes, by using the filename only (strip the path from the filename).

Steps to reproduce:
1. Clone the master branch (before this PR is merged)
2. mkdir testbuild
3. cd testbuild
4. cmake ./..

