### PR TITLE
make cake tmp = zoneminder tmp

### DIFF
--- a/web/api/CMakeLists.txt
+++ b/web/api/CMakeLists.txt
@@ -11,5 +11,8 @@ configure_file(app/Config/database.php.default "${CMAKE_CURRENT_BINARY_DIR}/app/
 # Configure core.php
 configure_file(app/Config/core.php.default "${CMAKE_CURRENT_BINARY_DIR}/app/Config/core.php" @ONLY)
 
-# Configure bootstrap.php
+# Configure app/Config/bootstrap.php
 configure_file(app/Config/bootstrap.php.in "${CMAKE_CURRENT_BINARY_DIR}/app/Config/bootstrap.php" @ONLY)
+
+# Configure lib/Cake/bootstrap.php
+configure_file(lib/Cake/bootstrap.php.in "${CMAKE_CURRENT_BINARY_DIR}/lib/Cake//bootstrap.php" @ONLY)

--- a/web/api/lib/Cake/bootstrap.php.in
+++ b/web/api/lib/Cake/bootstrap.php.in
@@ -18,6 +18,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+// Force Cake's temp folder = ZoneMinder's temp folder
+define('TMP', '@ZM_TMPDIR@');
+
 define('TIME_START', microtime(true));
 
 if (!defined('E_DEPRECATED')) {


### PR DESCRIPTION
This pr forces Cake's temp folder to be the same folder as ZoneMinder's.
Unlike changing the log folder location, there is no Cake-friendly way to do this.

This pr makes symlinking the cake tmp folder obsolete. 
Any symlinking by packaging scripts should be removed if this pr is merged.