### PR TITLE
Suppress debug messages on ZM service start/restart

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/General.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/General.pm
@@ -103,8 +103,10 @@ sub getCmdFormat {
   my $suffix = "";
   my $command = $prefix.$null_command.$suffix;
   Debug( "Testing \"$command\"\n" );
-  my $output = qx($command);
+  my $output = qx($command 2>&1);
   my $status = $? >> 8;
+  $output //= $!;
+  
   if ( !$status ) {
     Debug( "Test ok, using format \"$prefix<command>$suffix\"\n" );
     return( $prefix, $suffix );
@@ -116,8 +118,10 @@ sub getCmdFormat {
     $suffix = "'";
     $command = $prefix.$null_command.$suffix;
     Debug( "Testing \"$command\"\n" );
-    my $output = qx($command);
+    my $output = qx($command 2>&1);
     my $status = $? >> 8;
+    $output //= $!;
+    
     if ( !$status ) {
       Debug( "Test ok, using format \"$prefix<command>$suffix\"\n" );
       return( $prefix, $suffix );
@@ -129,8 +133,10 @@ sub getCmdFormat {
       $suffix = "'";
       $command = $prefix.$null_command.$suffix;
       Debug( "Testing \"$command\"\n" );
-      $output = qx($command);
+      $output = qx($command 2>&1);
       $status = $? >> 8;
+      $output //= $!;
+      
       if ( !$status ) {
         Debug( "Test ok, using format \"$prefix<command>$suffix\"\n" );
         return( $prefix, $suffix );


### PR DESCRIPTION
The tests that determine the format for superuser calls on the target environment  leak debug messages to STDOUT.  Starting the Zoneminder process will display an intimidating series of error messages that can safely be ignored by the user: 

e.g.
```
root@2bfdd23cc27a:~# service zoneminder start

Starting ZoneMinder: Can't exec "sudo": No such file or directory at /usr/share/perl5/ZoneMinder/General.pm line 1                                                   10.
Use of uninitialized value $output in scalar chomp at /usr/share/perl5/ZoneMinder/General.pm line 119.
Use of uninitialized value $output in concatenation (.) or string at /usr/share/perl5/ZoneMinder/General.pm line 1                                                   20.
success
```

This patch redirects STDERR from the qx(...) calls to the debug message., And if the output of qx(...) is undefined, replaces it with any error in $! resulting from the qx(...) call.