### PR TITLE
change mode of opening log files to append instead of overwrite

### DIFF
--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -413,6 +413,7 @@ static void zm_log_fps(double d, const char *postfix) {
     Debug(1, "%1.0fk %s", d / 1000, postfix);
 }
 
+#if LIBAVCODEC_VERSION_CHECK(57, 0, 0, 0, 0)
 void zm_dump_codecpar ( const AVCodecParameters *par ) {
   Debug(1, "Dumping codecpar codec_type(%d) codec_id(%d) codec_tag(%d) width(%d) height(%d)", 
     par->codec_type,
@@ -422,6 +423,7 @@ void zm_dump_codecpar ( const AVCodecParameters *par ) {
     par->height
 ); 
 }
+#endif
 
 void zm_dump_codec ( const AVCodecContext *codec ) {
   Debug(1, "Dumping codecpar codec_type(%d) codec_id(%d) width(%d) height(%d)", 
@@ -431,7 +433,6 @@ void zm_dump_codec ( const AVCodecContext *codec ) {
     codec->height
 ); 
 }
-
 
 /* "user interface" functions */
 void zm_dump_stream_format(AVFormatContext *ic, int i, int index, int is_output) {

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -324,7 +324,9 @@ static av_always_inline av_const int64_t av_clip64_c(int64_t a, int64_t amin, in
 
 void zm_dump_stream_format(AVFormatContext *ic, int i, int index, int is_output);
 void zm_dump_codec ( const AVCodecContext *codec );
+#if LIBAVCODEC_VERSION_CHECK(57, 0, 0, 0, 0)
 void zm_dump_codecpar ( const AVCodecParameters *par );
+#endif
 
 #if LIBAVCODEC_VERSION_CHECK(56, 8, 0, 60, 100)
     #define zm_av_packet_unref( packet ) av_packet_unref( packet )


### PR DESCRIPTION
So if zmc or zma restarts for whatever reason, they overwrite their logs.  This is bad.

This PR changes the mode to append.