### PR TITLE
call zmcamtool during postinst

### DIFF
--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -38,6 +38,10 @@ if [ "$1" = "configure" ]; then
 
         zmupdate.pl --nointeractive
         zmupdate.pl --nointeractive -f
+
+        # Add any new PTZ control configurations to the database (will not overwrite)
+        zmcamtool.pl --import >/dev/null 2>&1
+
       else
         echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
       fi

--- a/distros/ubuntu1504_cmake_split_packages/zoneminder-core.postinst
+++ b/distros/ubuntu1504_cmake_split_packages/zoneminder-core.postinst
@@ -73,6 +73,9 @@ if [ "$dbc_install" = "true" ] && [ "$1" = "configure" ]; then
     # Run the ZoneMinder update tool
     zmupdate.pl --nointeractive
 
+    # Add any new PTZ control configurations to the database (will not overwrite)
+    zmcamtool.pl --import >/dev/null 2>&1
+
 fi
 
 #DEBHELPER#

--- a/distros/ubuntu1604/zoneminder.postinst
+++ b/distros/ubuntu1604/zoneminder.postinst
@@ -47,6 +47,10 @@ if [ "$1" = "configure" ]; then
 
         zmupdate.pl --nointeractive
         zmupdate.pl --nointeractive -f
+
+        # Add any new PTZ control configurations to the database (will not overwrite)
+        zmcamtool.pl --import >/dev/null 2>&1
+
       else
         echo 'NOTE: mysql not running, please start mysql and run dpkg-reconfigure zoneminder when it is running.'
       fi


### PR DESCRIPTION
@connortechnology 
Setting this as a pr so you see this.

This uses zmcamtool to non-destructively import new ptz configs during an upgrade. It will not overwrite.

Been doing this for some time with the redhat packaging scripts:
https://github.com/ZoneMinder/ZoneMinder/blob/master/distros/redhat/zoneminder.spec#L198

