### PR TITLE
change cake cache engine from File -> Apc

### DIFF
--- a/web/api/app/Config/bootstrap.php.in
+++ b/web/api/app/Config/bootstrap.php.in
@@ -23,7 +23,7 @@
  */
 
 // Setup a 'default' cache configuration for use in the application.
-Cache::config('default', array('engine' => 'File'));
+Cache::config('default', array('engine' => 'Apc'));
 
 /**
  * The settings below can be used to set additional paths to models, views and controllers.

--- a/web/api/app/Config/core.php.default
+++ b/web/api/app/Config/core.php.default
@@ -352,7 +352,7 @@
  *       Please check the comments in bootstrap.php for more info on the cache engines available
  *       and their settings.
  */
-$engine = 'File';
+$engine = 'Apc';
 
 // In development mode, caches should expire quickly.
 $duration = '+999 days';


### PR DESCRIPTION
From discussion in #1841 
This PR changes the cake cache engine from File -> Apc.
The Apc cache engine uses shared memory, which gets us out of having to manage cake's cache folders ourselves.

This needs to be tested to verify the additional memory requirements, no new problems are created, etc.

@onlyjob 
@barjac 
@connortechnology 

If this PR is merged, it will require a new package dependency on php-apcu. Since the name of the package varies by distro, I have attempted to track down a few of them:
Fedora: php-pecl-apcu-bc
CentOS: php-pecl-apcu
Ubuntu (Debian?): php-apcu
