### PR TITLE
add a robots.txt to the docroot to tell bots to not scrape our ZM install

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -10,7 +10,7 @@ configure_file(includes/config.php.in "${CMAKE_CURRENT_BINARY_DIR}/includes/conf
 
 # Install the web files
 install(DIRECTORY api ajax css fonts graphics includes js lang skins tools views DESTINATION "${ZM_WEBDIR}" PATTERN "*.in" EXCLUDE PATTERN "*Make*" EXCLUDE PATTERN "*cmake*" EXCLUDE)
-install(FILES index.php DESTINATION "${ZM_WEBDIR}")
+install(FILES index.php robots.txt DESTINATION "${ZM_WEBDIR}")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/includes/config.php" DESTINATION "${ZM_WEBDIR}/includes")
 
 # Install the api config files (if its not in the source directory)

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Won't do anything for sites configured just using the /zm alias, but for those of who dedicate a virtualhost to ZM, it will stop our logs from being filled up with errors from bots crawling our ZM install.  