### PR TITLE
Add zip package to the docker image. Fix #1974

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update \
     php-mysql \
     vlc-data \
     yasm \
+    zip \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Copy local code into our container


### PR DESCRIPTION
Otherwise no export of a event as ZIP file is possible.