### PR TITLE
Fix user language setting never being used

### DIFF
--- a/web/includes/lang.php
+++ b/web/includes/lang.php
@@ -37,7 +37,7 @@ function loadLanguage( $prefix="" )
     $fallbackLangFile = $prefix.'lang/en_gb.php';
     $systemLangFile = $prefix.'lang/'.ZM_LANG_DEFAULT.'.php';
     if ( isset($user['Language']) )
-        $userLangFile = $prefix.$user['Language'].'.php';
+        $userLangFile = $prefix.'lang/'.$user['Language'].'.php';
 
     if ( isset($userLangFile) && file_exists( $userLangFile ) )
         return( $userLangFile );


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858675 pointed here
https://forums.zoneminder.com/viewtopic.php?t=19403
Checked and sure enough was still there not pointing to the lang folder.