### PR TITLE
Support for hiding / showing advanced options in Options view

### DIFF
--- a/db/zm_update-1.30.3.sql
+++ b/db/zm_update-1.30.3.sql
@@ -1,0 +1,11 @@
+--
+-- This updates a 1.30.2 database to 1.30.3
+--
+-- Make changes to Config table
+--
+ALTER TABLE Config ADD COLUMN `Advanced` BOOL NOT NULL DEFAULT 0 AFTER `Requires`;
+UPDATE Config SET Advanced = '1' WHERE ID IN ( \
+19, 20, 32, 39, 40, 41, 89, \
+11, 12, 13,  87, 93, 94, 131, 132, 133, 134, 135, \
+136, 146, 147, 155 \
+);

--- a/web/skins/classic/css/classic/views/options.css
+++ b/web/skins/classic/css/classic/views/options.css
@@ -22,3 +22,6 @@ input.large {
     text-align: left;
 }
 
+.advanced {
+  display: none;
+}

--- a/web/skins/classic/views/js/options.js.php
+++ b/web/skins/classic/views/js/options.js.php
@@ -3,3 +3,22 @@ if ( restartWarning )
 {
     alert( "<?php echo translate('OptionRestartWarning') ?>" );
 }
+
+function toggleAdvanced() {
+    var rows = document.getElementsByClassName('advanced');
+    var text = document.querySelector('#btnToggleAdvanced');
+
+    if (text.value === 'Show Advanced') {
+      var r = Array.prototype.filter.call(rows, function(row) {
+        row.style.display = 'table-row';
+      });
+
+      text.value = 'Hide Advanced';
+    } else {
+      var r = Array.prototype.filter.call(rows, function(row) {
+        row.style.display = 'none';
+      });
+
+      text.value = 'Show Advanced';
+    }
+}

--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -57,6 +57,7 @@ xhtmlHeaders( __FILE__, translate('Options') );
   <div id="page">
     <div id="header">
       <h2><?php echo translate('Options') ?></h2>
+      <input id="btnToggleAdvanced" type="button" onclick="toggleAdvanced();" value="Show Advanced"></input>
     </div>
     <div id="content">
       <ul class="tabList">
@@ -267,7 +268,7 @@ elseif ( $tab == "users" )
         $shortName = preg_replace( '/^ZM_/', '', $name );
         $optionPromptText = !empty($OLANG[$shortName])?$OLANG[$shortName]['Prompt']:$value['Prompt'];
 ?>
-            <tr>
+            <tr <?php echo ($value['Advanced'] == 0) ? '' : 'class="advanced"'; ?>>
               <td><?php echo $shortName ?></td>
               <td><?php echo validHtmlStr($optionPromptText) ?>&nbsp;(<?php echo makePopupLink( '?view=optionhelp&amp;option='.$name, 'zmOptionHelp', 'optionhelp', '?' ) ?>)</td>
 <?php   


### PR DESCRIPTION
* Only a subset of the options have been set to advanced ('1').  Add more as needed.
* Toggled state does not survive tab changes.

I'll need someone to remind me the right way to submit DB changes in a PR.  I've included `db/zm_update-1.30.3.sql` for now.