### PR TITLE
Share perl db functions

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -234,8 +234,8 @@ sub ZmDbUpdate {
   my @columns = keys %data;
   my @values = values %data;
 
-  my $sql = 'UPDATE '.$tablename.' SET '.join(', ', map { $_ . '=?' } @columns );
-  ' WHERE ' . join(' AND ', map { $_ . '=?' } keys %where );
+  my $sql = 'UPDATE '.$tablename.' SET '.join(', ', map { $_ . '=?' } @columns )
+  ' WHERE ' . join(' AND ', map { $_ . '=?'} keys %where );
 
     my $sth = $dbh->prepare_cached( $sql )
     or die( "Can't prepare '$sql': ".$dbh->errstr() );

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -224,11 +224,12 @@ sub ZmDbInsert {
 }
 
 # Can be passed either an array of name value pairs, or a hash
+# where must be a hash ref
 sub ZmDbUpdate {
   zmDbConnect();
   my $tablename = shift;
 
-  my %where = %{shift} if @_;
+  my %where = %{shift @_} if @_;
   my %data = ( @_ == 1 ? @{$_[0]} : @_ );
   my @columns = keys %data;
   my @values = values %data;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -234,8 +234,11 @@ sub ZmDbUpdate {
   my @columns = keys %data;
   my @values = values %data;
 
-  my $sql = 'UPDATE '.$tablename.' SET '.join(', ', map { $_ . '=?' } @columns )
-  ' WHERE ' . join(' AND ', map { $_ . '=?'} keys %where );
+  my $sql = join(' ',
+      'UPDATE',$tablename,
+      'SET'.join(', ', map { $_ . '=?' } @columns ),
+      'WHERE' , join(' AND ', map { $_ . '=?'} keys %where )
+      );
 
     my $sth = $dbh->prepare_cached( $sql )
     or die( "Can't prepare '$sql': ".$dbh->errstr() );

--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -160,7 +160,7 @@ sub checkExists {
 
   my $sql = "SELECT count(*) FROM $sqltable WHERE Name = ?";
   my $sth = $ZoneMinder::Database::dbh->prepare_cached( $sql )
-    or die( "Can't prepare '$sql': ".$dbh->errstr() );
+    or die( "Can't prepare '$sql': ".$ZoneMinder::Database::dbh->errstr() );
   my $res = $sth->execute($sqlname)
     or die( "Can't execute: ".$sth->errstr() );
 

--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -149,70 +149,6 @@ if ($topreset) {
 # SUBROUTINES #
 ###############
 
-# Execute a pre-built sql select query
-sub selectQuery {
-  my $dbh = shift;
-  my $sql = shift;
-  my $monitorid = shift;
-
-  my $sth = $dbh->prepare_cached( $sql )
-    or die( "Can't prepare '$sql': ".$dbh->errstr() );
-  my $res = $sth->execute($monitorid)
-    or die( "Can't execute: ".$sth->errstr() );
-
-  my @data = $sth->fetchrow_array();
-  $sth->finish();
-
-  return @data;
-}
-
-# Exectute a pre-built sql query
-sub runQuery {
-  my $dbh = shift;
-  my $sql = shift;
-  my $sth = $dbh->prepare_cached( $sql )
-    or die( "Can't prepare '$sql': ".$dbh->errstr() );
-  my $res = $sth->execute()
-    or die( "Can't execute: ".$sth->errstr() );
-  $sth->finish();
-
-  return $res;
-}
-
-# Build and execute a sql insert query
-sub insertQuery {
-  my $dbh = shift;
-  my $tablename = shift;
-  my @data = @_;
-
-  my $sql = "INSERT INTO $tablename VALUES (NULL,"
-    .(join ', ', ('?') x @data).')'; # Add "?" for each array element
-
-    my $sth = $dbh->prepare_cached( $sql )
-    or die( "Can't prepare '$sql': ".$dbh->errstr() );
-  my $res = $sth->execute(@data)
-    or die( "Can't execute: ".$sth->errstr() );
-  $sth->finish();
-
-  return $res;
-}
-
-# Build and execute a sql delete query
-sub deleteQuery {
-  my $dbh = shift;
-  my $sqltable = shift;
-  my $sqlname = shift;
-
-  my $sql = "DELETE FROM $sqltable WHERE Name = ?";
-  my $sth = $dbh->prepare_cached( $sql )
-    or die( "Can't prepare '$sql': ".$dbh->errstr() );
-  my $res = $sth->execute($sqlname)
-    or die( "Can't execute: ".$sth->errstr() );
-  $sth->finish();
-
-  return $res;
-}
-
 # Build and execute a sql select count query
 sub checkExists {
   my $dbh = shift;
@@ -278,13 +214,13 @@ sub importsql {
   foreach (keys %controls) {
     if (!checkExists($dbh,'Controls',$_)) {
 # No existing Control was found. Add new control to dB.
-      runQuery($dbh,$controls{$_});
+      zmDbQuery($controls{$_});
       push @newcontrols, $_;
     } elsif ($overwrite) {
 # An existing Control was found and the overwrite flag is set.
 # Overwrite the control.
-      deleteQuery($dbh,'Controls',$_);
-      runQuery($dbh,$controls{$_});
+      zmDbDelete('Controls', {Name=>$_} );
+      zmDbQuery($controls{$_});
       push @overwritecontrols, $_;
     } else {
 # An existing Control was found and the overwrite flag was not set.
@@ -296,13 +232,13 @@ sub importsql {
   foreach (keys %monitorpresets) {
     if (!checkExists($dbh,'MonitorPresets',$_)) {
 # No existing MonitorPreset was found.  Add new MonitorPreset to dB.
-      runQuery($dbh,$monitorpresets{$_});
+      zmDbQuery($monitorpresets{$_});
       push @newpresets, $_;
     } elsif ($overwrite) {
 # An existing MonitorPreset was found and the overwrite flag is set.
 # Overwrite the MonitorPreset.
-      deleteQuery($dbh,'MonitorPresets',$_);
-      runQuery($dbh,$monitorpresets{$_});
+      zmDbDelete('MonitorPresets', {Name=>$_} );
+      zmDbQuery($monitorpresets{$_});
       push @overwritepresets, $_;
     } else {
 # An existing MonitorPreset was found and the overwrite flag was
@@ -373,34 +309,34 @@ sub exportsql {
 }
 
 sub toPreset {
-  my $dbh = zmDbConnect();
   my $monitorid = $ARGV[0];
 
 # Grap the following fields from the Monitors table
-  my $sql = 'SELECT 
-    Name, 
-    Type, 
-    Device, 
-    Channel, 
-    Format, 
-    Protocol, 
-    Method, 
-    Host, 
-    Port, 
-    Path, 
-    SubPath, 
-    Width, 
-    Height, 
-    Palette, 
-    MaxFPS, 
-    Controllable, 
-    ControlId, 
-    ControlDevice, 
-    ControlAddress, 
-    DefaultRate, 
-    DefaultScale 
-      FROM Monitors WHERE Id = ?';
-  my @data = selectQuery($dbh,$sql,$monitorid);
+  my @columns = qw(
+    Name 
+    Type 
+    Device 
+    Channel 
+    Format 
+    Protocol 
+    Method 
+    Host 
+    Port 
+    Path 
+    SubPath 
+    Width 
+    Height 
+    Palette 
+    MaxFPS 
+    Controllable 
+    ControlId 
+    ControlDevice 
+    ControlAddress 
+    DefaultRate 
+    DefaultScale
+  );
+  my $sql = 'SELECT ' . join(',',@columns).' FROM Monitors WHERE Id = ?';
+  my @data = zmDbQuery($sql,$monitorid);
 
   if (!@data) {
     die( "Error: Monitor Id $monitorid does not appear to exist in the database.\n" );
@@ -421,20 +357,22 @@ sub toPreset {
     }
   }
 
-  if (!checkExists($dbh,"MonitorPresets",$data[0])) {
+  my %data = map { $_, shift @data } @columns;
+
+  if (!checkExists($dbh,'MonitorPresets',$data{Name})) {
 # No existing Preset was found.  Add new Preset to dB.
-    print "Adding new preset: $data[0]\n";
-    insertQuery($dbh,'MonitorPresets',@data);
+    print "Adding new preset: $data{Name}\n";
+    zmDbInsert('MonitorPresets',\%data);
   } elsif ($overwrite) {
 # An existing Control was found and the overwrite flag is set.
 # Overwrite the control.
     print "Existing preset $data[0] detected.\nOverwriting...\n";
-    deleteQuery($dbh,'MonitorPresets',$data[0]);
-    insertQuery($dbh,'MonitorPresets',@data);
+    zmDbDelete('MonitorPresets', { Name => $data{Name} });
+    zmDbInsert('MonitorPresets',\%data);
   } else {
 # An existing Control was found and the overwrite flag was not set.
 # Do nothing.
-    print "Existing preset $data[0] detected and overwrite flag not set.\nSkipping...\n";
+    print "Existing preset $data{Name} detected and overwrite flag not set.\nSkipping...\n";
   }
 }
 

--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -102,13 +102,16 @@ GetOptions(
     'version'       =>\$version
 ) or pod2usage(-exitstatus => -1);
 
-$Config{ZM_DB_USER} = $dbUser;
-$Config{ZM_DB_PASS} = $dbPass;
 
 if ( $version ) {
   print( ZoneMinder::Base::ZM_VERSION . "\n");
   exit(0);
 }
+
+$Config{ZM_DB_USER} = $dbUser;
+$Config{ZM_DB_PASS} = $dbPass;
+zmDbConnect( 1 ); # Force reconnect with new credentials
+
 # Check to make sure commandline params make sense
 if ( ((!$help) && ($import + $export + $topreset) != 1 )) {
   print( STDERR qq/Please give only one of the following: "import", "export", or "topreset".\n/ );
@@ -151,13 +154,12 @@ if ($topreset) {
 
 # Build and execute a sql select count query
 sub checkExists {
-  my $dbh = shift;
   my $sqltable = shift;
   my $sqlname = shift;
   my $result = 0; 
 
   my $sql = "SELECT count(*) FROM $sqltable WHERE Name = ?";
-  my $sth = $dbh->prepare_cached( $sql )
+  my $sth = $ZoneMinder::Database::dbh->prepare_cached( $sql )
     or die( "Can't prepare '$sql': ".$dbh->errstr() );
   my $res = $sth->execute($sqlname)
     or die( "Can't execute: ".$sth->errstr() );
@@ -210,9 +212,8 @@ sub importsql {
 # Now that we've got what we were looking for,
 # compare to what is already in the dB
 
-  my $dbh = zmDbConnect();
   foreach (keys %controls) {
-    if (!checkExists($dbh,'Controls',$_)) {
+    if (!checkExists('Controls',$_)) {
 # No existing Control was found. Add new control to dB.
       zmDbQuery($controls{$_});
       push @newcontrols, $_;
@@ -230,7 +231,7 @@ sub importsql {
   }
 
   foreach (keys %monitorpresets) {
-    if (!checkExists($dbh,'MonitorPresets',$_)) {
+    if (!checkExists('MonitorPresets',$_)) {
 # No existing MonitorPreset was found.  Add new MonitorPreset to dB.
       zmDbQuery($monitorpresets{$_});
       push @newpresets, $_;
@@ -359,7 +360,7 @@ sub toPreset {
 
   my %data = map { $_, shift @data } @columns;
 
-  if (!checkExists($dbh,'MonitorPresets',$data{Name})) {
+  if (!checkExists($ZoneMinder::Database::dbh,'MonitorPresets',$data{Name})) {
 # No existing Preset was found.  Add new Preset to dB.
     print "Adding new preset: $data{Name}\n";
     zmDbInsert('MonitorPresets',\%data);


### PR DESCRIPTION
Move some common functions into ZoneMinder::Database.pm so that we cut down on duplicated code.

There is lots more work to do here in terms of using these functions.