### PR TITLE
Fix intermittent API authentication problem caused by whitespace in CakePHP file

### DIFF
--- a/web/api/app/Model/Host.php
+++ b/web/api/app/Model/Host.php
@@ -1,4 +1,3 @@
-
 <?php
 App::uses('AppModel', 'Model');
 


### PR DESCRIPTION
Remove whitespace causing problems with session authentication. This fixes issue #1813