### PR TITLE
Fix delete filter

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -212,11 +212,9 @@ if ( !empty($action) ) {
         deleteEvent( $markEid );
         $refreshParent = true;
       }
-      if ( isset( $_REQUEST['object'] ) and ( $_REQUEST['object'] == 'filter' ) ) {
-        if ( !empty($_REQUEST['Id']) ) {
-          dbQuery( 'DELETE FROM Filters WHERE Id=?', array( $_REQUEST['Id'] ) );
-          //$refreshParent = true;
-        }
+      if ( !empty($_REQUEST['fid']) ) {
+        dbQuery( 'DELETE FROM Filters WHERE Name=?', array( $_REQUEST['fid'] ) );
+        //$refreshParent = true;
       }
     }
   }


### PR DESCRIPTION
Delete filter didn't work because the request does not include 'object' and the request sends fid instead of Id.  The object check appears to have been added accidentally in a cleanup merge.  Reverted to the old functionality.