### PR TITLE
Let systemd create the needed temporary directory

### DIFF
--- a/misc/zoneminder.service.in
+++ b/misc/zoneminder.service.in
@@ -9,6 +9,10 @@ Requires=mysqld.service httpd.service
 [Service]
 User=@WEB_USER@
 Type=forking
+PrivateTmp=true
+PermissionsStartOnly=true
+ExecStartPre=/usr/bin/mkdir -p @ZM_RUNDIR@
+ExecStartPre=/usr/bin/chown -R @WEB_USER@:@WEB_USER@ @ZM_RUNDIR@
 ExecStart=@BINDIR@/zmpkg.pl start
 ExecReload=@BINDIR@/zmpkg.pl restart
 ExecStop=@BINDIR@/zmpkg.pl stop


### PR DESCRIPTION
This addresses the fact that ZoneMinder cannot create the temporary directory
without elevated privileges. By letting systemd handle the creation, the
directory can be created as needed before ZoneMinder runs the first time.