### PR TITLE
fixes escaping

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -832,12 +832,13 @@ function packageControl( $command ) {
 function daemonControl( $command, $daemon=false, $args=false ) {
   $string = ZM_PATH_BIN."/zmdc.pl $command";
   if ( $daemon ) {
-    $string .= escapeshellarg(" $daemon");
+    $string .= ' ' . $daemon;
     if ( $args ) {
-      $string .= escapeshellarg(" $args");
+      $string .= ' ' . $args;
     }
   }
-  $string .= " 2>/dev/null >&- <&- >/dev/null";
+  $string = escapeshellcmd( $string );
+  $string .= ' 2>/dev/null >&- <&- >/dev/null';
   exec( $string );
 }
 
@@ -944,10 +945,11 @@ function zmaStatus( $monitor ) {
 function daemonCheck( $daemon=false, $args=false ) {
   $string = ZM_PATH_BIN."/zmdc.pl check";
   if ( $daemon ) {
-    $string .= escapeshellarg(" $daemon");
+    $string .= ' ' . $daemon;
     if ( $args )
-      $string .= escapeshellarg(" $args");
+      $string .= ' '. $args;
   }
+  $string = escapeshellcmd( $string );
   $result = exec( $string );
   return( preg_match( '/running/', $result ) );
 }


### PR DESCRIPTION
escapeshellarg adds quotes, which is bad.  Use escapeshellcmd on the whole string instead.

fix #1849 