### PR TITLE
Add h264 event view functionality and new feature alarmCues

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -367,7 +367,7 @@ function getNearEvents() {
   else
     $midSql = '';
 
-  $sql = "select E.Id as Id from Events as E inner join Monitors as M on E.MonitorId = M.Id where ".dbEscape($sortColumn)." ".($sortOrder=='asc'?'<=':'>=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." order by $sortColumn ".($sortOrder=='asc'?'desc':'asc');
+  $sql = "SELECT E.Id AS Id, E.StartTime AS StartTime FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE $sortColumn ".($sortOrder=='asc'?'<=':'>=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." ORDER BY $sortColumn ".($sortOrder=='asc'?'desc':'asc') . ' LIMIT 2';
   $result = dbQuery( $sql );
   while ( $id = dbFetchNext( $result, 'Id' ) ) {
     if ( $id == $eventId ) {
@@ -376,7 +376,7 @@ function getNearEvents() {
     }
   }
 
-  $sql = "select E.Id as Id from Events as E inner join Monitors as M on E.MonitorId = M.Id where $sortColumn ".($sortOrder=='asc'?'>=':'<=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." order by $sortColumn $sortOrder";
+  $sql = "SELECT E.Id AS Id, E.StartTime AS StartTime FROM Events AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE $sortColumn ".($sortOrder=='asc'?'>=':'<=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." ORDER BY $sortColumn $sortOrder LIMIT 2";
   $result = dbQuery( $sql );
   while ( $id = dbFetchNext( $result, 'Id' ) ) {
     if ( $id == $eventId ) {
@@ -388,8 +388,10 @@ function getNearEvents() {
   $result = array( 'EventId'=>$eventId );
   $result['PrevEventId'] = empty($prevEvent)?0:$prevEvent['Id'];
   $result['NextEventId'] = empty($nextEvent)?0:$nextEvent['Id'];
-  $result['PrevEventDefVideoPath'] = empty($prevEvent)?0:(getEventDefaultVideoPath($prevEvent));
-  $result['NextEventDefVideoPath'] = empty($nextEvent)?0:(getEventDefaultVideoPath($nextEvent));
+  $result['PrevEventStartTime'] = empty($prevEvent)?0:$prevEvent['StartTime'];
+  $result['NextEventStartTime'] = empty($nextEvent)?0:$nextEvent['StartTime'];
+  $result['PrevEventDefVideoPath'] = empty($prevEvent)?0:(getEventDefaultVideoPath($prevEvent['Id']));
+  $result['NextEventDefVideoPath'] = empty($nextEvent)?0:(getEventDefaultVideoPath($nextEvent['Id']));
   return( $result );
 }
 

--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -136,6 +136,17 @@ $statusData = array(
                   //"Path" => array( "postFunc" => "getEventPath" ),
                   ),
                   ),
+                  "frames" => array(
+                      "permission" => "Events",
+                      "table" => "Frames",
+                      "selector" => "EventId",
+                      "elements" => array(
+                        "EventId" => true,
+                        "FrameId" => true,
+                        "Type" => true,
+                        "Delta" => true,
+                        ),
+                      ),
                   "frame" => array(
                       "permission" => "Events",
                       "table" => "Frames",

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -993,7 +993,7 @@ function zmaCheck( $monitor ) {
 }
 
 function getImageSrc( $event, $frame, $scale=SCALE_BASE, $captureOnly=false, $overwrite=false ) {
-  $eventPath = getEventPath( $event );
+  $eventPath = ZM_DIR_EVENTS . '/' . getEventPath( $event );
 
   if ( !is_array($frame) )
     $frame = array( 'FrameId'=>$frame, 'Type'=>'' );

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -452,7 +452,8 @@ function getEventPath( $event ) {
 }
 
 function getEventDefaultVideoPath( $event ) {
-	return ZM_DIR_EVENTS . '/' . getEventPath($event) . '/' . $event['DefaultVideo'];
+  $Event = new Event( $event );
+  return $Event->getStreamSrc( array( "mode"=>"mpeg", "format"=>"h264" ) );
 }
 
 function deletePath( $path ) {

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2306,6 +2306,7 @@ function getStreamMode( ) {
     $streamMode = 'single';
     Info( 'The system has fallen back to single jpeg mode for streaming. Consider enabling Cambozola or upgrading the client browser.' );
   }
+  return $streamMode;
 } // end function getStreamMode
 
 function folder_size($dir) {

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -1,3 +1,15 @@
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
+    color: white;
+    background-color: black;
+    display: inline-block;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -37,6 +37,7 @@ span.noneCue {
 
 #dataBar #dataTable {
     width: 100%;
+    table-layout: fixed;
 }
 
 #dataBar #dataTable td {

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -10,6 +10,25 @@
     display: inline-block;
 }
 
+.alarmCue {
+    background-color: #222222;
+    height: 1.25em;
+    text-align: left;
+    margin: 0 auto 0 auto;
+    border-radius: 0 0 .3em .3em;
+}
+
+.alarmCue span {
+    background-color:red;
+    height: 100%;
+    display: inline-block;
+    border-radius: 0;
+}
+
+span.noneCue {
+    background: none;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;
@@ -101,6 +120,7 @@
 
 #imageFeed {
     display: inline-block;
+    position: relative;
     text-align: center;
 }
 

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -198,20 +198,16 @@ span.noneCue {
 }
 
 #eventStills {
-    width: 100%;
     position: relative;
 }
 
 #eventThumbsPanel {
     position: relative;
-    width: 100%;
-    margin: 4px auto;
     z-index: 1;
 }
 
 #eventThumbs {
     margin: 0 auto;
-    width: 100%;
     overflow: hidden;
     height: 300px;
 }
@@ -231,13 +227,17 @@ span.noneCue {
 
 #eventImagePanel {
     position: absolute;
+    top: 0;
+    left: 0;
     z-index: 10;
+    width: 100%;
 }
 
 #eventImageFrame {
     border: 2px solid gray;
     background-color: white;
     padding: 4px;
+    display: inline-block;
 }
 
 #eventImage {
@@ -245,6 +245,14 @@ span.noneCue {
 
 #eventImageBar {
     margin-top: 2px;
+}
+
+#eventImageBar::after {
+  visibility: hidden;
+  display: block;
+  content: "";
+  clear: both;
+  height: 0;
 }
 
 #eventImageStats {
@@ -262,6 +270,7 @@ span.noneCue {
 
 #eventImageNav {
     position: relative;
+    margin: 4px 0 0 0;
 }
 
 #eventImageNav input {

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -192,6 +192,7 @@ span.noneCue {
 }
 
 #progressBar .progressBox {
+    transition: width .1s;
     height: 100%;
     background: rgba(170, 170, 170, .7);
     border-radius: 0 0 .3em .3em;

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -227,6 +227,7 @@ span.noneCue {
 }
 
 #eventImagePanel {
+    display: none;
     position: absolute;
     top: 0;
     left: 0;
@@ -271,7 +272,7 @@ span.noneCue {
 
 #eventImageNav {
     position: relative;
-    margin: 4px 0 0 0;
+    margin: 0 0 4px 0;
 }
 
 #eventImageNav input {
@@ -280,20 +281,20 @@ span.noneCue {
 }
 
 #thumbsSliderPanel {
-    width: 400px;
-    margin: 4px auto 0;
-    background: #888888;
-    padding: 1px;
+    width: 80%;
+    margin: 0px auto 4px auto;
 }
 
 #thumbsSlider {
-    width: 400px;
-    height: 10px;
-    background: #dddddd;
+    width: 100%;
+    height: 1.25em;
+    position: relative;
+    top: -1.25em;
+    margin: 0 0 -1.25em 0;
 }
 
 #thumbsKnob {
-    width: 8px;
-    height: 10px;
-    background-color: #444444;
+    width: 1em;
+    height: 100%;
+    background-color: #999999;
 }

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -25,6 +25,11 @@
     padding: 2px;
 }
 
+#eventVideo {
+   display: inline-block;
+   position: relative;
+}
+
 #menuBar1 {
     width: 100%;
     padding: 3px 0;
@@ -95,6 +100,7 @@
 }
 
 #imageFeed {
+    display: inline-block;
     text-align: center;
 }
 
@@ -159,22 +165,15 @@
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.25em;
+    height: 1.25em;
+    margin: 0 auto -1.25em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 100%;
+    background: rgba(170, 170, 170, .7);
+    border-radius: 0 0 .3em .3em;
 }
 
 #eventStills {

--- a/web/skins/classic/css/classic/views/frame.css
+++ b/web/skins/classic/css/classic/views/frame.css
@@ -1,33 +1,16 @@
 #scaleControl {
   float: right;
 }
+
 #controls {
     width: 80%;
     text-align: center;
     margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
 }
 
 #controls a {
     width: 40px;
     margin-left: -20px;
-}
-
-#firstLink {
-    position: absolute;
-    left: 13%;
-}
-
-#prevLink {
-    position: absolute;
-    left: 37%;
-}
-
-#nextLink {
-    position: absolute;
-    left: 63%;
-}
-
-#lastLink {
-    position: absolute;
-    left: 87%;
 }

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -1,3 +1,15 @@
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
+    color: white;
+    background-color: black;
+    display: inline-block;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -10,6 +10,11 @@
     display: inline-block;
 }
 
+#eventVideo {
+    display: inline-block;
+    position: relative;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;
@@ -78,6 +83,7 @@
 }
 
 #imageFeed {
+    display: inline-block;
     text-align: center;
 }
 
@@ -142,22 +148,15 @@
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.25em;
+    height: 1.25em;
+    margin: 0 auto -1.25em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 100%;
+    background: rgba(170, 170, 170, .7);
+    border-radius: 0 0 .3em .3em;
 }
 
 #eventStills {

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -10,6 +10,25 @@
     display: inline-block;
 }
 
+.alarmCue {
+    background-color: #222222;
+    height: 1.25em;
+    text-align: left;
+    margin: 0 auto 0 auto;
+    border-radius: 0 0 .3em .3em;
+}
+
+.alarmCue span {
+    background-color:red;
+    height: 100%;
+    display: inline-block;
+    border-radius: 0;
+}
+
+span.noneCue {
+    background: none;
+}
+
 #eventVideo {
     display: inline-block;
     position: relative;
@@ -84,6 +103,7 @@
 
 #imageFeed {
     display: inline-block;
+    position: relative;
     text-align: center;
 }
 

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -181,20 +181,17 @@ span.noneCue {
 }
 
 #eventStills {
-    width: 100%;
     position: relative;
 }
 
 #eventThumbsPanel {
     position: relative;
-    width: 100%;
     margin: 4px auto;
     z-index: 1;
 }
 
 #eventThumbs {
     margin: 0 auto;
-    width: 100%;
     overflow: hidden;
     height: 300px;
 }
@@ -214,13 +211,17 @@ span.noneCue {
 
 #eventImagePanel {
     position: absolute;
+    top: 0;
+    left: 0;
     z-index: 10;
+    width: 100%;
 }
 
 #eventImageFrame {
     border: 2px solid gray;
     background-color: white;
     padding: 4px;
+    display: inline-block;
 }
 
 #eventImage {
@@ -228,6 +229,14 @@ span.noneCue {
 
 #eventImageBar {
     margin-top: 2px;
+}
+
+#eventImageBar::after {
+  visibility: hidden;
+  display: block;
+  content: "";
+  clear: both;
+  height: 0;
 }
 
 #eventImageStats {
@@ -245,6 +254,7 @@ span.noneCue {
 
 #eventImageNav {
     position: relative;
+    margin: 4px 0 0 0;
 }
 
 #eventImageNav input {

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -42,6 +42,7 @@ span.noneCue {
 
 #dataBar #dataTable {
     width: 100%;
+    table-layout: fixed;
 }
 
 #dataBar #dataTable td {

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -211,6 +211,7 @@ span.noneCue {
 }
 
 #eventImagePanel {
+    display: none;
     position: absolute;
     top: 0;
     left: 0;
@@ -255,7 +256,7 @@ span.noneCue {
 
 #eventImageNav {
     position: relative;
-    margin: 4px 0 0 0;
+    margin: 0 0 4px 0;
 }
 
 #eventImageNav input {
@@ -265,19 +266,25 @@ span.noneCue {
 
 #thumbsSliderPanel {
     width: 400px;
-    margin: 4px auto 0;
-    background: #888888;
-    padding: 1px;
+    width: 80%;
+    margin: 0px auto 4px auto;
 }
 
 #thumbsSlider {
-    width: 400px;
-    height: 10px;
-    background: #dddddd;
+    width: 100%;
+    height: 1.25em;
+    position: relative;
+    top: -1.25em;
+    margin: 0 0 -1.25em 0;
+}
+
+#eventVideo {
+    display: inline-block;
+    position: relative;
 }
 
 #thumbsKnob {
-    width: 8px;
-    height: 10px;
-    background-color: #444444;
+    width: 1em;
+    height: 100%;
+    background-color: #999999;
 }

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -175,6 +175,7 @@ span.noneCue {
 }
 
 #progressBar .progressBox {
+    transition: width .1s;
     height: 100%;
     background: rgba(170, 170, 170, .7);
     border-radius: 0 0 .3em .3em;

--- a/web/skins/classic/css/dark/views/frame.css
+++ b/web/skins/classic/css/dark/views/frame.css
@@ -1,33 +1,16 @@
 #scaleControl {
   float: right;
 }
+
 #controls {
     width: 80%;
     text-align: center;
     margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
 }
 
 #controls a {
     width: 40px;
     margin-left: -20px;
-}
-
-#firstLink {
-    position: absolute;
-    left: 13%;
-}
-
-#prevLink {
-    position: absolute;
-    left: 37%;
-}
-
-#nextLink {
-    position: absolute;
-    left: 63%;
-}
-
-#lastLink {
-    position: absolute;
-    left: 87%;
 }

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -1,3 +1,15 @@
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
+    color: white;
+    background-color: black;
+    display: inline-block;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -176,6 +176,7 @@ span.noneCue {
 }
 
 #progressBar .progressBox {
+    transition: width .1s;
     height: 100%;
     background: rgba(170, 170, 170, .7);
     border-radius: 0 0 .3em .3em;

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -37,6 +37,7 @@ span.noneCue {
 
 #dataBar #dataTable {
     width: 100%;
+    table-layout: fixed;
 }
 
 #dataBar #dataTable td {

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -212,6 +212,7 @@ span.noneCue {
 }
 
 #eventImagePanel {
+    display: none;
     position: absolute;
     top: 0;
     left: 0;
@@ -256,7 +257,7 @@ span.noneCue {
 
 #eventImageNav {
     position: relative;
-    margin: 4px 0 0 0;
+    margin: 0 0 4px 0;
 }
 
 #eventImageNav input {
@@ -265,22 +266,22 @@ span.noneCue {
 }
 
 #thumbsSliderPanel {
-    width: 400px;
-    margin: 4px auto 0;
-    background: #888888;
-    padding: 1px;
+    width: 80%;
+    margin: 0px auto 4px auto;
 }
 
 #thumbsSlider {
-    width: 400px;
-    height: 10px;
-    background: #dddddd;
+    width: 100%;
+    height: 1.25em;
+    position: relative;
+    top: -1.25em;
+    margin: 0 0 -1.25em 0;
 }
 
 #thumbsKnob {
-    width: 8px;
-    height: 10px;
-    background-color: #444444;
+    width: 1em;
+    height: 100%;
+    background-color: #999999;
 }
 #eventVideo {
     display: inline-block;

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -182,20 +182,17 @@ span.noneCue {
 }
 
 #eventStills {
-    width: 100%;
     position: relative;
 }
 
 #eventThumbsPanel {
     position: relative;
-    width: 100%;
-    margin: 4px auto;
+    margin: 0;
     z-index: 1;
 }
 
 #eventThumbs {
     margin: 0 auto;
-    width: 100%;
     overflow: hidden;
     height: 300px;
 }
@@ -215,13 +212,17 @@ span.noneCue {
 
 #eventImagePanel {
     position: absolute;
+    top: 0;
+    left: 0;
     z-index: 10;
+    width: 100%;
 }
 
 #eventImageFrame {
     border: 2px solid gray;
     background-color: white;
     padding: 4px;
+    display: inline-block;
 }
 
 #eventImage {
@@ -244,8 +245,17 @@ span.noneCue {
     float: right;
 }
 
+#eventImageBar::after {
+  visibility: hidden;
+  display: block;
+  content: "";
+  clear: both;
+  height: 0;
+}
+
 #eventImageNav {
     position: relative;
+    margin: 4px 0 0 0;
 }
 
 #eventImageNav input {
@@ -301,10 +311,6 @@ span.noneCue {
 		color-stop(0.13, rgb(3,113,168)),
 		color-stop(1, rgb(0,136,204))
 	);
-}
-
-#eventVideo:hover #video-controls {
-	opacity: .9;
 }
 
 button {

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -10,6 +10,25 @@
     display: inline-block;
 }
 
+.alarmCue {
+    background-color: #222222;
+    height: 1.25em;
+    text-align: left;
+    margin: 0 auto 0 auto;
+    border-radius: 0 0 .3em .3em;
+}
+
+.alarmCue span {
+    background-color:red;
+    height: 100%;
+    display: inline-block;
+    border-radius: 0;
+}
+
+span.noneCue {
+    background: none;
+}
+
 #dataBar {
     width: 100%;
     margin: 2px auto;
@@ -79,6 +98,7 @@
 
 #imageFeed {
     display: inline-block;
+    position: relative;
     text-align: center;
 }
 

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -76,7 +76,9 @@
     clear: both;
     visibility: hidden;
 }
+
 #imageFeed {
+    display: inline-block;
     text-align: center;
 }
 
@@ -147,22 +149,15 @@
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.25em;
+    height: 1.25em;
+    margin: 0 auto -1.25em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 100%;
+    background: rgba(170, 170, 170, .7);
+    border-radius: 0 0 .3em .3em;
 }
 
 #eventStills {
@@ -256,6 +251,7 @@
     background-color: #444444;
 }
 #eventVideo {
+    display: inline-block;
     position: relative;
 }
 

--- a/web/skins/classic/css/flat/views/frame.css
+++ b/web/skins/classic/css/flat/views/frame.css
@@ -6,29 +6,11 @@
     width: 80%;
     text-align: center;
     margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
 }
 
 #controls a {
     width: 40px;
     margin-left: -20px;
-}
-
-#firstLink {
-    position: absolute;
-    left: 13%;
-}
-
-#prevLink {
-    position: absolute;
-    left: 37%;
-}
-
-#nextLink {
-    position: absolute;
-    left: 63%;
-}
-
-#lastLink {
-    position: absolute;
-    left: 87%;
 }

--- a/web/skins/classic/includes/config.php
+++ b/web/skins/classic/includes/config.php
@@ -31,6 +31,7 @@ $rates = array(
 );
 
 $scales = array(
+    "auto" => translate("Scale to Fit"),
     "400" => "4x",
     "300" => "3x",
     "200" => "2x",
@@ -42,6 +43,8 @@ $scales = array(
     "25" => "1/4x",
     "12.5" => "1/8x",
 );
+
+if (isset($_REQUEST['view']) && !($_REQUEST['view'] == 'event')) unset($scales['auto']); //Remove auto if we aren't using event view
 
 $bwArray = array(
     "high" => translate('High'),

--- a/web/skins/classic/includes/config.php
+++ b/web/skins/classic/includes/config.php
@@ -44,7 +44,7 @@ $scales = array(
     "12.5" => "1/8x",
 );
 
-if (isset($_REQUEST['view']) && !($_REQUEST['view'] == 'event')) unset($scales['auto']); //Remove auto if we aren't using event view
+if (isset($_REQUEST['view']) && ($_REQUEST['view'] == 'montage')) unset($scales['auto']); //Remove auto if we aren't using event view
 
 $bwArray = array(
     "high" => translate('High'),

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -92,6 +92,7 @@ var $j = jQuery.noConflict();
 <?php } else if ( $title == 'Event' ) {
 ?>
   <link href="skins/<?php echo $skin ?>/js/video-js.css" rel="stylesheet">
+  <link href="skins/<?php echo $skin ?>/js/video-js-skin.css" rel="stylesheet">
   <script src="skins/<?php echo $skin ?>/js/video.js"></script>
   <script src="./js/videojs.zoomrotate.js"></script>
   <script src="skins/<?php echo $skin ?>/js/moment.min.js"></script>

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -283,3 +283,36 @@ function addVideoTimingTrack(video, LabelFormat, monitorName, duration, startTim
 	track.src = 'data:plain/text;charset=utf-8,'+encodeURIComponent(webvttdata);
 	video.appendChild(track);
 }
+
+var resizeTimer;
+
+function endOfResize(e) {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(changeScale, 250);
+}
+
+function scaleToFit (baseWidth, baseHeight, scaleEl, bottomEl) {
+  $j(window).on('resize', endOfResize)  //set delayed scaling when Scale to Fit is selected
+  let ratio = baseWidth / baseHeight;
+  let container = $j('#content');
+  let viewPort = $j(window);
+// jquery does not provide a bottom offet, and offset dows not include margins.  outerHeight true minus false gives total vertical margins.
+  let bottomLoc = bottomEl.offset().top + (bottomEl.outerHeight(true) - bottomEl.outerHeight()) + bottomEl.outerHeight(true);
+  let newHeight = viewPort.height() - (bottomLoc - scaleEl.outerHeight(true))
+  let newWidth = ratio * newHeight;
+  if (newWidth > container.innerWidth()) {
+    newWidth = container.innerWidth();
+    newHeight = newWidth / ratio;
+  }
+  let autoScale = Math.round(newWidth / baseWidth * SCALE_BASE);
+  let scales = $j('#scale option').map(function() {return parseInt($j(this).val());}).get();
+  scales.shift();
+  let closest;
+  $j(scales).each(function () { //Set zms scale to nearest regular scale.  Zoom does not like arbitrary scale values.
+    if (closest == null || Math.abs(this - autoScale) < Math.abs(closest - autoScale)) {
+      closest = this.valueOf();
+    }
+  });
+  autoScale = closest;
+  return {width: Math.floor(newWidth), height: Math.floor(newHeight), autoScale: autoScale};
+}

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -262,6 +262,17 @@ function convertLabelFormat(LabelFormat, monitorName){
 }
 
 function addVideoTimingTrack(video, LabelFormat, monitorName, duration, startTime){
+//This is a hacky way to handle changing the texttrack. If we ever upgrade vjs in a revamp replace this.  Old method preserved because it's the right way.
+  let cues = vid.textTracks()[0].cues();
+  let labelFormat = convertLabelFormat(LabelFormat, monitorName);
+  startTime = moment(startTime);
+
+  for (let i = 0; i <= duration; i++) {
+    cues[i] = {id: i, index: i, startTime: i, Ca: i+1, text: startTime.format(labelFormat)};
+    startTime.add(1, 's');
+  }
+}
+/*
 	var labelFormat = convertLabelFormat(LabelFormat, monitorName);
 	var webvttformat = 'HH:mm:ss.SSS', webvttdata="WEBVTT\n\n";
 
@@ -283,6 +294,7 @@ function addVideoTimingTrack(video, LabelFormat, monitorName, duration, startTim
 	track.src = 'data:plain/text;charset=utf-8,'+encodeURIComponent(webvttdata);
 	video.appendChild(track);
 }
+*/
 
 var resizeTimer;
 

--- a/web/skins/classic/js/skin.js.php
+++ b/web/skins/classic/js/skin.js.php
@@ -39,4 +39,4 @@ var refreshParent = <?php echo !empty($refreshParent)?'true':'false' ?>;
 
 var focusWindow = <?php echo !empty($focusWindow)?'true':'false' ?>;
 
-var imagePrefix = "<?php echo viewImagePath( "", '&' ) ?>";
+var imagePrefix = "<?php echo "?view=image&eid=" ?>";

--- a/web/skins/classic/js/video-js-skin.css
+++ b/web/skins/classic/js/video-js-skin.css
@@ -1,5 +1,6 @@
 .vjs-tech {
   pointer-events: none;
+  transition: transform .25s;
 }
 
 .vjs-captions-button {

--- a/web/skins/classic/js/video-js-skin.css
+++ b/web/skins/classic/js/video-js-skin.css
@@ -1,0 +1,64 @@
+.vjs-tech {
+  pointer-events: none;
+}
+
+.vjs-captions-button {
+  display: none;
+}
+
+.vjs-tt-cue {
+  margin-bottom: .75em;
+}
+
+.vjs-menu {
+  z-index: 5;
+}
+
+.vjs-default-skin .vjs-playback-rate.vjs-menu-button .vjs-menu .vjs-menu-content {
+  width: 5em;
+}
+
+.vjs-default-skin.vjs-user-inactive:hover .vjs-progress-control {
+  font-size: .3em;
+}
+
+.vjs-default-skin.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+  visibility: visible;
+  opacity: 1;
+  bottom: -2em;
+  -webkit-transition: all .2s;
+  -moz-transition: all .2s;
+  -o-transition: all .2s;
+  transition: all .2s
+}
+
+.vjs-default-skin.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control,
+.vjs-default-skin.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-time-divider {
+  display: none;
+}
+
+.vjs-default-skin .vjs-progress-holder .vjs-play-progress, .vjs-default-skin .vjs-progress-holder .vjs-load-progress {
+  height: 1em;
+}
+
+.vjs-progress-holder.vjs-slider {
+  background-color: transparent;
+  z-index: 1;
+}
+
+.vjs-progress-control.vjs-control {
+  background-color: rgba(7, 20, 30, 0.8);
+  height: 1.3em;
+  top: -1.3em;
+  display: block !important;
+}
+
+.vjs-control div.alarmCue {
+  position: relative;
+  top: -1.3em;
+  background: none;
+}
+
+.vjs-control .alarmCue {
+  height: 1.3em;
+}

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -125,24 +125,25 @@ if ( canEdit( 'Events' ) ) {
 ?>
         <div id="deleteEvent"><a href="#" onclick="deleteEvent()"><?php echo translate('Delete') ?></a></div>
         <div id="editEvent"><a href="#" onclick="editEvent()"><?php echo translate('Edit') ?></a></div>
-<?php 
-} // end if can edit Events
-  if ( $Event->DefaultVideo() ) { ?>
-<div id="downloadEventFile"><a href="<?php echo $Event->getStreamSrc()?>">Download MP4</a></div>
         <div id="archiveEvent"<?php echo $Event->Archived == 1 ? ' class="hidden"' : ''  ?>><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
         <div id="unarchiveEvent"<?php echo $Event->Archived == 0 ? ' class="hidden"' : '' ?>><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
 <?php
-  } // end if Event->DefaultVideo
+} // end if can edit Events
 ?>
         <div id="framesEvent"><a href="#" onclick="showEventFrames()"><?php echo translate('Frames') ?></a></div>
+        <div id="streamEvent" class="hidden"><a href="#" onclick="showStream()"><?php echo translate('Stream') ?></a></div>
+        <div id="stillsEvent"><a href="#" onclick="showStills()"><?php echo translate('Stills') ?></a></div>
 <?php
-if ( $Event->SaveJPEGs() & 3 ) { // Analysis or Jpegs
+  if ( $Event->DefaultVideo() ) { 
 ?>
-        <div id="stillsEvent"<?php if ( $streamMode == 'still' ) { ?> class="hidden"<?php } ?>><a href="#" onclick="showStills()"><?php echo translate('Stills') ?></a></div>
+        <div id="downloadEventFile"><a href="<?php echo $Event->getStreamSrc(array('mode'=>'mp4'))?>" download>Download MP4</a></div>
 <?php
-} // has frames or analysis
+  } else {
 ?>
         <div id="videoEvent"><a href="#" onclick="videoEvent();"><?php echo translate('Video') ?></a></div>
+<?php
+  } // end if Event->DefaultVideo
+?>
         <div id="exportEvent"><a href="#" onclick="exportEvent();"><?php echo translate('Export') ?></a></div>
       </div>
       <div id="eventVideo" class="">
@@ -197,9 +198,6 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
           <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
           <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
         </div>
-<?php 
-  if ($Event->SaveJPEGs() & 3) { // frames or analysis
-?>
       </div><!--eventVideo-->
       <div id="eventStills" class="hidden">
         <div id="eventThumbsPanel">
@@ -236,7 +234,6 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
         </div>
       </div>
 <?php
-  } // end if SaveJPEGs() & 3 Analysis or Jpegs
 } // end if Event exists
 ?>
     </div><!--content-->

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -43,6 +43,8 @@ else
 
 if ( isset( $_REQUEST['scale'] ) ) {
   $scale = validInt($_REQUEST['scale']);
+} else if ( isset( $_COOKIE['zmEventScaleAuto'] ) ) { //If we're using scale to fit use it on all monitors
+  $scale = 'auto';
 } else if ( isset( $_COOKIE['zmEventScale'.$Event->MonitorId()] ) ) {
   $scale = $_COOKIE['zmEventScale'.$Event->MonitorId()];
 } else {

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -150,20 +150,11 @@ if ( $Event->SaveJPEGs() & 3 ) { // Analysis or Jpegs
 if ( $Event->DefaultVideo() ) {
 ?>
         <div id="videoFeed">
-          <video id="videoobj" class="video-js vjs-default-skin" width="<?php echo reScale( $Event->Width(), $scale ) ?>" height="<?php echo reScale( $Event->Height(), $scale ) ?>" data-setup='{ "controls": true, "playbackRates": [0.5, 1, 1.5, 2, 4, 8, 16, 32, 64, 128, 256], "autoplay": true, "preload": "auto", "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'>
+          <video id="videoobj" class="video-js vjs-default-skin" style="transform: matrix(1, 0, 0, 1, 0, 0)" width="<?php echo reScale( $Event->Width(), $scale ) ?>" height="<?php echo reScale( $Event->Height(), $scale ) ?>" data-setup='{ "controls": true, "autoplay": true, "preload": "auto", "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'>
           <source src="<?php echo $Event->getStreamSrc( array( 'mode'=>'mpeg','format'=>'h264' ) ); ?>" type="video/mp4">
           <track id="monitorCaption" kind="captions" label="English" srclang="en" src='data:plain/text;charset=utf-8,"WEBVTT\n\n 00:00:00.000 --> 00:00:01.000 ZoneMinder"' default>
           Your browser does not support the video tag.
           </video>
-        </div>
-        <!--script>includeVideoJs();</script-->
-        <script>
-        var LabelFormat = "<?php echo validJsStr($Monitor->LabelFormat())?>";
-        var monitorName = "<?php echo validJsStr($Monitor->Name())?>";
-        var duration = <?php echo $Event->Length() ?>, startTime = '<?php echo $Event->StartTime() ?>';
-
-        addVideoTimingTrack(document.getElementById('videoobj'), LabelFormat, monitorName, duration, startTime);
-        </script>
         </div><!--videoFeed-->
 <?php
 }  // end if DefaultVideo

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -215,6 +215,13 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
           </div>
         </div>
         <div id="eventImageNav">
+          <div id="thumbsSliderPanel">
+            <div id="alarmCue" class="alarmCue"></div>
+            <div id="thumbsSlider">
+              <div id="thumbsKnob">
+              </div>
+            </div>
+          </div>
           <div id="eventImageButtons">
             <div id="prevButtonsPanel">
               <input id="prevEventBtn" type="button" value="&lt;E" onclick="prevEvent()" disabled="disabled"/>
@@ -223,12 +230,6 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
               <input id="nextImageBtn" type="button" value="&gt;" onclick="nextImage()" disabled="disabled"/>
               <input id="nextThumbsBtn" type="button" value="&gt;&gt;" onclick="nextThumbs()" disabled="disabled"/>
               <input id="nextEventBtn" type="button" value="E&gt;" onclick="nextEvent()" disabled="disabled"/>
-            </div>
-          </div>
-          <div id="thumbsSliderPanel">
-            <div id="thumbsSlider">
-              <div id="thumbsKnob">
-              </div>
             </div>
           </div>
         </div>

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -126,12 +126,12 @@ if ( canEdit( 'Events' ) ) {
 ?>
         <div id="deleteEvent"><a href="#" onclick="deleteEvent()"><?php echo translate('Delete') ?></a></div>
         <div id="editEvent"><a href="#" onclick="editEvent()"><?php echo translate('Edit') ?></a></div>
-        <div id="archiveEvent" class="hidden"><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
-        <div id="unarchiveEvent" class="hidden"><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
 <?php 
 } // end if can edit Events
   if ( $Event->DefaultVideo() ) { ?>
 <div id="downloadEventFile"><a href="<?php echo $Event->getStreamSrc()?>">Download MP4</a></div>
+        <div id="archiveEvent"<?php echo $Event->Archived == 1 ? ' class="hidden"' : ''  ?>><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
+        <div id="unarchiveEvent"<?php echo $Event->Archived == 0 ? ' class="hidden"' : '' ?>><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
 <?php
   } // end if Event->DefaultVideo
 ?>
@@ -184,26 +184,26 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
         </div>
         <p id="dvrControls">
           <input type="button" value="&lt;+" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" onclick="streamPrev( true );"/>
-          <input type="button" value="&lt;&lt;" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" disabled="disabled" onclick="streamFastRev( true );"/>
+          <input type="button" value="&lt;&lt;" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" onclick="streamFastRev( true );"/>
           <input type="button" value="&lt;" id="slowRevBtn" title="<?php echo translate('StepBack') ?>" class="unavail" disabled="disabled" onclick="streamSlowRev( true );"/>
           <input type="button" value="||" id="pauseBtn" title="<?php echo translate('Pause') ?>" class="inactive" onclick="pauseClicked();"/>
           <input type="button" value="|>" id="playBtn" title="<?php echo translate('Play') ?>" class="active" disabled="disabled" onclick="playClicked();"/>
           <input type="button" value="&gt;" id="slowFwdBtn" title="<?php echo translate('StepForward') ?>" class="unavail" disabled="disabled" onclick="streamSlowFwd( true );"/>
-          <input type="button" value="&gt;&gt;" id="fastFwdBtn" title="<?php echo translate('FastForward') ?>" class="inactive" disabled="disabled" onclick="streamFastFwd( true );"/>
-          <input type="button" value="&ndash;" id="zoomOutBtn" title="<?php echo translate('ZoomOut') ?>" class="avail" onclick="streamZoomOut();"/>
+          <input type="button" value="&gt;&gt;" id="fastFwdBtn" title="<?php echo translate('FastForward') ?>" class="inactive" onclick="streamFastFwd( true );"/>
+          <input type="button" value="&ndash;" id="zoomOutBtn" title="<?php echo translate('ZoomOut') ?>" class="unavail" disabled="disabled" onclick="streamZoomOut();"/>
           <input type="button" value="+&gt;" id="nextBtn" title="<?php echo translate('Next') ?>" class="inactive" onclick="streamNext( true );"/>
         </p>
         <div id="replayStatus">
-          <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">&nbsp;</span></span>
-          <span id="rate"><?php echo translate('Rate') ?>: <span id="rateValue"></span>x</span>
-          <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue"></span>s</span>
-          <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue"></span>x</span>
+          <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">Replay</span></span>
         </div>
         <div id="progressBar" class="invisible">
 <?php for ( $i = 0; $i < $panelSections; $i++ ) { ?>
            <div class="progressBox" id="progressBox<?php echo $i ?>" title=""></div>
 <?php } ?>
     </div>
+          <span id="rate"><?php echo translate('Rate') ?>: <span id="rateValue"><?php echo $rate/100 ?></span>x</span>
+          <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
+          <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
         </div>
       </div>
 <?php 

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -161,10 +161,12 @@ if ( $Event->DefaultVideo() ) {
 
         addVideoTimingTrack(document.getElementById('videoobj'), LabelFormat, monitorName, duration, startTime);
         </script>
+        </div><!--videoFeed-->
 <?php
 }  // end if DefaultVideo
 ?>
-        <div id="imageFeed" <?php if ( $Event->DefaultVideo() ) { ?>class="hidden"<?php } ?> >
+<?php if (!$Event->DefaultVideo()) { ?>
+      <div id="imageFeed">
 <?php
 if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   $streamSrc = $Event->getStreamSrc( array( 'mode'=>'mpeg', 'scale'=>$scale, 'rate'=>$rate, 'bitrate'=>ZM_WEB_VIDEO_BITRATE, 'maxfps'=>ZM_WEB_VIDEO_MAXFPS, 'format'=>ZM_MPEG_REPLAY_FORMAT, 'replay'=>$replayMode ) );
@@ -182,6 +184,7 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
           <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
         </div><!--progressBar-->
       </div><!--imageFeed-->
+<?php } /*end if !DefaultVideo*/ ?>
         <p id="dvrControls">
           <input type="button" value="&lt;+" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" onclick="streamPrev( true );"/>
           <input type="button" value="&lt;&lt;" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" onclick="streamFastRev( true );"/>
@@ -195,7 +198,6 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
         </p>
         <div id="replayStatus">
           <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">Replay</span></span>
-    </div>
           <span id="rate"><?php echo translate('Rate') ?>: <span id="rateValue"><?php echo $rate/100 ?></span>x</span>
           <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
           <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
@@ -203,7 +205,7 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
 <?php 
   if ($Event->SaveJPEGs() & 3) { // frames or analysis
 ?>
-    </div><!--eventVideo-->
+      </div><!--eventVideo-->
       <div id="eventStills" class="hidden">
         <div id="eventThumbsPanel">
           <div id="eventThumbs">
@@ -242,6 +244,7 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   } // end if SaveJPEGs() & 3 Analysis or Jpegs
 } // end if Event exists
 ?>
+    </div><!--content-->
   </div><!--page-->
 </body>
 </html>

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -152,6 +152,7 @@ if ( $Event->DefaultVideo() ) {
         <div id="videoFeed">
           <video id="videoobj" class="video-js vjs-default-skin" width="<?php echo reScale( $Event->Width(), $scale ) ?>" height="<?php echo reScale( $Event->Height(), $scale ) ?>" data-setup='{ "controls": true, "playbackRates": [0.5, 1, 1.5, 2, 4, 8, 16, 32, 64, 128, 256], "autoplay": true, "preload": "auto", "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'>
           <source src="<?php echo $Event->getStreamSrc( array( 'mode'=>'mpeg','format'=>'h264' ) ); ?>" type="video/mp4">
+          <track id="monitorCaption" kind="captions" label="English" srclang="en" src='data:plain/text;charset=utf-8,"WEBVTT\n\n 00:00:00.000 --> 00:00:01.000 ZoneMinder"' default>
           Your browser does not support the video tag.
           </video>
         </div>

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -61,6 +61,7 @@ if ( isset( $_REQUEST['streamMode'] ) )
 else
   $streamMode = 'video';
 
+$replayMode = '';
 if ( isset( $_REQUEST['replayMode'] ) )
   $replayMode = validHtmlStr($_REQUEST['replayMode']);
 if ( isset( $_COOKIE['replayMode']) && preg_match('#^[a-z]+$#', $_COOKIE['replayMode']) )

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -182,6 +182,7 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   }
 } // end if stream method
 ?>
+        <div id="alarmCue" class="alarmCue"></div>
         <div id="progressBar" style="width: <?php echo reScale($Event->Width(), $scale);?>px;">
           <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
         </div><!--progressBar-->

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -85,10 +85,6 @@ parseSort();
 parseFilter( $_REQUEST['filter'] );
 $filterQuery = $_REQUEST['filter']['query'];
 
-$panelSections = 40;
-$panelSectionWidth = (int)ceil(reScale($Event->Width(),$scale)/$panelSections);
-$panelWidth = ($panelSections*$panelSectionWidth-1);
-
 $connkey = generateConnKey();
 
 $focusWindow = true;
@@ -182,7 +178,10 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   }
 } // end if stream method
 ?>
-        </div>
+        <div id="progressBar" style="width: <?php echo reScale($Event->Width(), $scale);?>px;">
+          <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
+        </div><!--progressBar-->
+      </div><!--imageFeed-->
         <p id="dvrControls">
           <input type="button" value="&lt;+" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" onclick="streamPrev( true );"/>
           <input type="button" value="&lt;&lt;" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" onclick="streamFastRev( true );"/>
@@ -196,20 +195,15 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
         </p>
         <div id="replayStatus">
           <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">Replay</span></span>
-        </div>
-        <div id="progressBar" class="invisible">
-<?php for ( $i = 0; $i < $panelSections; $i++ ) { ?>
-           <div class="progressBox" id="progressBox<?php echo $i ?>" title=""></div>
-<?php } ?>
     </div>
           <span id="rate"><?php echo translate('Rate') ?>: <span id="rateValue"><?php echo $rate/100 ?></span>x</span>
           <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
           <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
         </div>
-      </div>
 <?php 
   if ($Event->SaveJPEGs() & 3) { // frames or analysis
 ?>
+    </div><!--eventVideo-->
       <div id="eventStills" class="hidden">
         <div id="eventThumbsPanel">
           <div id="eventThumbs">

--- a/web/skins/classic/views/frame.php
+++ b/web/skins/classic/views/frame.php
@@ -51,7 +51,7 @@ $lastFid = $maxFid;
 $alarmFrame = $Frame->Type()=='Alarm';
 
 if ( isset( $_REQUEST['scale'] ) ) {
-  $scale = validInt($_REQUEST['scale']);
+  $scale = $_REQUEST['scale'];
 } else if ( isset( $_COOKIE['zmWatchScale'.$Monitor->Id()] ) ) {
   $scale = $_COOKIE['zmWatchScale'.$Monitor->Id()];
 } else if ( isset( $_COOKIE['zmWatchScale'] ) ) {

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -245,6 +245,8 @@ function eventQuery( eventId ) {
 
 var prevEventId = 0;
 var nextEventId = 0;
+var prevEventStartTime = 0;
+var nextEventStartTime = 0;
 var PrevEventDefVideoPath = "";
 var NextEventDefVideoPath = "";
 
@@ -253,6 +255,8 @@ function getNearEventsResponse( respObj, respText ) {
     return;
   prevEventId = respObj.nearevents.PrevEventId;
   nextEventId = respObj.nearevents.NextEventId;
+  prevEventStartTime = Date.parse(respObj.nearevents.PrevEventStartTime);
+  nextEventStartTime = Date.parse(respObj.nearevents.NextEventStartTime);
   PrevEventDefVideoPath = respObj.nearevents.PrevEventDefVideoPath;
   NextEventDefVideoPath = respObj.nearevents.NextEventDefVideoPath;
 

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -124,7 +124,11 @@ function renderAlarmCues (containerEl) {
 function setButtonState( element, butClass ) {
   if ( element ) {
     element.className = butClass;
-    element.disabled = (butClass != 'inactive');
+    if (butClass == 'unavail' || (butClass == 'active' && (element.id == 'pauseBtn' || element.id == 'playBtn'))) {
+      element.disabled = true;
+    } else {
+      element.disabled = false;
+    }
   } else {
     console.log("Element was null in setButtonState");
   }
@@ -198,19 +202,15 @@ function getCmdResponse( respObj, respText ) {
     initialAlarmCues(eventId);
     lastEventId = eventId;
   }
+  if (lastEventId == 0) lastEventId = eventId; //Only fires on first load.
   if ( streamStatus.paused == true ) {
-    $('modeValue').set( 'text', 'Paused' );
-    $('rate').addClass( 'hidden' );
     streamPause( );
   } else {
-    $('modeValue').set( 'text', "Replay" );
-    $('rateValue').set( 'text', streamStatus.rate );
-    $('rate').removeClass( 'hidden' );
+    $j('#rateValue').html(streamStatus.rate);
     streamPlay( );
-  if (lastEventId == 0) lastEventId = eventId; //Only fires on first load.
   }
-  $('progressValue').set( 'text', secsToTime( parseInt(streamStatus.progress) ) );
-  $('zoomValue').set( 'text', streamStatus.zoom );
+  $j('#progressValue').html(secsToTime(parseInt(streamStatus.progress)));
+  $j('#zoomValue').html(streamStatus.zoom);
   if ( streamStatus.zoom == "1.0" )
     setButtonState( $('zoomOutBtn'), 'unavail' );
   else
@@ -225,17 +225,29 @@ function getCmdResponse( respObj, respText ) {
       streamImg.src = streamImg.src.replace( /auth=\w+/i, 'auth='+streamStatus.auth );
   } // end if haev a new auth hash
 
-  streamCmdTimer = streamQuery.delay( streamTimeout );
+  streamCmdTimer = streamQuery.delay( streamTimeout ); //Timeout is refresh rate for progressBox and time display
 }
 
 var streamReq = new Request.JSON( { url: thisUrl, method: 'get', timeout: AJAX_TIMEOUT, link: 'chain', onSuccess: getCmdResponse } );
 
-function pauseClicked( ) {
-  streamReq.send( streamParms+"&command="+CMD_PAUSE );
+function pauseClicked() {
+  if (vid) {
+    vid.pause();
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_PAUSE );
+    streamPause();
+  }
+}
+
+function vjsPause () {
+  stopFastRev();
+  streamPause();
 }
 
 // Called when stream becomes paused, just updates the button status
 function streamPause( ) {
+  $j('#modeValue').html('Paused');
+  $j('#rateValue').html('0');
   setButtonState( $('pauseBtn'), 'active' );
   setButtonState( $('playBtn'), 'inactive' );
   setButtonState( $('fastFwdBtn'), 'unavail' );
@@ -245,13 +257,28 @@ function streamPause( ) {
 }
 
 function playClicked( ) {
-  streamReq.send( streamParms+"&command="+CMD_PLAY );
+  if (vid) {
+    if (vid.paused()) {
+      vid.play();
+    } else {
+      vjsPlay(); //handles fast forward and rewind
+    }
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_PLAY );
+    streamPlay();
+  }
+}
+
+function vjsPlay () { //catches if we change mode programatically
+  stopFastRev();
+  $j('#rateValue').html(vid.playbackRate());
+  streamPlay();
 }
 
 function streamPlay( ) {
+  $j('#modeValue').html('Replay');
   setButtonState( $('pauseBtn'), 'inactive' );
-  if (streamStatus)
-    setButtonState( $('playBtn'), streamStatus.rate==1?'active':'inactive' );
+  setButtonState( $('playBtn'), 'active' );
   setButtonState( $('fastFwdBtn'), 'inactive' );
   setButtonState( $('slowFwdBtn'), 'unavail' );
   setButtonState( $('slowRevBtn'), 'unavail' );
@@ -261,35 +288,44 @@ function streamPlay( ) {
 function streamFastFwd( action ) {
   setButtonState( $('pauseBtn'), 'inactive' );
   setButtonState( $('playBtn'), 'inactive' );
-  setButtonState( $('fastFwdBtn'), 'inactive' );
+  setButtonState( $('fastFwdBtn'), 'active' );
   setButtonState( $('slowFwdBtn'), 'unavail' );
   setButtonState( $('slowRevBtn'), 'unavail' );
   setButtonState( $('fastRevBtn'), 'inactive' );
-  streamReq.send( streamParms+"&command="+CMD_FASTFWD );
+  if (vid) {
+    if (revSpeed != .5) stopFastRev();
+    vid.playbackRate(rates[rates.indexOf(vid.playbackRate()*100)-1]/100);
+    if (rates.indexOf(vid.playbackRate()*100)-1 == -1) setButtonState($('fastFwdBtn'), 'unavail');
+    $j('#rateValue').html(vid.playbackRate());
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_FASTFWD );
+  }
 }
 
+var spf = Math.round((eventData.Length / eventData.Frames)*1000000 )/1000000;//Seconds per frame for videojs frame by frame.
+var intervalRewind;
+var revSpeed = .5;
+
 function streamSlowFwd( action ) {
-  setButtonState( $('pauseBtn'), 'inactive' );
-  setButtonState( $('playBtn'), 'inactive' );
-  setButtonState( $('fastFwdBtn'), 'unavail' );
-  setButtonState( $('slowFwdBtn'), 'active' );
-  setButtonState( $('slowRevBtn'), 'inactive' );
-  setButtonState( $('fastRevBtn'), 'unavail' );
-  streamReq.send( streamParms+"&command="+CMD_SLOWFWD );
-  setButtonState( $('pauseBtn'), 'inactive' );
-  setButtonState( $('slowFwdBtn'), 'inactive' );
+  if (vid) {
+   vid.currentTime(vid.currentTime() + spf);
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_SLOWFWD );
+  }
 }
 
 function streamSlowRev( action ) {
-  setButtonState( $('pauseBtn'), 'inactive' );
-  setButtonState( $('playBtn'), 'inactive' );
-  setButtonState( $('fastFwdBtn'), 'unavail' );
-  setButtonState( $('slowFwdBtn'), 'inactive' );
-  setButtonState( $('slowRevBtn'), 'active' );
-  setButtonState( $('fastRevBtn'), 'unavail' );
-  streamReq.send( streamParms+"&command="+CMD_SLOWREV );
-  setButtonState( $('pauseBtn'), 'inactive' );
-  setButtonState( $('slowRevBtn'), 'inactive' );
+  if (vid) {
+    vid.currentTime(vid.currentTime() - spf);
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_SLOWREV );
+  }
+}
+
+function stopFastRev () {
+  clearInterval(intervalRewind);
+  vid.playbackRate(1);
+  revSpeed = .5;
 }
 
 function streamFastRev( action ) {
@@ -298,8 +334,26 @@ function streamFastRev( action ) {
   setButtonState( $('fastFwdBtn'), 'inactive' );
   setButtonState( $('slowFwdBtn'), 'unavail' );
   setButtonState( $('slowRevBtn'), 'unavail' );
-  setButtonState( $('fastRevBtn'), 'inactive' );
-  streamReq.send( streamParms+"&command="+CMD_FASTREV );
+  setButtonState( $('fastRevBtn'), 'active' );
+  if (vid) { //There is no reverse play with mp4.  Set the speed to 0 and manualy set the time back.
+    revSpeed = rates[rates.indexOf(revSpeed*100)-1]/100;
+    if (rates.indexOf(revSpeed*100) == 0) {
+      setButtonState( $('fastRevBtn'), 'unavail' );
+    }
+    clearInterval(intervalRewind);
+    $j('#rateValue').html(-revSpeed);
+    intervalRewind = setInterval(function() {
+      if (vid.currentTime() <= 0) {
+        clearInterval(intervalRewind);
+        vid.pause();
+      } else {
+        vid.playbackRate(0);
+        vid.currentTime(vid.currentTime() - (revSpeed/2)); //Half of reverse speed because our interval is 500ms.
+      }
+    }, 500); //500ms is a compromise between smooth reverse and realistic performance
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_FASTREV );
+  }
 }
 
 function streamPrev(action) {
@@ -340,14 +394,61 @@ function streamNext(action) {
   }
 }
 
+function vjsPanZoom (action, x, y) { //Pan and zoom with centering where the click occurs
+  let outer = $j('#videoobj');
+  let video = outer.children().first();
+  let zoom =  parseFloat($j('#zoomValue').html());
+  let zoomRate = .5;
+  let matrix = video.css('transform').split(',');
+  let currentPanX = parseFloat(matrix[4]);
+  let currentPanY = parseFloat(matrix[5]);
+  let xDist = outer.width()/2 - x //Click distance from center of view
+  let yDist = outer.height()/2 - y
+  if (action == 'zoomOut') {
+    zoom -= zoomRate;
+    if (x && y) {
+      x = (xDist + currentPanX)*((zoom-zoomRate)/zoom); // if ctrl-click Pan but use ratio of old zoom to new zoom for coords
+      y = (yDist + currentPanY)*((zoom-zoomRate)/zoom);
+    } else {
+      x = currentPanX*((zoom-zoomRate)/zoom); //Leave zoom centered where it was
+      y = currentPanY*((zoom-zoomRate)/zoom);
+    }
+    if (zoom <= 1) {
+      zoom = 1;
+      $j('#zoomOutBtn').attr('class', 'unavail').attr('disabled', 'disabled');
+    }
+    $j('#zoomValue').html(zoom);
+  } else if (action == 'zoom') {
+    zoom += zoomRate;
+    x = (xDist + currentPanX)*(zoom/(zoom-zoomRate)); //Pan but use ratio of new zoom to old zoom for coords.  Center on mouse click.
+    y = (yDist + currentPanY)*(zoom/(zoom-zoomRate));
+    $j('#zoomOutBtn').attr('class', 'inactive').removeAttr('disabled');
+    $j('#zoomValue').html(zoom);
+  } else if (action == 'pan') {
+    x = xDist + currentPanX;
+    y = yDist + currentPanY;
+  }
+  let limitX = ((zoom*outer.width()) - outer.width())/2; //Calculate outer bounds of video
+  let limitY = ((zoom*outer.height()) - outer.height())/2;
+  x = Math.min(Math.max((x),-limitX),limitX); //Limit pan to outer bounds of video
+  y = Math.min(Math.max((y),-limitY),limitY);
+  video.css('transform', 'matrix('+zoom+', 0, 0, '+zoom+', '+x+', '+y+')');
 }
 
 function streamZoomIn( x, y ) {
-  streamReq.send( streamParms+"&command="+CMD_ZOOMIN+"&x="+x+"&y="+y );
+  if (vid) {
+    vjsPanZoom('zoom', x, y);
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_ZOOMIN+"&x="+x+"&y="+y );
+  }
 }
 
 function streamZoomOut() {
-  streamReq.send( streamParms+"&command="+CMD_ZOOMOUT );
+  if (vid) {
+    vjsPanZoom('zoomOut');
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_ZOOMOUT );
+  }
 }
 
 function streamScale( scale ) {
@@ -355,7 +456,11 @@ function streamScale( scale ) {
 }
 
 function streamPan( x, y ) {
-  streamReq.send( streamParms+"&command="+CMD_PAN+"&x="+x+"&y="+y );
+  if (vid) {
+    vjsPanZoom('pan', x, y);
+  } else {
+    streamReq.send( streamParms+"&command="+CMD_PAN+"&x="+x+"&y="+y );
+  }
 }
 
 function streamSeek( offset ) {
@@ -738,6 +843,7 @@ function actQuery( action, parms ) {
 }
 
 function deleteEvent() {
+  pauseClicked(); //Provides visual feedback that your click happened.
   actQuery( 'delete' );
   streamNext( true );
 }
@@ -835,15 +941,6 @@ function updateProgressBar() {
   $j("#progressBox").css('width', curWidth + '%');
 } // end function updateProgressBar()
 
-function handleClick( event ) {
-  var target = event.target;
-  var x = event.page.x - $(target).getLeft();
-  var y = event.page.y - $(target).getTop();
-
-  if ( event.shift )
-    streamPan( x, y );
-  else
-    streamZoomIn( x, y );
 // Handles seeking when clicking on the progress bar.
 function progressBarNav (){
   $j('#progressBar').click(function(e){
@@ -853,99 +950,24 @@ function progressBarNav (){
   });
 }
 
-function setupListener() {
+function handleClick( event ) {
+  var target = event.target;
+  if (vid) {
+    if (target.id != 'videoobj') return; //ignore clicks on control bar
+    var x = event.offsetX;
+    var y = event.offsetY;
+  } else {
+    var x = event.page.x - $(target).getLeft();
+    var y = event.page.y - $(target).getTop();
+  }
 
-  // Buttons
-  var playButton = document.getElementById("play-pause");
-  var muteButton = document.getElementById("mute");
-  var fullScreenButton = document.getElementById("full-screen");
-
-  // Sliders
-  var seekBar = document.getElementById("seekbar");
-  var volumeBar = document.getElementById("volume-bar");
-
-  // Event listener for the play/pause button
-  playButton.addEventListener( "click", function() {
-      if (vid.paused == true) {
-      // Play the video
-      vid.play();
-
-      // Update the button text to 'Pause'
-      playButton.innerHTML = "Pause";
-      } else {
-      // Pause the video
-      vid.pause();
-
-      // Update the button text to 'Play'
-      playButton.innerHTML = "Play";
-      }
-      });
-
-
-  // Event listener for the mute button
-  muteButton.addEventListener("click", function() {
-      if (vid.muted == false) {
-      // Mute the video
-      vid.muted = true;
-
-      // Update the button text
-      muteButton.innerHTML = "Unmute";
-      } else {
-      // Unmute the video
-      vid.muted = false;
-
-      // Update the button text
-      muteButton.innerHTML = "Mute";
-      }
-      });
-
-
-  // Event listener for the full-screen button
-  fullScreenButton.addEventListener("click", function() {
-      if (vid.requestFullscreen) {
-      vid.requestFullscreen();
-      } else if (vid.mozRequestFullScreen) {
-      vid.mozRequestFullScreen(); // Firefox
-      } else if (vid.webkitRequestFullscreen) {
-      vid.webkitRequestFullscreen(); // Chrome and Safari
-      }
-      });
-
-
-  // Event listener for the seek bar
-  seekBar.addEventListener("change", function() {
-      // Calculate the new time
-      var time = vid.duration * (seekBar.value / 100);
-
-      // Update the video time
-      vid.currentTime = time;
-      });
-
-
-  // Update the seek bar as the video plays
-  vid.addEventListener("timeupdate", function() {
-      // Calculate the slider value
-      var value = (100 / vid.duration) * vid.currentTime;
-
-      // Update the slider value
-      seekBar.value = value;
-      });
-
-  // Pause the video when the seek handle is being dragged
-  seekBar.addEventListener("mousedown", function() {
-      vid.pause();
-      });
-
-  // Play the video when the seek handle is dropped
-  seekBar.addEventListener("mouseup", function() {
-      vid.play();
-      });
-
-  // Event listener for the volume bar
-  volumeBar.addEventListener("change", function() {
-      // Update the video volume
-      vid.volume = volumeBar.value;
-      });
+  if (event.shift || event.shiftKey) {//handle both jquery and mootools
+    streamPan(x, y);
+  } else if (vid && event.ctrlKey) { //allow zoom out by control click.  useful in fullscreen
+    vjsPanZoom('zoomOut', x, y);
+  } else {
+    streamZoomIn(x, y);
+  }
 }
 
 function initPage() {
@@ -955,6 +977,10 @@ function initPage() {
     addVideoTimingTrack(vid, LabelFormat, eventData.MonitorName, eventData.Length, eventData.StartTime);
     $j('.vjs-progress-control').append('<div class="alarmCue"></div>');//add a place for videojs only on first load
     vid.on('ended', vjsReplay);
+    vid.on('play', vjsPlay);
+    vid.on('pause', vjsPause);
+    vid.on('click', function(event){handleClick(event);});
+    vid.on('timeupdate', function (){$j('#progressValue').html(secsToTime(Math.floor(vid.currentTime())))});
   } else {
     progressBarNav ();
     streamCmdTimer = streamQuery.delay( 250 );

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1,5 +1,45 @@
 var vid = null;
 
+function vjsReplay() {
+  let endTime = (Date.parse(eventData.EndTime)).getTime();
+  switch(replayMode.value) {
+    case 'none':
+      break;
+    case 'single':
+      player.play();
+      break;
+    case 'all':
+      if (nextEventId == 0) {
+        let overLaid = $j("#videoobj");
+        overLaid.append('<p class="vjsMessage" style="height: '+overLaid.height()+'px; line-height: '+overLaid.height()+'px;">No more events</p>');
+      } else {
+        let nextStartTime = nextEventStartTime.getTime(); //nextEventStartTime.getTime() is a mootools workaround, highjacks Date.parse
+        if (nextStartTime <= endTime) {
+         streamNext( true );
+         return;
+        }
+        let overLaid = $j("#videoobj");
+        vid.pause();
+        overLaid.append('<p class="vjsMessage" style="height: '+overLaid.height()+'px; line-height: '+overLaid.height()+'px;"></p>');
+        let gapDuration = (new Date().getTime()) + (nextStartTime - endTime);
+        let messageP = $j(".vjsMessage");
+        let x = setInterval(function() {
+          let now = new Date().getTime();
+          let remainder = new Date(Math.round(gapDuration - now)).toISOString().substr(11,8);
+          messageP.html(remainder + ' to next event.');
+          if (remainder < 0) {
+            clearInterval(x);
+            streamNext( true );
+          }
+        }, 1000);
+      }
+        break;
+    case 'gapless':
+      streamNext( true );
+      break;
+  }
+}
+
 function setButtonState( element, butClass ) {
   if ( element ) {
     element.className = butClass;
@@ -163,6 +203,8 @@ function streamFastRev( action ) {
 function streamPrev( action ) {
   if ( action )
     streamReq.send( streamParms+"&command="+CMD_PREV );
+    $j(".vjsMessage").remove();
+    $j(".vjsMessage").remove();//This shouldn't happen
 }
 
 function streamNext( action ) {
@@ -808,6 +850,7 @@ function initPage() {
     sources[0].src=null;
     window.videoobj.load();
     streamPlay();    */
+    vid.on('ended', vjsReplay);
   } else {
     streamCmdTimer = streamQuery.delay( 250 );
     eventQuery.pass( eventData.Id ).delay( 500 );

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -572,7 +572,7 @@ function loadEventThumb( event, frame, loadImage ) {
     console.error( "No holder found for frame "+frame.FrameId );
     return;
   }
-  var img = new Asset.image( imagePrefix+frame.Image.imagePath,
+  var img = new Asset.image( imagePrefix+frame.EventId+"&fid="+frame.FrameId,
       {
       'onload': ( function( loadImage ) {
           thumbImg.setProperty( 'src', img.getProperty( 'src' ) );
@@ -588,29 +588,6 @@ function loadEventThumb( event, frame, loadImage ) {
       );
 }
 
-function updateStillsSizes( noDelay ) {
-  var containerDim = $('eventThumbs').getSize();
-
-  var containerWidth = containerDim.x;
-  var containerHeight = containerDim.y;
-  var popupWidth = parseInt($('eventImage').getStyle( 'width' ));
-  var popupHeight = parseInt($('eventImage').getStyle( 'height' ));
-
-  var left = (containerWidth - popupWidth)/2;
-  if ( left < 0 ) left = 0;
-  var top = (containerHeight - popupHeight)/2;
-  if ( top < 0 ) top = 0;
-  if ( popupHeight == 0 && !noDelay ) {
-    // image not yet loaded lets give it another second
-    updateStillsSizes.pass( true ).delay( 50 );
-    return;
-  }
-  $('eventImagePanel').setStyles( {
-      'left': left,
-      'top': top
-      } );
-}
-
 function loadEventImage( event, frame ) {
   console.debug( "Loading "+event.Id+"/"+frame.FrameId );
   var eventImg = $('eventImage');
@@ -624,14 +601,6 @@ function loadEventImage( event, frame ) {
       lastThumbImg.setOpacity( 1.0 );
     }
 
-    eventImg.setProperties( {
-        'class': frame.Type=='Alarm'?'alarm':'normal',
-        'src': thumbImg.getProperty( 'src' ),
-        'title': thumbImg.getProperty( 'title' ),
-        'alt': thumbImg.getProperty( 'alt' ),
-        'width': event.Width,
-        'height': event.Height
-        } );
     $('eventImageBar').setStyle( 'width', event.Width );
     if ( frame.Type=='Alarm' )
       $('eventImageStats').removeClass( 'hidden' );
@@ -642,10 +611,17 @@ function loadEventImage( event, frame ) {
 
     if ( eventImagePanel.getStyle( 'display' ) == 'none' ) {
       eventImagePanel.setOpacity( 0 );
-      updateStillsSizes();
-      eventImagePanel.setStyle( 'display', 'block' );
+      eventImagePanel.setStyle( 'display', 'inline-block' );
       new Fx.Tween( eventImagePanel, { duration: 500, transition: Fx.Transitions.Sine } ).start( 'opacity', 0, 1 );
     }
+
+    eventImg.setProperties( {
+        'class': frame.Type=='Alarm'?'alarm':'normal',
+        'src': thumbImg.getProperty( 'src' ),
+        'title': thumbImg.getProperty( 'title' ),
+        'alt': thumbImg.getProperty( 'alt' ),
+        'height': $j('#eventThumbs').height() - $j('#eventImageBar').outerHeight(true)-10
+        } );
 
     $('eventImageNo').set( 'text', frame.FrameId );
     $('prevImageBtn').disabled = (frame.FrameId==1);
@@ -693,7 +669,7 @@ function resetEventStills() {
     } ).set( 0 );
   }
   if ( $('eventThumbs').getStyle( 'height' ).match( /^\d+/ ) < (parseInt(eventData.Height)+80) )
-    $('eventThumbs').setStyle( 'height', (parseInt(eventData.Height)+80)+'px' );
+    $('eventThumbs').setStyle( 'height', ($j(vid ? '#videoobj' : 'evtStream').height())+'px' );
 }
 
 function getFrameResponse( respObj, respText ) {
@@ -873,21 +849,19 @@ function showEventFrames() {
   createPopup( '?view=frames&eid='+eventData.Id, 'zmFrames', 'frames' );
 }
 
-function showVideo() {
+function showStream() {
   $('eventStills').addClass( 'hidden' );
-  $('imageFeed').addClass('hidden');
   $('eventVideo').removeClass( 'hidden' );
 
   $('stillsEvent').removeClass( 'hidden' );
-  $('videoEvent').addClass( 'hidden' );
+  $('streamEvent').addClass( 'hidden' );
 
   streamMode = 'video';
 }
 
 function showStills() {
   $('eventStills').removeClass( 'hidden' );
-  $('imageFeed').removeClass('hidden');
-  $('eventVideo').addClass( 'hidden' );		
+  $('eventVideo').addClass( 'hidden' );
 
   if (vid && ( vid.paused != true ) ) {
     // Pause the video
@@ -899,11 +873,11 @@ function showStills() {
   }
 
   $('stillsEvent').addClass( 'hidden' );
-  $('videoEvent').removeClass( 'hidden' );
+  $('streamEvent').removeClass( 'hidden' );
 
   streamMode = 'stills';
 
-  streamPause( true );
+  pauseClicked();
   if ( !scroll ) {
     scroll = new Fx.Scroll( 'eventThumbs', {
       wait: false,
@@ -914,7 +888,6 @@ function showStills() {
     );
   }
   resetEventStills();
-  $(window).addEvent( 'resize', updateStillsSizes );
 }
 
 function showFrameStats() {

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -33,8 +33,8 @@ var eventData = {
     Length: '<?php echo $Event->Length() ?>'
 };
 
-var filterQuery = '<?php echo isset($filterQuery)?validJsStr($filterQuery):'' ?>';
-var sortQuery = '<?php echo isset($sortQuery)?validJsStr($sortQuery):'' ?>';
+var filterQuery = '<?php echo isset($filterQuery)?validJsStr(htmlspecialchars_decode($filterQuery)):'' ?>';
+var sortQuery = '<?php echo isset($sortQuery)?validJsStr(htmlspecialchars_decode($sortQuery)):'' ?>';
 
 var scale = <?php echo $scale ?>;
 var canEditEvents = <?php echo canEdit( 'Events' )?'true':'false' ?>;

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -30,13 +30,20 @@ var eventData = {
     MonitorId: '<?php echo $Event->MonitorId() ?>',
     Width: '<?php echo $Event->Width() ?>',
     Height: '<?php echo $Event->Height() ?>',
-    Length: '<?php echo $Event->Length() ?>'
+    Length: '<?php echo $Event->Length() ?>',
+    StartTime: '<?php echo $Event->StartTime() ?>',
+    EndTime: '<?php echo $Event->EndTime() ?>',
+    Frames: '<?php echo $Event->Frames() ?>',
+    MonitorName: '<?php echo $Monitor->Name() ?>'
 };
 
 var filterQuery = '<?php echo isset($filterQuery)?validJsStr(htmlspecialchars_decode($filterQuery)):'' ?>';
 var sortQuery = '<?php echo isset($sortQuery)?validJsStr(htmlspecialchars_decode($sortQuery)):'' ?>';
 
-var scale = <?php echo $scale ?>;
+var rates = <?php echo json_encode(array_keys($rates)) ?>;
+var scale = "<?php echo $scale ?>";
+var LabelFormat = "<?php echo validJsStr($Monitor->LabelFormat())?>";
+
 var canEditEvents = <?php echo canEdit( 'Events' )?'true':'false' ?>;
 var streamTimeout = <?php echo 1000*ZM_WEB_REFRESH_STATUS ?>;
 

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -48,6 +48,7 @@ var canEditEvents = <?php echo canEdit( 'Events' )?'true':'false' ?>;
 var streamTimeout = <?php echo 1000*ZM_WEB_REFRESH_STATUS ?>;
 
 var canStreamNative = <?php echo canStreamNative()?'true':'false' ?>;
+var streamMode = '<?php echo $streamMode ?>';
 
 //
 // Strings

--- a/web/skins/classic/views/js/frame.js
+++ b/web/skins/classic/views/js/frame.js
@@ -1,15 +1,34 @@
 function changeScale() {
-  var scale = $('scale').get('value');
-  var img = $('frameImg');
-  if ( img ) {
-    var baseWidth = $('base_width').value;
-    var baseHeight = $('base_height').value;
-    var newWidth = ( baseWidth * scale ) / SCALE_BASE;
-    var newHeight = ( baseHeight * scale ) / SCALE_BASE;
+  let scale = $j('#scale').val();
+  let img = $j('#frameImg');
+  let controlsLinks = {
+      next: $j('#nextLink'),
+      prev: $j('#prevLink'),
+      first: $j('#firstLink'),
+      last: $j('#lastLink')
+      }
 
-    img.style.width = newWidth + "px";
-    img.style.height = newHeight + "px";
+  if (img) {
+    let baseWidth = $j('#base_width').val();
+    let baseHeight = $j('#base_height').val();
+    if (scale == "auto") {
+      let newSize = scaleToFit(baseWidth, baseHeight, img, $j('#controls'));
+      newWidth = newSize.width;
+      newHeight = newSize.height;
+      autoScale = newSize.autoScale;
+    } else {
+      $j(window).off('resize', endOfResize); //remove resize handler when Scale to Fit is not active
+      newWidth = baseWidth * scale / SCALE_BASE;
+      newHeight = baseHeight * scale / SCALE_BASE;
+    }
+    img.css('width', newWidth + "px");
+    img.css('height', newHeight + "px");
   }
   Cookie.write( 'zmWatchScale', scale, { duration: 10*365 } );
+  $j.each(controlsLinks, function(k, anchor) {  //Make frames respect scale choices
+    anchor.prop('href', anchor.prop('href').replace(/scale=.*&/, 'scale=' + scale + '&'));
+
+  });
 }
 
+if (scale == "auto") $j(document).ready(changeScale);

--- a/web/skins/classic/views/js/frame.js.php
+++ b/web/skins/classic/views/js/frame.js.php
@@ -1,2 +1,3 @@
+var scale = '<?php echo $scale ?>';
 
 var SCALE_BASE = <?php echo SCALE_BASE ?>;

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -25,18 +25,29 @@ function showPtzControls() {
 
 function changeScale() {
   var scale = $('scale').get('value');
-  var newWidth = ( monitorWidth * scale ) / SCALE_BASE;
-  var newHeight = ( monitorHeight * scale ) / SCALE_BASE;
+  var newWidth;
+  var newHeight;
+  if (scale == "auto") {
+    let newSize = scaleToFit(monitorWidth, monitorHeight, $j('#liveStream'+monitorId), $j('#replayStatus'));
+    newWidth = newSize.width;
+    newHeight = newSize.height;
+    autoScale = newSize.autoScale;
+  } else {
+    $j(window).off('resize', endOfResize); //remove resize handler when Scale to Fit is not active
+    newWidth = monitorWidth * scale / SCALE_BASE;
+    newHeight = monitorHeight * scale / SCALE_BASE;
+  }
+
 
   Cookie.write( 'zmWatchScale'+monitorId, scale, { duration: 10*365 } );
 
   /*Stream could be an applet so can't use moo tools*/
-  var streamImg = document.getElementById('liveStream'+monitorId);
+  var streamImg = $('liveStream'+monitorId);
   if ( streamImg ) {
     streamImg.style.width = newWidth + "px";
     streamImg.style.height = newHeight + "px";
 
-    streamImg.src = streamImg.src.replace(/scale=\d+/i, 'scale='+scale);
+    streamImg.src = streamImg.src.replace(/scale=\d+/i, 'scale='+(scale== 'auto' ? autoScale : scale));
   } else {
     console.error("No element found for liveStream.");
   }
@@ -622,6 +633,7 @@ function initPage() {
 
   if ( refreshApplet && appletRefreshTime )
     appletRefresh.delay( appletRefreshTime*1000 );
+  if (scale == "auto") changeScale();
 }
 
 // Kick everything off

--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -50,7 +50,7 @@ var monitorWidth = <?php echo $monitor->Width() ?>;
 var monitorHeight = <?php echo $monitor->Height() ?>;
 var monitorUrl = '<?php echo ( $monitor->Server()->Url() ) ?>';
 
-var scale = <?php echo $scale ?>;
+var scale = '<?php echo $scale ?>';
 
 var statusRefreshTimeout = <?php echo 1000*ZM_WEB_REFRESH_STATUS ?>;
 var eventsRefreshTimeout = <?php echo 1000*ZM_WEB_REFRESH_EVENTS ?>;

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -59,39 +59,26 @@ $Event = null;
 $path = null;
 
 if ( empty($_REQUEST['path']) ) {
+  if ( ! empty($_REQUEST['fid']) ) {
+    $show = empty($_REQUEST['show']) ? 'capture' : $_REQUEST['show'];
 
-	if ( ! empty($_REQUEST['fid']) ) {
-		if ( $_REQUEST['fid'] == 'snapshot' ) {
-			$Event = new Event( $_REQUEST['eid'] );
-      $Frame = new Frame();
-      $Frame->FrameId('snapshot');
-			$path = $Event->Path().'/snapshot.jpg';
-Warning("Path to snapshot: $path");
-		} else {
-
-			$show = empty($_REQUEST['show']) ? 'capture' : $_REQUEST['show'];
-
-			if ( ! empty($_REQUEST['eid'] ) ) {
-				$Event = new Event( $_REQUEST['eid'] );
-				$Frame = Frame::find_one( array( 'EventId' => $_REQUEST['eid'], 'FrameId' => $_REQUEST['fid'] ) );
-				if ( ! $Frame ) {
-          $previousBulkFrame = dbFetchOne( "SELECT * FROM Frames WHERE EventId=? AND FrameId < ? AND Type='BULK'", NULL, array($_REQUEST['eid'], $_REQUEST['fid'] ) );
-          $nextBulkFrame = dbFetchOne( "SELECT * FROM Frames WHERE EventId=? AND FrameId > ? AND Type='BULK'", NULL, array($_REQUEST['eid'], $_REQUEST['fid'] ) );
-          if ( $previousBulkFrame and $nextBulkFrame ) {
-            $Frame = new Frame( $previousBulkFrame );
-            $Frame->Id( $_REQUEST['fid'] );
-            $Frame->Delta( $previousBulkFrame['Delta'] + ( ( $nextBulkFrame['Delta'] - $previousBulkFrame['Delta'] ) * ( $previousBulkFrame['Id']/$nextBulkFrame['Id'] ) ) );
-          } else {
+    if ( ! empty($_REQUEST['eid'] ) ) {
+      $Event = new Event( $_REQUEST['eid'] );
+      $Frame = Frame::find_one( array( 'EventId' => $_REQUEST['eid'], 'FrameId' => $_REQUEST['fid'] ) );
+      if ( ! $Frame ) {
+        $previousBulkFrame = dbFetchOne( "SELECT * FROM Frames WHERE EventId=? AND FrameId < ? ORDER BY FrameID DESC LIMIT 1", NULL, array($_REQUEST['eid'], $_REQUEST['fid'] ) );
+        $nextBulkFrame = dbFetchOne( "SELECT * FROM Frames WHERE EventId=? AND FrameId > ? ORDER BY FrameID ASC LIMIT 1", NULL, array($_REQUEST['eid'], $_REQUEST['fid'] ) );
+        if ( $previousBulkFrame and $nextBulkFrame ) {
+          $Frame = new Frame( $previousBulkFrame );
+          $Frame->FrameId = ( $_REQUEST['fid'] );
+          $percentage = ($Frame->FrameId() - $previousBulkFrame['FrameId']) / ($nextBulkFrame['FrameId'] - $previousBulkFrame['FrameId']);
+          $Frame->Delta = ( $previousBulkFrame['Delta'] + floor( 100* ( $nextBulkFrame['Delta'] - $previousBulkFrame['Delta'] ) * $percentage )/100 );
+Logger::Debug("Got virtual frame from Bulk Frames previous delta: " . $previousBulkFrame['Delta'] . " + nextdelta:" . $nextBulkFrame['Delta'] . ' - ' . $previousBulkFrame['Delta'] . ' * ' . $percentage );
+        } else {
           Fatal("No Frame found for event(".$_REQUEST['eid'].") and frame id(".$_REQUEST['fid'].")");
-          }
         }
-        // Frame can be non-existent.  We have Bulk frames.  So now we should try to load the bulk frame 
-
-      } else {
-# If we are only specifying fid, then the fid must be the primary key into the frames table. But when the event is specified, then it is the frame #
-        $Frame = new Frame( $_REQUEST['fid'] );
-        $Event = new Event( $Frame->EventId() );
       }
+      // Frame can be non-existent.  We have Bulk frames.  So now we should try to load the bulk frame 
     } else {
 # If we are only specifying fid, then the fid must be the primary key into the frames table. But when the event is specified, then it is the frame #
       $Frame = new Frame( $_REQUEST['fid'] );


### PR DESCRIPTION
This PR is focused on adding missing features to the h264/videojs event view with some bleedover into ZMS.  Addresses #1404   and #1961.

### videojs
All control buttons now work on h264 feeds.  Replay mode now functions.  

### zms and videojs
Fixes nearEvents query.  prevEvent always returned zero due to extraneous dbescape.  Added startTime information for use in videojs replaymode.  

Prevent zms feed from loading when event uses h264.  Previously event view would load and hide the zms imagefeed which led to unneeded load on the server and network connection.  

Decode ampersands in event.js.php so navigating respects sort order.

New setting for scaleToFit.  Fits video/image feeds to the window size.  Mainly useful when navigating between different camera events.  

Stills view works on all events.  Uses video stream scale to determine pagination of thumbs.  Previously there was both a scrolling window and navigation buttons.  This made it awkward to use.  Modified slider bar to 

scale with window length.  

Added alarmCues to scrub bars similar to what zmNinja uses.  Present on mp4, zms, and stills view.

Message added when end of events reached or last event in filter reached.  

### zms
Scrub bar converted to a simple percent based progress bar and moved below jpeg stream.  Simplifies code and is more visually similar to videojs.  Also fixes a bug where click events were added multiple times to the scrub bar causing increasing seek commands to be sent to zms.  

Fixed a watch bug where dvrcontrols never appeared regardless of settings.

![1-30alarmcues](https://user-images.githubusercontent.com/31593470/33241495-3bb88d42-d294-11e7-89e1-3cf191000fda.jpg)
