### PR TITLE
Setup api cache dirs

### DIFF
--- a/distros/ubuntu1604/zoneminder.links
+++ b/distros/ubuntu1604/zoneminder.links
@@ -1,3 +1,4 @@
 /var/cache/zoneminder/events	/usr/share/zoneminder/www/events
 /var/cache/zoneminder/images	/usr/share/zoneminder/www/images
 /var/cache/zoneminder/temp	/usr/share/zoneminder/www/temp
+/var/tmp  /usr/share/zoneminder/www/api/app/tmp

--- a/distros/ubuntu1604/zoneminder.tmpfile
+++ b/distros/ubuntu1604/zoneminder.tmpfile
@@ -1,2 +1,6 @@
-d /var/run/zm 0755 www-data www-data
-d /tmp/zm     0755 www-data www-data
+d /var/run/zm                   0755 www-data www-data
+d /tmp/zm                       0755 www-data www-data
+d /var/tmp/zm                   0755 www-data www-data
+d /var/tmp/cache                0755 www-data www-data
+d /var/tmp/cache/models         0755 www-data www-data
+d /var/tmp/cache/persistent     0755 www-data www-data


### PR DESCRIPTION
So with the default cakephp api install, we don't auto-create the /usr/share/zoneminder/api/app/tmp link to /var/tmp.  I'm hoping this change fixes that.

The other problem is that cakephp will only create the directories under that when in debug mode.  We don't really want to default to debug mode, so let's create them manually during install. Since we are using /var/tmp which I don't think gets cleaned out on reboot, this should be enough.  Otherwise, we will have to make it part of the startup process/init script.