### PR TITLE
include conf.d folder contents in debian packaging

### DIFF
--- a/distros/debian/install
+++ b/distros/debian/install
@@ -6,3 +6,4 @@ usr/share/perl5/ZoneMinder.pm
 usr/share/zoneminder/db
 usr/share/zoneminder/www
 etc/zm
+etc/zm/conf.d/*

--- a/distros/ubuntu1204/zoneminder.install
+++ b/distros/ubuntu1204/zoneminder.install
@@ -1,4 +1,5 @@
 etc/zm/zm.conf
+etc/zm/conf.d/*
 usr/bin
 usr/lib/zoneminder
 usr/share/polkit-1

--- a/distros/ubuntu1504_cmake_split_packages/zoneminder-core.install
+++ b/distros/ubuntu1504_cmake_split_packages/zoneminder-core.install
@@ -1,4 +1,5 @@
 etc/zm
+etc/zm/conf.d/*
 usr/bin
 usr/share/polkit-1/actions
 usr/share/polkit-1/rules.d

--- a/distros/ubuntu1604/zoneminder.install
+++ b/distros/ubuntu1604/zoneminder.install
@@ -1,4 +1,5 @@
 etc/zm/zm.conf
+etc/zm/conf.d/*
 usr/bin
 usr/lib/zoneminder
 usr/share/polkit-1


### PR DESCRIPTION
Currently the contents of the conf.d folder are not being included in debian packages.
This fixes that, and is a necessary prerequisite for the next pr which will move additional config variables into this folder.