### PR TITLE
Use Event.Width and Event.Height instead of Monitor.Width and Monitor…

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -195,8 +195,8 @@ sub GenerateVideo {
       $frame_rate = $fps;
     }
 
-    my $width = $self->{MonitorWidth};
-    my $height = $self->{MonitorHeight};
+    my $width = $self->{Width};
+    my $height = $self->{Height};
     my $video_size = " ${width}x${height}";
 
     if ( $scale ) {

--- a/scripts/zmvideo.pl.in
+++ b/scripts/zmvideo.pl.in
@@ -197,8 +197,6 @@ my $sql = " SELECT (SELECT max(Delta) FROM Frames WHERE EventId=Events.Id)-(SELE
    Events.*,
    unix_timestamp(Events.StartTime) as Time,
    M.Name as MonitorName,
-   M.Width as MonitorWidth,
-   M.Height as MonitorHeight,
    M.Palette
    FROM Events
    INNER JOIN Monitors as M on Events.MonitorId = M.Id


### PR DESCRIPTION
….Height when generating video of an event.

Event.Width and Event.Height are rotated already, and furthermore, the monitor resolution may have been changed since the event happened.