### PR TITLE
add a line to pick up the host to connect to for mysql

### DIFF
--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -67,6 +67,7 @@ class DATABASE_CONFIG {
 	public $default = array(
 		'datasource' => 'Database/Mysql',
 		'persistent' => false,
+    'host' => ZM_DB_HOST,
 		'login' => ZM_DB_USER,
 		'password' => ZM_DB_PASS,
 		'database' => ZM_DB_NAME,


### PR DESCRIPTION
The default database.php include doesn't have a line to pick up the DB_HOST setting. This works fine for a local db server.  However if a remote db server is used, api config won't work.  This should have no ill effects, and is well testing in my storageareas branch.