### PR TITLE
Use ctype_digit

### DIFF
--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -88,7 +88,7 @@ class DATABASE_CONFIG {
 	public function __construct() {
 		if (strpos(ZM_DB_HOST, ':')):
 			$array = explode(':', ZM_DB_HOST, 2);
-                        if (is_numeric($array[1])):
+                        if (ctype_digit($array[1])):
 				$this->default['host'] = $array[0];
 				$this->default['port'] = $array[1];
 			else:

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -33,7 +33,7 @@ function dbConnect()
 	if (strpos(ZM_DB_HOST, ':')) {
 		// Host variable may carry a port or socket.
 		list($host, $portOrSocket) = explode(':', ZM_DB_HOST, 2);
-			if (is_numeric($portOrSocket)) {
+			if (ctype_digit($portOrSocket)) {
 				$socket = ':host='.$host . ';port='.$portOrSocket;
 			} else {
 				$socket = ':unix_socket='.$portOrSocket;


### PR DESCRIPTION
I believe the Ctype extension is now a dependency of ZoneMinder.
If so, this use case could be done slightly more efficiently (faster/less overhead) with ctype_digit() than is_numeric().

If the Ctype extension is not a required dependency please close this Pull Request.
Thanks