### PR TITLE
 Allow API authentication using the `auth` query parameter containing an auth. hash.

### DIFF
--- a/web/ajax/stream.php
+++ b/web/ajax/stream.php
@@ -21,23 +21,23 @@ if ( !@socket_bind( $socket, $locSockFile ) )
 switch ( $_REQUEST['command'] )
 {
     case CMD_VARPLAY :
-        Debug( "Varplaying to ".$_REQUEST['rate'] );
+        Logger::Debug( "Varplaying to ".$_REQUEST['rate'] );
         $msg = pack( "lcn", MSG_CMD, $_REQUEST['command'], $_REQUEST['rate']+32768 );
         break;
     case CMD_ZOOMIN :
-        Debug( "Zooming to ".$_REQUEST['x'].",".$_REQUEST['y'] );
+        Logger::Debug( "Zooming to ".$_REQUEST['x'].",".$_REQUEST['y'] );
         $msg = pack( "lcnn", MSG_CMD, $_REQUEST['command'], $_REQUEST['x'], $_REQUEST['y'] );
         break;
     case CMD_PAN :
-        Debug( "Panning to ".$_REQUEST['x'].",".$_REQUEST['y'] );
+        Logger::Debug( "Panning to ".$_REQUEST['x'].",".$_REQUEST['y'] );
         $msg = pack( "lcnn", MSG_CMD, $_REQUEST['command'], $_REQUEST['x'], $_REQUEST['y'] );
         break;
     case CMD_SCALE :
-        Debug( "Scaling to ".$_REQUEST['scale'] );
+        Logger::Debug( "Scaling to ".$_REQUEST['scale'] );
         $msg = pack( "lcn", MSG_CMD, $_REQUEST['command'], $_REQUEST['scale'] );
         break;
     case CMD_SEEK :
-        Debug( "Seeking to ".$_REQUEST['offset'] );
+        Logger::Debug( "Seeking to ".$_REQUEST['offset'] );
         $msg = pack( "lcN", MSG_CMD, $_REQUEST['command'], $_REQUEST['offset'] );
         break;
     default :

--- a/web/api/app/Controller/AppController.php
+++ b/web/api/app/Controller/AppController.php
@@ -88,6 +88,31 @@ class AppController extends Controller {
         }
       }
 
+      if ( isset($_REQUEST['auth']) ) {
+        require_once "../../../includes/functions.php";
+
+        // Define some defines required by getAuthUser in functions.php
+        $defines = array('ZM_AUTH_HASH_IPS', 'ZM_AUTH_HASH_SECRET', 'ZM_AUTH_RELAY', 'ZM_OPT_USE_AUTH');
+        $configQuery = array(
+                             'conditions' => array('OR' => array('Name' => $defines)),
+                             'fields' => array('Name', 'Value')
+                             );
+        $config = $this->Config->find('list', $configQuery);
+
+        foreach ($defines as $define) {
+          define($define, $config[$define]);
+        }
+
+        $user = getAuthUser($_REQUEST['auth']);
+        if ( ! $user ) {
+          throw new UnauthorizedException(__('User not found'));
+          return;
+        } else {
+          $this->Session->Write( 'user.Username', $user['Username'] );
+          $this->Session->Write( 'user.Enabled', $user['Enabled'] );
+        }
+      }
+
       if( ! $this->Session->Read('user.Username') ) {
         throw new UnauthorizedException(__('Not Authenticated'));
         return;

--- a/web/includes/Event.php
+++ b/web/includes/Event.php
@@ -218,11 +218,11 @@ class Event {
           } 
             
           $command ='ffmpeg -v 0 -i '.$videoPath.' -vf "select=gte(n\\,'.$frame['FrameId'].'),setpts=PTS-STARTPTS" '.$eventPath.'/'.$captImage;
-          Debug( "Running $command" );
+          Logger::Debug( "Running $command" );
           $output = array();
           $retval = 0;
           exec( $command, $output, $retval );
-          Debug("Retval: $retval, output: " . implode("\n", $output));
+          Logger::Debug("Retval: $retval, output: " . implode("\n", $output));
         } else {
           Error("Can't create frame images from video becuase there is no video file for this event (".$Event->DefaultVideo() );
         }

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -88,7 +88,7 @@ function dbLog( $sql, $update=false )
     global $dbLogLevel;
     $noExecute = $update && ($dbLogLevel >= DB_LOG_DEBUG);
     if ( $dbLogLevel > DB_LOG_OFF )
-        Debug( "SQL-LOG: $sql".($noExecute?" (not executed)":"") );
+        Logger::Debug( "SQL-LOG: $sql".($noExecute?" (not executed)":"") );
     return( $noExecute );
 }
 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -27,6 +27,9 @@ if ( version_compare( phpversion(), "4.3.0", "<") ) {
   }
 }
 
+require_once( 'logger.php' );
+require_once( 'database.php' );
+
 function userLogin( $username, $password="", $passwordHashed=false ) {
   global $user, $cookies;
 

--- a/web/includes/logger.php
+++ b/web/includes/logger.php
@@ -165,7 +165,7 @@ class Logger
 
         $this->initialised = true;
 
-        Debug( "LogOpts: level=".self::$codes[$this->level]."/".self::$codes[$this->effectiveLevel].", screen=".self::$codes[$this->termLevel].", database=".self::$codes[$this->databaseLevel].", logfile=".self::$codes[$this->fileLevel]."->".$this->logFile.", weblog=".self::$codes[$this->weblogLevel].", syslog=".self::$codes[$this->syslogLevel] );
+        Logger::Debug( "LogOpts: level=".self::$codes[$this->level]."/".self::$codes[$this->effectiveLevel].", screen=".self::$codes[$this->termLevel].", database=".self::$codes[$this->databaseLevel].", logfile=".self::$codes[$this->fileLevel]."->".$this->logFile.", weblog=".self::$codes[$this->weblogLevel].", syslog=".self::$codes[$this->syslogLevel] );
     }
 
     private function terminate()
@@ -210,6 +210,11 @@ class Logger
                 self::$instance->initialise( array( 'id'=>'web_php', 'syslogLevel'=>self::INFO, 'weblogLevel'=>self::INFO ) );
         }
         return self::$instance;
+    }
+
+    public static function Debug( $string )
+    {
+        Logger::fetch()->logPrint( Logger::DEBUG, $string );
     }
 
     public function id( $id=NULL )
@@ -503,11 +508,6 @@ function Dump( &$var, $label="VAR" )
     print( $label." => " );
     print_r( $var );
     Logger::fetch()->logPrint( Logger::DEBUG, ob_get_clean() );
-}
-
-function Debug( $string )
-{
-    Logger::fetch()->logPrint( Logger::DEBUG, $string );
 }
 
 function Info( $string )

--- a/web/index.php
+++ b/web/index.php
@@ -175,7 +175,7 @@ isset($view) || $view = NULL;
 isset($request) || $request = NULL;
 isset($action) || $action = NULL;
 
-if ( ZM_ENABLE_CSRF_MAGIC && $action != 'login' ) {
+if ( ZM_ENABLE_CSRF_MAGIC ) {
     Logger::Debug("Calling csrf_check with the following values: \$request = \"$request\", \$view = \"$view\", \$action = \"$action\"");
     csrf_check();
 }

--- a/web/index.php
+++ b/web/index.php
@@ -113,7 +113,7 @@ if ( !file_exists( ZM_SKIN_PATH ) )
 $skinBase[] = $skin;
 
 $currentCookieParams = session_get_cookie_params(); 
-Debug('Setting cookie parameters to lifetime('.$currentCookieParams['lifetime'].') path('.$currentCookieParams['path'].') domain ('.$currentCookieParams['domain'].') secure('.$currentCookieParams['secure'].') httpOnly(1)');
+Logger::Debug('Setting cookie parameters to lifetime('.$currentCookieParams['lifetime'].') path('.$currentCookieParams['path'].') domain ('.$currentCookieParams['domain'].') secure('.$currentCookieParams['secure'].') httpOnly(1)');
 session_set_cookie_params( 
     $currentCookieParams["lifetime"], 
     $currentCookieParams["path"], 
@@ -176,7 +176,7 @@ isset($request) || $request = NULL;
 isset($action) || $action = NULL;
 
 if ( ZM_ENABLE_CSRF_MAGIC && $action != 'login' ) {
-    Debug("Calling csrf_check with the following values: \$request = \"$request\", \$view = \"$view\", \$action = \"$action\"");
+    Logger::Debug("Calling csrf_check with the following values: \$request = \"$request\", \$view = \"$view\", \$action = \"$action\"");
     csrf_check();
 }
 


### PR DESCRIPTION
This implements #1827. Let's try to keep the discussion about the concept there and focus this pull request on the technical details of the implementation to avoid fragmenting the conversation.

The reason for moving the global `Debug` function was because it conflicted with a CakePHP method of the same name. I thought of a few different approaches to workaround the problem but I settled on moving it to a static method on Logger as it seemed cleanest.
> PHP Fatal error:  Cannot redeclare Debug() (previously declared in /usr/local/share/zoneminder/www/api/lib/Cake/basics.php:73) in /usr/local/share/zoneminder/www/includes/logger.php on line 508