### PR TITLE
move cake log to zoneminder log folder

### DIFF
--- a/web/api/app/Config/bootstrap.php.in
+++ b/web/api/app/Config/bootstrap.php.in
@@ -100,12 +100,16 @@ App::uses('CakeLog', 'Log');
 CakeLog::config('debug', array(
 	'engine' => 'File',
 	'types' => array('notice', 'info', 'debug'),
-	'file' => 'debug',
+	'file' => 'cake_debug',
 ));
 CakeLog::config('error', array(
 	'engine' => 'File',
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
-	'file' => 'error',
+	'file' => 'cake_error',
+));
+CakeLog::config('custom_path', array(
+    'engine' => 'File',
+    'path' => '@ZM_LOGDIR@'
 ));
 
 Configure::write('ZM_CONFIG',  '@ZM_CONFIG@');


### PR DESCRIPTION
This moves the cake log files out of cake's tmp folder and into the same location as the zoneminder log files.
Notice the log files have been renamed to cake_debug.log and cake_error.log. This gives us one less folder to worry about in the cake temp folder saga.