### PR TITLE
Adding group handling in API

### DIFF
--- a/web/api/app/Config/routes.php
+++ b/web/api/app/Config/routes.php
@@ -35,7 +35,8 @@
 
 	/* Add new API to retrieve camera controls - for PTZ */
 	/* refer to https://github.com/ZoneMinder/ZoneMinder/issues/799#issuecomment-105233112 */
-	Router::mapResources('controls'); 
+	Router::mapResources('controls');
+        Router::mapResources('groups');	
 	Router::parseExtensions();
 
 /**

--- a/web/api/app/Controller/GroupsController.php
+++ b/web/api/app/Controller/GroupsController.php
@@ -1,0 +1,145 @@
+<?php
+App::uses('AppController', 'Controller');
+/**
+ * Groups Controller
+ *
+ * @property Group $Group
+ * @property PaginatorComponent $Paginator
+ */
+class GroupsController extends AppController {
+
+
+/**
+ * Components
+ *
+ * @var array
+ */
+	public $components = array('Paginator', 'RequestHandler');
+
+
+public function beforeFilter() {
+	parent::beforeFilter();
+        $canView = $this->Session->Read('groupsPermission');
+	if ($canView =='None')
+	{
+		throw new UnauthorizedException(__('Insufficient Privileges'));
+		return;
+	}
+
+}
+
+
+/**
+ * index method
+ *
+ * @return void
+ */
+	public function index() {
+                $this->Group->recursive = 0;
+        	$groups = $this->Group->find('all');
+        	$this->set(array(
+        	    'groups' => $groups,
+        	    '_serialize' => array('groups')
+        	));
+	}
+
+/**
+ * view method
+ *
+ * @throws NotFoundException
+ * @param string $id
+ * @return void
+ */
+	public function view($id = null) {
+		$this->Group->recursive = 0;
+		if (!$this->Group->exists($id)) {
+			throw new NotFoundException(__('Invalid group'));
+		}
+		
+		$group = $this->Group->find('first');
+		$this->set(array(
+			'group' => $group,
+			'_serialize' => array('group')
+		));
+	}
+
+/**
+ * add method
+ *
+ * @return void
+ */
+	public function add() {
+		if ($this->request->is('post')) {
+
+			if ($this->Session->Read('groupPermission') != 'Edit')
+			{
+				 throw new UnauthorizedException(__('Insufficient privileges'));
+				return;
+			}
+
+			$this->Group->create();
+			if ($this->Group->save($this->request->data)) {
+				return $this->flash(__('The group has been saved.'), array('action' => 'index'));
+			}
+		}
+	}
+
+/**
+ * edit method
+ *
+ * @throws NotFoundException
+ * @param string $id
+ * @return void
+ */
+	public function edit($id = null) {
+		$this->Group->id = $id;
+
+		if (!$this->Group->exists($id)) {
+			throw new NotFoundException(__('Invalid group'));
+		}
+		if ($this->Session->Read('groupPermission') != 'Edit')
+		{
+			 throw new UnauthorizedException(__('Insufficient privileges'));
+			return;
+		}
+		if ($this->Group->save($this->request->data)) {
+			$message = 'Saved';
+		} else {
+			$message = 'Error';
+		}
+
+		$this->set(array(
+			'message' => $message,
+			'_serialize' => array('message')
+		));
+	}
+
+/**
+ * delete method
+ *
+ * @throws NotFoundException
+ * @param string $id
+ * @return void
+ */
+	public function delete($id = null) {
+		$this->Group->id = $id;
+		if (!$this->Group->exists()) {
+			throw new NotFoundException(__('Invalid group'));
+		}
+		if ($this->Session->Read('groupPermission') != 'Edit')
+		{
+			 throw new UnauthorizedException(__('Insufficient privileges'));
+			return;
+		}
+		$this->request->allowMethod('post', 'delete');
+
+
+		if ($this->Group->delete()) {
+			return $this->flash(__('The group has been deleted.'), array('action' => 'index'));
+		} else {
+			return $this->flash(__('The group could not be deleted. Please, try again.'), array('action' => 'index'));
+		}
+	}
+
+}
+

--- a/web/api/app/Model/Group.php
+++ b/web/api/app/Model/Group.php
@@ -1,0 +1,52 @@
+<?php
+App::uses('AppModel', 'Model');
+/**
+ * Group Model
+ *
+ * @property Event $Event
+ * @property Zone $Zone
+ */
+class Group extends AppModel {
+
+/**
+ * Use table
+ *
+ * @var mixed False or table name
+ */
+	public $useTable = 'Groups';
+
+/**
+ * Primary key field
+ *
+ * @var string
+ */
+	public $primaryKey = 'Id';
+
+/**
+ * Display field
+ *
+ * @var string
+ */
+	public $displayField = 'Name';
+
+	public $recursive = -1;
+
+/**
+ * Validation rules
+ *
+ * @var array
+ */
+	public $validate = array(
+		'Id' => array(
+			'numeric' => array(
+				'rule' => array('numeric'),
+				//'message' => 'Your custom message here',
+				//'allowEmpty' => false,
+				//'required' => false,
+				//'last' => false, // Stop validation after this rule
+				//'on' => 'create', // Limit validation to 'create' or 'update' operations
+			),
+		),
+	);
+
+}

--- a/web/api/app/View/Groups/json/edit.ctp
+++ b/web/api/app/View/Groups/json/edit.ctp
@@ -1,0 +1,2 @@
+echo json_encode($message);
+echo json_encode($group);

--- a/web/api/app/View/Groups/json/index.ctp
+++ b/web/api/app/View/Groups/json/index.ctp
@@ -1,0 +1,1 @@
+echo json_encode($groups);

--- a/web/api/app/View/Groups/json/view.ctp
+++ b/web/api/app/View/Groups/json/view.ctp
@@ -1,0 +1,1 @@
+echo json_encode($group);

--- a/web/api/app/View/Groups/xml/edit.ctp
+++ b/web/api/app/View/Groups/xml/edit.ctp
@@ -1,0 +1,2 @@
+$xml = Xml::fromArray(array('response' => $message));
+echo $xml->asXML();

--- a/web/api/app/View/Groups/xml/index.ctp
+++ b/web/api/app/View/Groups/xml/index.ctp
@@ -1,0 +1,2 @@
+$xml = Xml::fromArray(array('response' => $groups));
+echo $xml->asXML();

--- a/web/api/app/View/Groups/xml/view.ctp
+++ b/web/api/app/View/Groups/xml/view.ctp
@@ -1,0 +1,2 @@
+$xml = Xml::fromArray(array('response' => $group));
+echo $xml->asXML();


### PR DESCRIPTION
I've written a raspberry-pi  zoneminder Kiosk a few years ago (https://github.com/Tim-Craig/zm-applet).  It would get the camera and group information from the old XML api.  I've recently updated the zm-applet to use the new Zoneminder API in a recent refactoring.  The Zoneminder API lacked monitor groups.  The PR is for adding group functionality to the Zoneminder API.

This has index, view, add, edit and delete functionality.

sample urls:

Index:
http://<zoneminder server>/<zoneminder path>/api/groups.json

View group id 1:
http://<zoneminder server>/<zoneminder path>/api/groups/1.json

Add a group:
curl -XPOST http://<zoneminder server>/<zoneminder path>/api/groups.json -d "Group[Name]=API-Test&Group[MonitorIds]=11,6,7"

Edit a group of Id 1:
curl -XPUT http://<zoneminder server>/<zoneminder path>/api/groups/1.json -d "Group[Name]=API-Testing"

Delete a group of Id 1:
curl -XDELETE http://<zoneminder server>/<zoneminder path>/api/groups/1.json