### PR TITLE
Added user-based quota support

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
@@ -321,21 +321,43 @@ sub Sql {
 } # end sub Sql
 
 sub getDiskPercent {
-  my $command = "df " . ($_[0] ? $_[0] : '.');
-  my $df = qx( $command );
+#RF Add quota support for user running filter - as functions.php
   my $space = -1;
-  if ( $df =~ /\s(\d+)%/ms ) {
-    $space = $1;
+  #get mountpoint
+  my $command = "stat -c %m " . ($_[0] ? $_[0] : '.');
+  my $df = qx( $command );
+    #untaint, ugly 
+  ($df) = ($df =~ /^(.*)$/gs);
+  $df = qx( quota -w -f $df );
+  if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms ) {
+    $space = int (100 * $1 / ($2 +1));
+  } else {
+    my $command = "df " . ($_[0] ? $_[0] : '.');
+    my $df = qx( $command );
+    if ( $df =~ /\s(\d+)%/ms ) {
+	  $space = $1;
+    }
   }
   return( $space );
 }
 
 sub getDiskBlocks {
+#RF Add quota support for user running filter - as functions.php
+  my $space = -1;
+  #get mountpoint
+  my $command = "stat -c %m .";
+  my $df = qx( $command );
+  #untaint, ugly 
+  ($df) = ($df =~ /^(.*)$/gs);
+  $df = qx( quota -w -f $df );
+  if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms ) {
+    $space = $1;
+  } else {
   my $command = "df .";
   my $df = qx( $command );
-  my $space = -1;
   if ( $df =~ /\s(\d+)\s+\d+\s+\d+%/ms ) {
-    $space = $1;
+      $space = $1;
+    }
   }
   return( $space );
 }

--- a/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
@@ -328,8 +328,8 @@ sub getDiskPercent {
   my $df = qx( $command );
     #untaint, ugly 
   ($df) = ($df =~ /^(.*)$/gs);
-  $df = qx( quota -w -f $df );
-  if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms ) {
+    $df = qx( quota -w -p -f $df );
+    if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?\s+(\d+)\s+(\d+)/ms ) {
     $space = int (100 * $1 / ($2 +1));
   } else {
     my $command = "df " . ($_[0] ? $_[0] : '.');
@@ -349,8 +349,8 @@ sub getDiskBlocks {
   my $df = qx( $command );
   #untaint, ugly 
   ($df) = ($df =~ /^(.*)$/gs);
-  $df = qx( quota -w -f $df );
-  if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms ) {
+    $df = qx( quota -w -p -f $df );
+    if ( $df =~ /\s+(\d+)\*?\s+(\d+)\*?\s+(\d+)\s+(\d+)/ms ) {
     $space = $1;
   } else {
   my $command = "df .";

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1480,27 +1480,41 @@ function getLoad() {
 }
 
 function getDiskPercent($path = ZM_DIR_EVENTS) {
-  $total = disk_total_space($path);
-  if ( $total === false ) {
-    Error('disk_total_space returned false. Verify the web account user has access to ' . $path );
-    return 0;
-  } elseif ( $total == 0 ) {
-    Error('disk_total_space indicates the following path has a filesystem size of zero bytes ' . $path );
-    return 100;
+  #RF Add quota support for user running the app
+  #get mountpoint
+  $df = shell_exec( 'stat -c %m '.$path );
+  $df = shell_exec( 'quota -w -f '.$df );
+  if ( preg_match( '/\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms', $df, $matches ) ) {
+    $space = round (100 * $matches[1] / ($matches[2]+1));
+  } else {
+    $total = disk_total_space($path);
+    if ( $total === false ) {
+      Error('disk_total_space returned false. Verify the web account user has access to ' . $path );
+      return 0;
+    }
+    $free = disk_free_space($path);
+    if ( $free === false ) {
+        Error('disk_free_space returned false. Verify the web account user has access to ' . $path );
+    }
+    $space = round((($total - $free) / $total) * 100);
   }
-  $free = disk_free_space($path);
-  if ( $free === false ) {
-    Error('disk_free_space returned false. Verify the web account user has access to ' . $path );
-  }
-  $space = round((($total - $free) / $total) * 100);
   return( $space );
 }
 
 function getDiskBlocks() {
-  $df = shell_exec( 'df '.escapeshellarg(ZM_DIR_EVENTS) );
+  #RF Add quota support for user running the app
   $space = -1;
-  if ( preg_match( '/\s(\d+)\s+\d+\s+\d+%/ms', $df, $matches ) )
+  #get mountpoint
+  $df = shell_exec( 'stat -c %m '.escapeshellarg(ZM_DIR_EVENTS));
+  $df = shell_exec( 'quota -w -f '.$df );
+  if ( preg_match( '/\s+(\d+)\*?\s+(\d+)\*?(\s+\d+){2}/ms', $df, $matches ) ) {
     $space = $matches[1];
+  } else {
+    $df = shell_exec( 'df '.escapeshellarg(ZM_DIR_EVENTS) );
+    if ( preg_match( '/\s(\d+)\s+\d+\s+\d+%/ms', $df, $matches ) ) {
+      $space = $matches[1];   
+    }
+  }
   return( $space );
 }
 


### PR DESCRIPTION
This branch adds simple user-based quota support so that the admin doesn't need to maintain a separate disk partition for ZM events to use filters effectively, or change disk partition sizes or use other methods of disk management as needs change.
The % disk used displayed on the GUI, and used by all the filters, respects a soft user quota if configured for the user running Zoneminder, (e.g. wwwrun in my case).  If no quota is configured, ZM maintains the original behaviour. The quota can be configured by a standard command line tool, or for example Webmin, and is picked up immediately.
User quotas are used on the basis that a) project quotas are only to be readable by root, only work with certain file systems like XFS and require additional configuration amongst other issues which add complexity, and b) Usually a non-root, non-regular user runs ZM, so setting a quota for that user for the partition storing events should rarely create unintended restrictions.  I've been using this code on a live system for a few months now.