### PR TITLE
make zmexport not rely on symlinks in the webroot

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -506,6 +506,20 @@ our @options = (
     category    => "paths",
   },
   {
+    name        => "ZM_DIR_EXPORTS",
+    default     => "@ZM_TMPDIR@",
+    description => "Directory where exported archives are stored",
+    help        => qqq("
+      This is the path to the exports directory where exported
+      tar.gz and zip archives are stored. By default this points to
+      ZoneMinder's temp folder, which often sits in ram. Since exported
+      archives can potentially become large, it is a good idea to move
+      this folder to some other location on machines with low memory.
+    "),
+    type        => $types{directory},
+    category    => "paths",
+  },
+  {
     name        => "ZM_PATH_ZMS",
     default     => "/cgi-bin/nph-zms",
     description => "Web path to zms streaming server",

--- a/web/includes/config.php.in
+++ b/web/includes/config.php.in
@@ -24,6 +24,7 @@
 define( "ZM_CONFIG", "@ZM_CONFIG@" );               // Path to config file
 // Define, and override any given in config file
 define( "ZM_VERSION", "@VERSION@" );               // Version
+define( "ZM_DIR_TEMP", "@ZM_TMPDIR@" );
 
 $configFile = ZM_CONFIG;
 $localConfigFile = basename($configFile);

--- a/web/skins/classic/includes/export_functions.php
+++ b/web/skins/classic/includes/export_functions.php
@@ -890,7 +890,7 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
 			{
 				$eids = array($eids);
 			}
-			$monitorPath = 'events/';
+			$monitorPath = ZM_DIR_EVENTS."/";
 			$html_eventMaster = 'zmEventImagesMaster_'.date('Ymd_His'). '.html';
 			if ( !($fp = fopen( $monitorPath."/".$html_eventMaster, "w" )) ) Fatal( "Can't open event images export file '$html_eventMaster'" );
 			fwrite( $fp, exportEventImagesMaster( $eids ) );
@@ -898,7 +898,7 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
 			$exportFileList[] = $monitorPath."/".$html_eventMaster;
 		}
 
-        $listFile = "temp/".$export_listFile;
+        $listFile = ZM_DIR_EXPORTS."/".$export_listFile;
         if ( !($fp = fopen( $listFile, "w" )) )
         {
             Fatal( "Can't open event export list file '$listFile'" );
@@ -911,7 +911,7 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
         $archive = "";
         if ( $exportFormat == "tar" )
         {
-            $archive = "temp/".$export_root.".tar.gz";
+            $archive = ZM_DIR_EXPORTS."/".$export_root.".tar.gz";
             @unlink( $archive );
             $command = "tar --create --gzip --file=$archive --files-from=$listFile";
             exec( escapeshellcmd( $command ), $output, $status );
@@ -925,8 +925,7 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
         }
         elseif ( $exportFormat == "zip" )
         {
-            $archive = "temp/zm_export.zip";
-            $archive = "temp/".$export_root.".zip";
+            $archive = ZM_DIR_EXPORTS."/".$export_root.".zip";
             @unlink( $archive );
             $command = "cat ".escapeshellarg($listFile)." | zip -q ".escapeshellarg($archive)." -@";
 //cat zmFileList.txt | zip -q zm_export.zip -@
@@ -948,7 +947,7 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
 		}
 
     }
-    return( $archive );
+    return( '?view=archive%26type='.$exportFormat );
 }
 function mygetEventPath( $event )
 {

--- a/web/views/archive.php
+++ b/web/views/archive.php
@@ -1,0 +1,62 @@
+<?php
+//
+// ZoneMinder file view file, $Date: 2008-09-29 14:15:13 +0100 (Mon, 29 Sep 2008) $, $Revision: 2640 $
+// Copyright (C) 2001-2008 Philip Coombes
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+
+if ( !canView( 'Events' ) )
+{
+    $view = "error";
+    return;
+}
+
+$archivetype = $_REQUEST['type'];
+
+if ( $archivetype ) {
+    switch ($archivetype) {
+        case "tar":
+            $mimetype = "gzip";
+            $file_ext = "tar.gz";
+            break;
+        case "zip":
+            $mimetype = "zip";
+            $file_ext = "zip";
+            break;
+        default:
+            $mimetype = NULL;
+            $file_ext = NULL;
+    }
+
+    if ( $mimetype ) {
+        $filename = "zmExport.$file_ext";
+        $filename_path = ZM_DIR_TEMP."/".$filename;
+        if ( is_readable($filename_path) ) {
+            header( "Content-type: application/$mimetype" );
+            header( "Content-Disposition: attachment; filename=$filename");
+            readfile( $filename_path );
+        } else {
+            Error("$filename_path does not exist or is not readable.");
+        }
+    } else {
+        Error("Unsupported archive type specified. Supported archives are tar and zip");
+    }
+} else {
+    Error("No archive type given to archive.php. Please specify a tar or zip archive.");
+}
+
+?>
+


### PR DESCRIPTION
Currently, zmexport requires symlinks under the webroot, pointing to the events folder and temp folder. This pr does away with that requirement.

This PR is a prerequisite before I can make ZoneMinder able to run w/o any symlinks under the web root.

This also resolves #1540 by creating ZM_DIR_EXPORTS to allow the end user to move the folder anywhere they want. It defaults to zoneminder's temp folder so backwards compatibility is maintained.