### PR TITLE
I believe level should be effectiveLevel here

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
@@ -375,8 +375,8 @@ sub level {
     $this->{effectiveLevel} = $this->{termLevel} if ( $this->{termLevel} > $this->{effectiveLevel} );
     $this->{effectiveLevel} = $this->{databaseLevel} if ( $this->{databaseLevel} > $this->{effectiveLevel} );
     $this->{effectiveLevel} = $this->{fileLevel} if ( $this->{fileLevel} > $this->{effectiveLevel} );
-    $this->{effectiveLevel} = $this->{syslogLevel} if ( $this->{syslogLevel} > $this->{level} );
-    $this->{effectiveLevel} = $this->{level} if ( $this->{effectiveLevel} > $this->{level} );
+    $this->{effectiveLevel} = $this->{syslogLevel} if ( $this->{syslogLevel} > $this->{effectiveLevel} );
+    $this->{effectiveLevel} = $this->{level} if ( $this->{effectiveLevel} > $this->{effectiveLevel} );
   }
   return( $this->{level} );
 }


### PR DESCRIPTION
effectiveLevel exists to provide a simple check whether we should be logging anything.  So it should be the lowest value of any of the output specific levels.  

The fix seems obvious, but maybe too obvious.  I don't see how this could have been bungled.