### PR TITLE
fix generated video download

### DIFF
--- a/web/skins/classic/views/video.php
+++ b/web/skins/classic/views/video.php
@@ -101,6 +101,9 @@ if ( isset($_REQUEST['downloadIndex']) )
     header( "Content-Transfer-Encoding: binary" );
     header( "Content-Type: application/force-download" );
     header( "Content-Length: ".filesize($videoFiles[$downloadIndex]) ); 
+    while ( ob_get_level() > 0 ) {
+     ob_end_clean();
+    }
     readfile( $videoFiles[$downloadIndex] );
     exit;
 }


### PR DESCRIPTION
Fixes out of memory php error when downloading large generated video files.  Fixes #2001 