### PR TITLE
Fix install location for config files when building to alternate directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,7 +801,8 @@ endif(ZM_PERL_SEARCH_PATH)
 
 # If this is an out-of-source build, copy the files we need to the binary directory
 if(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR))
-	file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/conf.d" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/conf.d" PATTERN "*.in" EXCLUDE)
+	file(GLOB ZM_CONFD_FILES "${CMAKE_CURRENT_SOURCE_DIR}/conf.d/*.conf")
+	file(COPY ${ZM_CONFD_FILES} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/conf.d")
 endif(NOT (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR))
 
 # Generate files from the .in files


### PR DESCRIPTION
With the previous code, we ended up with a directory structure like the following:

$ find /etc/zm/conf.d/
/etc/zm/conf.d/
/etc/zm/conf.d/01-system-paths.conf
/etc/zm/conf.d/conf.d
/etc/zm/conf.d/conf.d/README
/etc/zm/conf.d/conf.d/02-multiserver.conf