### PR TITLE
use ZoneMinder::Server::CpuLoad rather than Sys:CpuLoad

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Server.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Server.pm
@@ -107,6 +107,17 @@ sub Hostname {
   return $_[0]{Hostname};
 } # end sub Hostname
 
+sub CpuLoad {
+  my $output = qx(uptime);
+  my @sysloads = split ', ', (split ': ', $output)[-1];
+
+  if (join(', ',@sysloads) =~ /(\d+\.\d+)\s*,\s+(\d+\.\d+)\s*,\s+(\d+\.\d+)\s*$/) {
+    return @sysloads;
+  }
+
+  return (undef, undef, undef);
+} # end sub CpuLoad
+
 1;
 __END__
 # Below is stub documentation for your module. You'd better edit it!

--- a/scripts/zmdc.pl.in
+++ b/scripts/zmdc.pl.in
@@ -156,7 +156,7 @@ my $server_up = connect( CLIENT, $saddr );
 if ( ! $server_up ) {
   if ( $Config{ZM_SERVER_ID} ) {
 use Sys::MemInfo qw(totalmem freemem totalswap freeswap);
-use Sys::CpuLoad;
+use use ZoneMinder::Server qw(CpuLoad);
     if ( ! defined $dbh->do(q{UPDATE Servers SET Status=?,TotalMem=?,FreeMem=?,TotalSwap=?,FreeSwap=? WHERE Id=?}, undef,
           'NotRunning', &totalmem, &freemem, &totalswap, &freeswap, $Config{ZM_SERVER_ID} ) ) {
       Error("Failed Updating status of Server record to Not RUnning for Id=$Config{ZM_SERVER_ID}" . $dbh->errstr());
@@ -237,7 +237,7 @@ use Socket;
 use IO::Handle;
 use Time::HiRes qw(usleep);
 use Sys::MemInfo qw(totalmem freemem totalswap freeswap);
-use Sys::CpuLoad;
+use use ZoneMinder::Server qw(CpuLoad);
 #use Data::Dumper;
 
 # We count 10 of these, so total timeout is this value *10.
@@ -302,7 +302,7 @@ sub run {
     if ( $Config{ZM_SERVER_ID} ) {
       if ( ! ( $secs_count % 60 ) ) {
         $dbh = zmDbConnect() if ! $dbh->ping();
-        my @cpuload = Sys::CpuLoad::load();
+        my @cpuload = CpuLoad();
         dPrint( ZoneMinder::Logger::DEBUG, 'Updating Server record' );
         if ( ! defined $dbh->do(q{UPDATE Servers SET Status=?,CpuLoad=?,TotalMem=?,FreeMem=?,TotalSwap=?,FreeSwap=? WHERE Id=?}, undef,
             'Running', $cpuload[0], &totalmem, &freemem, &totalswap, &freeswap, $Config{ZM_SERVER_ID} ) ) {


### PR DESCRIPTION
The Perl Sys::CpuLoad module is not currently available in any RedHat distro. 

For the long term, I can certainly submit a new package request over at RedHat to get it added. This however, will be a slow process.

In the interim, this PR implements our own cpuload subroutine, which gives the same output as Sys::Cpuload. I placed the sub in ZoneMinder::Server because that seemed like the best place 