### PR TITLE
initial commit to change color of web console systemstats

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1517,20 +1517,20 @@ function systemStats() {
     if ( $normalized_load <= 0.75 ) {
         $htmlLoad=$load;
     } elseif ( $normalized_load <= 0.9 ) {
-        $htmlLoad="<span style=\"color:orange;\">$load</span>";
+        $htmlLoad="<span class=\"warning\">$load</span>";
     } elseif ( $normalized_load <= 1.1 ) {
-        $htmlLoad="<span style=\"color:red;\">$load</span>";
+        $htmlLoad="<span class=\"error\">$load</span>";
     } else {
-        $htmlLoad="<span style=\"color:red;text-decoration:blink;\">$load</span>";
+        $htmlLoad="<span class=\"critical\">$load</span>";
     }
 
     # Colorize the disk space stat
     if ( $diskPercent < 98 ) {
         $htmlDiskPercent="$diskPercent%";
     } elseif ( $diskPercent <= 99 ) {
-        $htmlDiskPercent="<span style=\"color:orange;\">$diskPercent%</span>";
+        $htmlDiskPercent="<span class=\"warning\">$diskPercent%</span>";
     } else {
-        $htmlDiskPercent="<span style=\"color:red;text-decoration:blink;\">$diskPercent%</span>";
+        $htmlDiskPercent="<span class=\"error\">$diskPercent%</span>";
     }
 
     # Colorize the PATH_MAP (usually /dev/shm) stat
@@ -1538,12 +1538,12 @@ function systemStats() {
         if ( disk_free_space(ZM_PATH_MAP) > 209715200 ) { # have to always have at least 200MiB free
             $htmlPathMapPercent="$pathMapPercent%";
         } else {
-            $htmlPathMapPercent="<span style=\"color:orange;\">$pathMapPercent%</span>";
+            $htmlPathMapPercent="<span class=\"warning\">$pathMapPercent%</span>";
         }
     } elseif ( $pathMapPercent < 100 ) {
-        $htmlPathMapPercent="<span style=\"color:orange;\">$pathMapPercent%</span>";
+        $htmlPathMapPercent="<span class=\"warning\">$pathMapPercent%</span>";
     } else {
-        $htmlPathMapPercent="<span style=\"color:red;text-decoration:blink;\">$pathMapPercent%</span>";
+        $htmlPathMapPercent="<span class=\"critical\">$pathMapPercent%</span>";
     }
 
     $htmlString = translate('Load').": $htmlLoad - ".translate('Disk').": $htmlDiskPercent - ".ZM_PATH_MAP.": $htmlPathMapPercent";

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1504,6 +1504,66 @@ function getDiskBlocks() {
   return( $space );
 }
 
+function systemStats() {
+
+    $load = getLoad();
+    $diskPercent = getDiskPercent();
+    $pathMapPercent = getDiskPercent(ZM_PATH_MAP);
+    $cpus = getcpus();
+
+    $normalized_load = $load / $cpus;
+
+    # Colorize the system load stat
+    if ( $normalized_load <= 0.75 ) {
+        $htmlLoad=$load;
+    } elseif ( $normalized_load <= 0.9 ) {
+        $htmlLoad="<span style=\"color:orange;\">$load</span>";
+    } elseif ( $normalized_load <= 1.1 ) {
+        $htmlLoad="<span style=\"color:red;\">$load</span>";
+    } else {
+        $htmlLoad="<span style=\"color:red;text-decoration:blink;\">$load</span>";
+    }
+
+    # Colorize the disk space stat
+    if ( $diskPercent < 98 ) {
+        $htmlDiskPercent="$diskPercent%";
+    } elseif ( $diskPercent <= 99 ) {
+        $htmlDiskPercent="<span style=\"color:orange;\">$diskPercent%</span>";
+    } else {
+        $htmlDiskPercent="<span style=\"color:red;text-decoration:blink;\">$diskPercent%</span>";
+    }
+
+    # Colorize the PATH_MAP (usually /dev/shm) stat
+    if ( $pathMapPercent < 90 ) {
+        if ( disk_free_space(ZM_PATH_MAP) > 209715200 ) { # have to always have at least 200MiB free
+            $htmlPathMapPercent="$pathMapPercent%";
+        } else {
+            $htmlPathMapPercent="<span style=\"color:orange;\">$pathMapPercent%</span>";
+        }
+    } elseif ( $pathMapPercent < 100 ) {
+        $htmlPathMapPercent="<span style=\"color:orange;\">$pathMapPercent%</span>";
+    } else {
+        $htmlPathMapPercent="<span style=\"color:red;text-decoration:blink;\">$pathMapPercent%</span>";
+    }
+
+    $htmlString = translate('Load').": $htmlLoad - ".translate('Disk').": $htmlDiskPercent - ".ZM_PATH_MAP.": $htmlPathMapPercent";
+
+    return( $htmlString );
+}
+
+function getcpus() {
+
+    if (is_readable("/proc/cpuinfo") ) { # Works on Linux
+        preg_match_all('/^processor/m', file_get_contents('/proc/cpuinfo'), $matches); 
+        $num_cpus = count($matches[0]);
+    } else { # Works on BSD
+        $matches = explode(":", shell_exec("sysctl hw.ncpu"));
+        $num_cpus = trim($matches[1]);
+    }
+
+    return( $num_cpus );
+}
+
 // Function to fix a problem whereby the built in PHP session handling 
 // features want to put the sid as a hidden field after the form or 
 // fieldset tag, neither of which will work with strict XHTML Basic.

--- a/web/skins/classic/css/classic/views/console.css
+++ b/web/skins/classic/css/classic/views/console.css
@@ -12,6 +12,19 @@
     float: right;
 }
 
+#systemStats .warning {
+    color: orange;
+}
+
+#systemStats .error {
+    color: red;
+}
+
+#systemStats .critical {
+    color: red;
+    text-decoration: blink;
+}
+
 #monitorSummary {
     float: left;
     text-align: left;

--- a/web/skins/classic/css/dark/views/console.css
+++ b/web/skins/classic/css/dark/views/console.css
@@ -12,6 +12,19 @@
     float: right;
 }
 
+#systemStats .warning {
+    color: orange;
+}
+
+#systemStats .error {
+    color: red;
+}
+
+#systemStats .critical {
+    color: red;
+    text-decoration: blink;
+}
+
 #monitorSummary {
     float: left;
     text-align: left;

--- a/web/skins/classic/css/flat/views/console.css
+++ b/web/skins/classic/css/flat/views/console.css
@@ -12,6 +12,19 @@
     float: right;
 }
 
+#systemStats .warning {
+    color: orange;
+}
+
+#systemStats .error {
+    color: red;
+}
+
+#systemStats .critical {
+    color: red;
+    text-decoration: blink;
+}
+
 #monitorSummary {
     float: left;
     text-align: left;

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -154,7 +154,7 @@ xhtmlHeaders( __FILE__, translate('Console') );
     <input type="hidden" name="action" value=""/>
     <div id="header">
       <h3 id="systemTime"><?php echo preg_match( '/%/', DATE_FMT_CONSOLE_LONG )?strftime( DATE_FMT_CONSOLE_LONG ):date( DATE_FMT_CONSOLE_LONG ) ?></h3>
-      <h3 id="systemStats"><?php echo translate('Load') ?>: <?php echo getLoad() ?> - <?php echo translate('Disk') ?>: <?php echo getDiskPercent() ?>% - <?php echo ZM_PATH_MAP ?>: <?php echo getDiskPercent(ZM_PATH_MAP) ?>%</h3>
+      <h3 id="systemStats"><?php echo systemStats() ?></h3>
       <h2 id="title">
         <a href="http://www.zoneminder.com" target="ZoneMinder">ZoneMinder</a> <?php echo translate('Console') ?> -
         <?php echo makePopupLink( '?view=state', 'zmState', 'state', $status, canEdit( 'System' ) ) ?> - 


### PR DESCRIPTION
This checks the three system stats on the web console: system load, disk space, and path_map (usually /dev/shm).

It checks each parameter against various thresholds and changes the color of the parameter from Normal -> Orange (yellow looked really bad) -> Red -> Blinking Red.

Initial testing was done with the classic skin. I used inline css to change the colors. This needs testing against the flat skin. If this does not look right with the flat skin then I will integrate the css into the skin files. Feedback is requested.

In addition to this, I am also considering using zmwatch or zmaudit to log periodic warnings to the zoneminder log should one of the parameters enter the red zone.