### PR TITLE
Strip non 7-bit ascii chars from log message

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -95,6 +95,7 @@ switch ( $_REQUEST['task'] )
         foreach ( dbFetchAll( $sql, NULL, $values ) as $log ) {
             $log['DateTime'] = preg_replace( '/^\d+/', strftime( "%Y-%m-%d %H:%M:%S", intval($log['TimeKey']) ), $log['TimeKey'] );
             $log['Server'] = ( $log['ServerId'] and isset($servers_by_Id[$log['ServerId']]) ) ? $servers_by_Id[$log['ServerId']]->Name() : '';
+            $log['Message'] = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $log['Message'] );
             $logs[] = $log;
         }
         $options = array();


### PR DESCRIPTION
Fix #1363

Some elements of our code can insert non-7-bit ascii chars into the logs.  When encoding/decoding these to/from json to view in the web ui the json decode dies.  

So we strip anything that is non 7-bit ascii out.  