### PR TITLE
Fix FTBS on F27

### DIFF
--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -30,9 +30,9 @@
 
 #include <set>
 #include <vector>
+#include <sys/uio.h>
 
 #if defined(BSD)
-#include <sys/uio.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #endif


### PR DESCRIPTION
move include <sys/uio.h> outside defined(BSD) block

Tested not to negatively affect:
el6
el7
f25
f26
Ubuntu 17.04