### PR TITLE
allow changing of the timestamp char code delimeter

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -701,6 +701,25 @@ our @options = (
     category    => 'config',
   },
   {
+    name        => 'ZM_TIMESTAMP_CODE_CHAR',
+    default     => '%',
+    description => 'Character to used to identify timestamp codes',
+    help        => q`
+      There are a few codes one can use to tell ZoneMinder to insert
+      data into the timestamp of each image. Traditionally, the
+      percent (%) character has been used to identify these codes since
+      the current character codes do not conflict with the strftime
+      codes, which can also be used in the timestamp. While this works
+      well for Linux, this does not work well for BSD operating systems.
+      Changing the default character to something else, such as an
+      exclamation point (!), resolves the issue. Note this only affects
+      the timestamp codes built into ZoneMinder. It has no effect on
+      the family of strftime codes one can use.
+      `,
+    type        => $types{string},
+    category    => 'config',
+  },
+  {
     name        => 'ZM_CPU_EXTENSIONS',
     default     => 'yes',
     description => 'Use advanced CPU extensions to increase performance',

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -2941,7 +2941,7 @@ void Monitor::TimestampImage( Image *ts_image, const struct timeval *ts_time ) c
     const char *s_ptr = label_time_text;
     char *d_ptr = label_text;
     while ( *s_ptr && ((d_ptr-label_text) < (unsigned int)sizeof(label_text)) ) {
-      if ( *s_ptr == '%' ) {
+      if ( *s_ptr == config.timestamp_code_char[0] ) {
         bool found_macro = false;
         switch ( *(s_ptr+1) ) {
           case 'N' :


### PR DESCRIPTION
fixes #1865 

This PR allows one to change the timestamp code character, under Options -> Config, from the default "%" to anything the user wants. Note that it only affects ZoneMinder's builtin codes. This has no affect on the standard strftime codes.

As described in #1865, this is one way to address the issue of BSD operating systems handling the % character differently than their Linux counterpart.

I'm willing to hear alternative methods to fix this.

@schrorg  @abishai 
Please test this and provide feedback as I don't currently have any FreeBSD systems running zoneminder.