### PR TITLE
fix path to logs for api

### DIFF
--- a/web/api/app/Config/bootstrap.php.in
+++ b/web/api/app/Config/bootstrap.php.in
@@ -101,15 +101,17 @@ CakeLog::config('debug', array(
 	'engine' => 'File',
 	'types' => array('notice', 'info', 'debug'),
 	'file' => 'cake_debug',
+    'path' => '@ZM_LOGDIR@/'
 ));
 CakeLog::config('error', array(
 	'engine' => 'File',
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'cake_error',
+    'path' => '@ZM_LOGDIR@/'
 ));
 CakeLog::config('custom_path', array(
     'engine' => 'File',
-    'path' => '@ZM_LOGDIR@'
+    'path' => '@ZM_LOGDIR@/'
 ));
 
 Configure::write('ZM_CONFIG',  '@ZM_CONFIG@');


### PR DESCRIPTION
Fixes the following warnings
 PHP Warning:  file_put_contents(/var/log/zmdebug.log) [<a href='http://php.net/function.file-put-contents'>function.file-put-contents</a>]: failed to open stream: Permission denied in /usr/share/zoneminder/www/api/lib/Cake/Log/Engine/FileLog.php on line 142
