### PR TITLE
Limit search api

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -101,8 +101,8 @@ class EventsController extends AppController {
  * @return void
  */
 	public function view($id = null) {
+ 
     $this->loadModel('Config');
-
     $this->Event->recursive = 1;
     if (!$this->Event->exists($id)) {
       throw new NotFoundException(__('Invalid event'));
@@ -117,10 +117,13 @@ class EventsController extends AppController {
     }
 
     $options = array('conditions' => array(array('Event.' . $this->Event->primaryKey => $id), $mon_options));
-    $event = $this->Event->find('first', $options);
 
+   
+    $event = $this->Event->find('first', $options);
+    
     # Get the previous and next events for any monitor
     $this->Event->id = $id;
+
     $event_neighbors = $this->Event->find('neighbors');
     $event['Event']['Next'] = $event_neighbors['next']['Event']['Id'];
     $event['Event']['Prev'] = $event_neighbors['prev']['Event']['Id'];
@@ -222,9 +225,11 @@ class EventsController extends AppController {
   public function search() {
     $this->Event->recursive = -1;
     $conditions = array();
+    $limit = $this->request->query("limit");
 
     foreach ($this->params['named'] as $param_name => $value) {
       // Transform params into mysql
+
       if (preg_match("/interval/i", $value, $matches)) {
         $condition = array("$param_name >= (date_sub(now(), $value))");
       } else {
@@ -234,7 +239,8 @@ class EventsController extends AppController {
     }
 
     $results = $this->Event->find('all', array(
-      'conditions' => $conditions
+      'conditions' => $conditions,
+      'limit' => $limit,
     ));
 
     $this->set(array(

--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -5,23 +5,25 @@ App::uses('AppController', 'Controller');
  *
  * @property Event $Event
  */
-class EventsController extends AppController {
+class EventsController extends AppController
+{
 
 /**
  * Components
  *
  * @var array
  */
-	public $components = array('RequestHandler', 'Scaler', 'Image', 'Paginator');
+    public $components = array('RequestHandler', 'Scaler', 'Image', 'Paginator');
 
-  public function beforeFilter() {
-    parent::beforeFilter();
-    $canView = $this->Session->Read('eventPermission');
-    if ($canView =='None') {
-      throw new UnauthorizedException(__('Insufficient Privileges'));
-      return;
+    public function beforeFilter()
+    {
+        parent::beforeFilter();
+        $canView = $this->Session->Read('eventPermission');
+        if ($canView == 'None') {
+            throw new UnauthorizedException(__('Insufficient Privileges'));
+            return;
+        }
     }
-  }
 
 /**
  * index method
@@ -29,69 +31,70 @@ class EventsController extends AppController {
  * @return void
  * This also creates a thumbnail for each event.
  */
-	public function index() {
-		$this->Event->recursive = -1;
-		
-    $allowedMonitors=preg_split ('@,@', $this->Session->Read('allowedMonitors'),NULL, PREG_SPLIT_NO_EMPTY);
+    public function index()
+    {
+        $this->Event->recursive = -1;
 
-    if (!empty($allowedMonitors)) {
-      $mon_options = array('Event.MonitorId' => $allowedMonitors);
-    } else {
-      $mon_options='';
+        $allowedMonitors = preg_split('@,@', $this->Session->Read('allowedMonitors'), null, PREG_SPLIT_NO_EMPTY);
+
+        if (!empty($allowedMonitors)) {
+            $mon_options = array('Event.MonitorId' => $allowedMonitors);
+        } else {
+            $mon_options = '';
+        }
+
+        if ($this->request->params['named']) {
+            //$this->FilterComponent = $this->Components->load('Filter');
+            //$conditions = $this->FilterComponent->buildFilter($this->request->params['named']);
+            $conditions = $this->request->params['named'];
+        } else {
+            $conditions = array();
+        }
+        $settings = array(
+            // https://github.com/ZoneMinder/ZoneMinder/issues/995
+            // 'limit' => $limit['ZM_WEB_EVENTS_PER_PAGE'],
+            //  25 events per page which is what the above
+            // default is, is way too low for an API
+            // changing this to 100 so we don't kill ZM
+            // with many event APIs. In future, we can
+            // make a nice ZM_API_ITEMS_PER_PAGE for all pagination
+            // API
+
+            'limit' => '100',
+            'order' => array('StartTime'),
+            'paramType' => 'querystring',
+        );
+        if (isset($conditions['GroupId'])) {
+            $settings['joins'] = array(
+                array(
+                    'table' => 'Groups_Monitors',
+                    'type' => 'inner',
+                    'conditions' => array(
+                        'Groups_Monitors.MonitorId = Event.MonitorId',
+                    ),
+                ),
+            );
+            $settings['contain'] = array('Group');
+        }
+        $settings['conditions'] = array($conditions, $mon_options);
+
+        // How many events to return
+        $this->loadModel('Config');
+        $limit = $this->Config->find('list', array(
+            'conditions' => array('Name' => 'ZM_WEB_EVENTS_PER_PAGE'),
+            'fields' => array('Name', 'Value'),
+        ));
+        $this->Paginator->settings = $settings;
+        $events = $this->Paginator->paginate('Event');
+
+        // For each event, get the frameID which has the largest score
+        foreach ($events as $key => $value) {
+            $maxScoreFrameId = $this->getMaxScoreAlarmFrameId($value['Event']['Id']);
+            $events[$key]['Event']['MaxScoreFrameId'] = $maxScoreFrameId;
+        }
+
+        $this->set(compact('events'));
     }
-
-		if ($this->request->params['named']) {	
-			//$this->FilterComponent = $this->Components->load('Filter');
-			//$conditions = $this->FilterComponent->buildFilter($this->request->params['named']);
-      $conditions = $this->request->params['named'];
-		} else {
-			$conditions = array();
-		}
-    $settings = array(
-			// https://github.com/ZoneMinder/ZoneMinder/issues/995
-			// 'limit' => $limit['ZM_WEB_EVENTS_PER_PAGE'],
-			//  25 events per page which is what the above
-			// default is, is way too low for an API
-			// changing this to 100 so we don't kill ZM
-			// with many event APIs. In future, we can
-			// make a nice ZM_API_ITEMS_PER_PAGE for all pagination
-			// API
-		
-			'limit' => '100',
-			'order' => array('StartTime'),
-			'paramType' => 'querystring',
-    );
-    if ( isset( $conditions['GroupId'] ) ) {
-      $settings['joins'] = array(
-        array(
-          'table' => 'Groups_Monitors',
-          'type' => 'inner',
-          'conditions' => array(
-            'Groups_Monitors.MonitorId = Event.MonitorId'
-          ),
-        ),
-      );
-      $settings['contain'] = array('Group');
-    }
-    $settings['conditions'] = array($conditions, $mon_options);
-
-		// How many events to return 
-		$this->loadModel('Config');
-		$limit = $this->Config->find('list', array(
-			'conditions' => array('Name' => 'ZM_WEB_EVENTS_PER_PAGE'),
-			'fields' => array('Name', 'Value')
-		));
-		$this->Paginator->settings = $settings;
-		$events = $this->Paginator->paginate('Event');
-
-		// For each event, get the frameID which has the largest score
-		foreach ($events as $key => $value) {
-			$maxScoreFrameId = $this->getMaxScoreAlarmFrameId($value['Event']['Id']);
-			$events[$key]['Event']['MaxScoreFrameId'] = $maxScoreFrameId;
-		}
-
-		$this->set(compact('events'));
-	}
 
 /**
  * view method
@@ -100,293 +103,300 @@ class EventsController extends AppController {
  * @param string $id
  * @return void
  */
-	public function view($id = null) {
- 
-    $this->loadModel('Config');
-    $this->Event->recursive = 1;
-    if (!$this->Event->exists($id)) {
-      throw new NotFoundException(__('Invalid event'));
+    public function view($id = null)
+    {
+
+        $this->loadModel('Config');
+        $this->Event->recursive = 1;
+        if (!$this->Event->exists($id)) {
+            throw new NotFoundException(__('Invalid event'));
+        }
+
+        $allowedMonitors = preg_split('@,@', $this->Session->Read('allowedMonitors'), null, PREG_SPLIT_NO_EMPTY);
+
+        if (!empty($allowedMonitors)) {
+            $mon_options = array('Event.MonitorId' => $allowedMonitors);
+        } else {
+            $mon_options = '';
+        }
+
+        $options = array('conditions' => array(array('Event.' . $this->Event->primaryKey => $id), $mon_options));
+
+        $event = $this->Event->find('first', $options);
+
+        # Get the previous and next events for any monitor
+        $this->Event->id = $id;
+
+        $event_neighbors = $this->Event->find('neighbors');
+        $event['Event']['Next'] = $event_neighbors['next']['Event']['Id'];
+        $event['Event']['Prev'] = $event_neighbors['prev']['Event']['Id'];
+
+        # Also get the previous and next events for the same monitor
+        $event_monitor_neighbors = $this->Event->find('neighbors', array(
+            'conditions' => array('Event.MonitorId' => $event['Event']['MonitorId']),
+        ));
+        $event['Event']['NextOfMonitor'] = $event_monitor_neighbors['next']['Event']['Id'];
+        $event['Event']['PrevOfMonitor'] = $event_monitor_neighbors['prev']['Event']['Id'];
+
+        $this->set(array(
+            'event' => $event,
+            '_serialize' => array('event'),
+        ));
     }
 
-    $allowedMonitors=preg_split ('@,@', $this->Session->Read('allowedMonitors'),NULL, PREG_SPLIT_NO_EMPTY);
+    /**
+     * add method
+     *
+     * @return void
+     */
+    public function add()
+    {
 
-    if (!empty($allowedMonitors)) {
-      $mon_options = array('Event.MonitorId' => $allowedMonitors);
-    } else {
-      $mon_options='';
+        if ($this->Session->Read('eventPermission') != 'Edit') {
+            throw new UnauthorizedException(__('Insufficient privileges'));
+            return;
+        }
+
+        if ($this->request->is('post')) {
+            $this->Event->create();
+            if ($this->Event->save($this->request->data)) {
+                return $this->flash(__('The event has been saved.'), array('action' => 'index'));
+            }
+        }
+        $monitors = $this->Event->Monitor->find('list');
+        $this->set(compact('monitors'));
     }
 
-    $options = array('conditions' => array(array('Event.' . $this->Event->primaryKey => $id), $mon_options));
+    /**
+     * edit method
+     *
+     * @throws NotFoundException
+     * @param string $id
+     * @return void
+     */
+    public function edit($id = null)
+    {
 
-   
-    $event = $this->Event->find('first', $options);
-    
-    # Get the previous and next events for any monitor
-    $this->Event->id = $id;
+        if ($this->Session->Read('eventPermission') != 'Edit') {
+            throw new UnauthorizedException(__('Insufficient privileges'));
+            return;
+        }
 
-    $event_neighbors = $this->Event->find('neighbors');
-    $event['Event']['Next'] = $event_neighbors['next']['Event']['Id'];
-    $event['Event']['Prev'] = $event_neighbors['prev']['Event']['Id'];
+        $this->Event->id = $id;
 
-    # Also get the previous and next events for the same monitor
-    $event_monitor_neighbors = $this->Event->find('neighbors', array(
-      'conditions'=>array('Event.MonitorId'=>$event['Event']['MonitorId'])
-    ));
-    $event['Event']['NextOfMonitor'] = $event_monitor_neighbors['next']['Event']['Id'];
-    $event['Event']['PrevOfMonitor'] = $event_monitor_neighbors['prev']['Event']['Id'];
+        if (!$this->Event->exists($id)) {
+            throw new NotFoundException(__('Invalid event'));
+        }
 
-    $this->set(array(
-      'event' => $event,
-      '_serialize' => array('event')
-    ));
-  }
+        if ($this->Event->save($this->request->data)) {
+            $message = 'Saved';
+        } else {
+            $message = 'Error';
+        }
 
-
-  /**
-   * add method
-   *
-   * @return void
-   */
-  public function add() {
-
-    if ($this->Session->Read('eventPermission') != 'Edit') {
-      throw new UnauthorizedException(__('Insufficient privileges'));
-      return;
+        $this->set(array(
+            'message' => $message,
+            '_serialize' => array('message'),
+        ));
     }
 
-    if ($this->request->is('post')) {
-      $this->Event->create();
-      if ($this->Event->save($this->request->data)) {
-        return $this->flash(__('The event has been saved.'), array('action' => 'index'));
-      }
-    }
-    $monitors = $this->Event->Monitor->find('list');
-    $this->set(compact('monitors'));
-  }
+    /**
+     * delete method
+     *
+     * @throws NotFoundException
+     * @param string $id
+     * @return void
+     */
+    public function delete($id = null)
+    {
+        if ($this->Session->Read('eventPermission') != 'Edit') {
+            throw new UnauthorizedException(__('Insufficient privileges'));
+            return;
+        }
+        $this->Event->id = $id;
+        if (!$this->Event->exists()) {
+            throw new NotFoundException(__('Invalid event'));
+        }
+        $this->request->allowMethod('post', 'delete');
+        if ($this->Event->delete()) {
+            //$this->loadModel('Frame');
+            //$this->Event->Frame->delete();
+            return $this->flash(__('The event has been deleted.'), array('action' => 'index'));
+        } else {
+            return $this->flash(__('The event could not be deleted. Please, try again.'), array('action' => 'index'));
+        }
+    } // end public function delete
 
-  /**
-   * edit method
-   *
-   * @throws NotFoundException
-   * @param string $id
-   * @return void
-   */
-  public function edit($id = null) {
+    public function search()
+    {
+        $this->Event->recursive = -1;
+        $conditions = array();
+        $limit = $this->request->query("limit");
 
-    if ($this->Session->Read('eventPermission') != 'Edit') {
-      throw new UnauthorizedException(__('Insufficient privileges'));
-      return;
-    }
+        foreach ($this->params['named'] as $param_name => $value) {
+            // Transform params into mysql
 
-    $this->Event->id = $id;
+            if (preg_match("/interval/i", $value, $matches)) {
+                $condition = array("$param_name >= (date_sub(now(), $value))");
+            } else {
+                $condition = array($param_name => $value);
+            }
+            array_push($conditions, $condition);
+        }
 
-    if (!$this->Event->exists($id)) {
-      throw new NotFoundException(__('Invalid event'));
-    }
+        $results = $this->Event->find('all', array(
+            'conditions' => $conditions,
+            'limit' => $limit,
+        ));
 
-    if ($this->Event->save($this->request->data)) {
-      $message = 'Saved';
-    } else {
-      $message = 'Error';
-    }
+        $this->set(array(
+            'results' => $results,
+            '_serialize' => array('results'),
+        ));
+    } // end public function search
 
-    $this->set(array(
-      'message' => $message,
-      '_serialize' => array('message')
-    ));
-  }
+    // format expected:
+    // you can changed AlarmFrames to any other named params
+    // consoleEvents/1 hour/AlarmFrames >=: 1/AlarmFrames <=: 20.json
 
-  /**
-   * delete method
-   *
-   * @throws NotFoundException
-   * @param string $id
-   * @return void
-   */
-  public function delete($id = null) {
-    if ($this->Session->Read('eventPermission') != 'Edit') {
-      throw new UnauthorizedException(__('Insufficient privileges'));
-      return;
-    }
-    $this->Event->id = $id;
-    if (!$this->Event->exists()) {
-      throw new NotFoundException(__('Invalid event'));
-    }
-    $this->request->allowMethod('post', 'delete');
-    if ($this->Event->delete()) {
-      //$this->loadModel('Frame');
-      //$this->Event->Frame->delete();
-      return $this->flash(__('The event has been deleted.'), array('action' => 'index'));
-    } else {
-      return $this->flash(__('The event could not be deleted. Please, try again.'), array('action' => 'index'));
-    }
-  } // end public function delete
+    public function consoleEvents($interval = null)
+    {
+        $this->Event->recursive = -1;
+        $results = array();
 
-  public function search() {
-    $this->Event->recursive = -1;
-    $conditions = array();
-    $limit = $this->request->query("limit");
+        $moreconditions = "";
+        foreach ($this->request->params['named'] as $name => $param) {
+            $moreconditions = $moreconditions . " AND " . $name . $param;
+        }
 
-    foreach ($this->params['named'] as $param_name => $value) {
-      // Transform params into mysql
+        $query = $this->Event->query("select MonitorId, COUNT(*) AS Count from Events WHERE (StartTime >= (DATE_SUB(NOW(), interval $interval)) $moreconditions) GROUP BY MonitorId;");
 
-      if (preg_match("/interval/i", $value, $matches)) {
-        $condition = array("$param_name >= (date_sub(now(), $value))");
-      } else {
-        $condition = array($param_name => $value);
-      }
-      array_push($conditions, $condition);
+        foreach ($query as $result) {
+            $results[$result['Events']['MonitorId']] = $result[0]['Count'];
+        }
+
+        $this->set(array(
+            'results' => $results,
+            '_serialize' => array('results'),
+        ));
     }
 
-    $results = $this->Event->find('all', array(
-      'conditions' => $conditions,
-      'limit' => $limit,
-    ));
+    // Create a thumbnail and return the thumbnail's data for a given event id.
+    public function createThumbnail($id = null)
+    {
+        $this->Event->recursive = -1;
 
-    $this->set(array(
-      'results' => $results,
-      '_serialize' => array('results')
-    ));
-  } // end public function search
+        if (!$this->Event->exists($id)) {
+            throw new NotFoundException(__('Invalid event'));
+        }
 
-  // format expected:
-  // you can changed AlarmFrames to any other named params
-  // consoleEvents/1 hour/AlarmFrames >=: 1/AlarmFrames <=: 20.json
+        $event = $this->Event->find('first', array(
+            'conditions' => array('Id' => $id),
+        ));
 
-  public function consoleEvents($interval = null) {
-    $this->Event->recursive = -1;
-    $results = array();
+        // Find the max Frame for this Event.  Error out otherwise.
+        $this->loadModel('Frame');
+        if (!$frame = $this->Frame->find('first', array(
+            'conditions' => array(
+                'EventId' => $event['Event']['Id'],
+                'Score' => $event['Event']['MaxScore'],
+            ),
+        ))) {
+            throw new NotFoundException(__("Can not find Frame for Event " . $event['Event']['Id']));
+        }
 
-    $moreconditions ="";
-    foreach ($this->request->params['named'] as $name => $param) {
-      $moreconditions = $moreconditions . " AND ".$name.$param;
-    }	
+        $this->loadModel('Config');
 
-    $query = $this->Event->query("select MonitorId, COUNT(*) AS Count from Events WHERE (StartTime >= (DATE_SUB(NOW(), interval $interval)) $moreconditions) GROUP BY MonitorId;");
+        // Get the config options required for reScale and getImageSrc
+        // The $bw, $thumbs and unset() code is a workaround / temporary
+        // until I have a better way of handing per-bandwidth config options
+        $bw = (isset($_COOKIE['zmBandwidth']) ? strtoupper(substr($_COOKIE['zmBandwidth'], 0, 1)) : 'L');
+        $thumbs = "ZM_WEB_${bw}_SCALE_THUMBS";
 
-    foreach ($query as $result) {
-      $results[$result['Events']['MonitorId']] = $result[0]['Count'];
+        $config = $this->Config->find('list', array(
+            'conditions' => array('OR' => array(
+                'Name' => array('ZM_WEB_LIST_THUMB_WIDTH',
+                    'ZM_WEB_LIST_THUMB_HEIGHT',
+                    'ZM_EVENT_IMAGE_DIGITS',
+                    'ZM_DIR_IMAGES',
+                    $thumbs,
+                    'ZM_DIR_EVENTS',
+                ),
+            )),
+            'fields' => array('Name', 'Value'),
+        ));
+        $config['ZM_WEB_SCALE_THUMBS'] = $config[$thumbs];
+        unset($config[$thumbs]);
+
+        // reScale based on either the width, or the hight, of the event.
+        if ($config['ZM_WEB_LIST_THUMB_WIDTH']) {
+            $thumbWidth = $config['ZM_WEB_LIST_THUMB_WIDTH'];
+            $scale = (100 * $thumbWidth) / $event['Event']['Width'];
+            $thumbHeight = $this->Scaler->reScale($event['Event']['Height'], $scale);
+        } elseif ($config['ZM_WEB_LIST_THUMB_HEIGHT']) {
+            $thumbHeight = $config['ZM_WEB_LIST_THUMB_HEIGHT'];
+            $scale = (100 * $thumbHeight) / $event['Event']['Height'];
+            $thumbWidth = $this->Scaler->reScale($event['Event']['Width'], $scale);
+        } else {
+            throw new NotFoundException(__('No thumbnail width or height specified, please check in Options->Web'));
+        }
+
+        $imageData = $this->Image->getImageSrc($event, $frame, $scale, $config);
+        $thumbData['Path'] = $imageData['thumbPath'];
+        $thumbData['Width'] = (int) $thumbWidth;
+        $thumbData['Height'] = (int) $thumbHeight;
+
+        return ($thumbData);
     }
 
-    $this->set(array(
-      'results' => $results,
-      '_serialize' => array('results')
-    ));
-  }
+    public function archive($id = null)
+    {
+        $this->Event->recursive = -1;
+        if (!$this->Event->exists($id)) {
+            throw new NotFoundException(__('Invalid event'));
+        }
 
-  // Create a thumbnail and return the thumbnail's data for a given event id.
-  public function createThumbnail($id = null) {
-    $this->Event->recursive = -1;
+        // Get the current value of Archive
+        $archived = $this->Event->find('first', array(
+            'fields' => array('Event.Archived'),
+            'conditions' => array('Event.Id' => $id),
+        ));
+        // If 0, 1, if 1, 0
+        $archiveVal = (($archived['Event']['Archived'] == 0) ? 1 : 0);
 
-    if (!$this->Event->exists($id)) {
-      throw new NotFoundException(__('Invalid event'));
+        // Save the new value
+        $this->Event->id = $id;
+        $this->Event->saveField('Archived', $archiveVal);
+
+        $this->set(array(
+            'archived' => $archiveVal,
+            '_serialize' => array('archived'),
+        ));
     }
 
-    $event = $this->Event->find('first', array(
-      'conditions' => array('Id' => $id)
-    ));
+    public function getMaxScoreAlarmFrameId($id = null)
+    {
+        $this->Event->recursive = -1;
 
-    // Find the max Frame for this Event.  Error out otherwise.
-    $this->loadModel('Frame');
-    if (! $frame = $this->Frame->find('first', array(
-      'conditions' => array(
-        'EventId' => $event['Event']['Id'],
-        'Score' => $event['Event']['MaxScore']
-      )
-    ))) {
-    throw new NotFoundException(__("Can not find Frame for Event " . $event['Event']['Id']));
+        if (!$this->Event->exists($id)) {
+            throw new NotFoundException(__('Invalid event'));
+        }
+
+        $event = $this->Event->find('first', array(
+            'conditions' => array('Id' => $id),
+        ));
+
+        // Find the max Frame for this Event.  Error out otherwise.
+        $this->loadModel('Frame');
+
+        if (!$frame = $this->Frame->find('first', array(
+            'conditions' => array(
+                'EventId' => $event['Event']['Id'],
+                'Score' => $event['Event']['MaxScore'],
+            ),
+        ))) {
+            throw new NotFoundException(__("Can not find Frame for Event " . $event['Event']['Id']));
+        }
+        return $frame['Frame']['Id'];
     }
-
-    $this->loadModel('Config');
-
-    // Get the config options required for reScale and getImageSrc
-    // The $bw, $thumbs and unset() code is a workaround / temporary
-    // until I have a better way of handing per-bandwidth config options
-    $bw = (isset($_COOKIE['zmBandwidth']) ? strtoupper(substr($_COOKIE['zmBandwidth'], 0, 1)) : 'L');
-    $thumbs = "ZM_WEB_${bw}_SCALE_THUMBS";
-
-    $config = $this->Config->find('list', array(
-      'conditions' => array('OR' => array(
-        'Name' => array('ZM_WEB_LIST_THUMB_WIDTH',
-        'ZM_WEB_LIST_THUMB_HEIGHT',
-        'ZM_EVENT_IMAGE_DIGITS',
-        'ZM_DIR_IMAGES',
-        $thumbs,
-        'ZM_DIR_EVENTS'
-      )
-    )),
-      'fields' => array('Name', 'Value')
-    ));
-    $config['ZM_WEB_SCALE_THUMBS'] = $config[$thumbs];
-    unset($config[$thumbs]);
-
-    // reScale based on either the width, or the hight, of the event.
-    if ( $config['ZM_WEB_LIST_THUMB_WIDTH'] ) {
-      $thumbWidth = $config['ZM_WEB_LIST_THUMB_WIDTH'];
-      $scale = (100 * $thumbWidth) / $event['Event']['Width'];
-      $thumbHeight = $this->Scaler->reScale( $event['Event']['Height'], $scale );
-    } elseif ( $config['ZM_WEB_LIST_THUMB_HEIGHT'] ) {
-      $thumbHeight = $config['ZM_WEB_LIST_THUMB_HEIGHT'];
-      $scale = (100*$thumbHeight)/$event['Event']['Height'];
-      $thumbWidth = $this->Scaler->reScale( $event['Event']['Width'], $scale );
-    } else {
-      throw new NotFoundException(__('No thumbnail width or height specified, please check in Options->Web'));
-    }
-
-    $imageData = $this->Image->getImageSrc( $event, $frame, $scale, $config );
-    $thumbData['Path'] = $imageData['thumbPath'];
-    $thumbData['Width'] = (int)$thumbWidth;
-    $thumbData['Height'] = (int)$thumbHeight;
-
-    return( $thumbData );
-  }
-
-  public function archive($id = null) {
-    $this->Event->recursive = -1;
-    if (!$this->Event->exists($id)) {
-      throw new NotFoundException(__('Invalid event'));
-    }
-
-    // Get the current value of Archive
-    $archived = $this->Event->find('first', array(
-      'fields' => array('Event.Archived'),
-      'conditions' => array('Event.Id' => $id)
-    ));
-    // If 0, 1, if 1, 0
-    $archiveVal = (($archived['Event']['Archived'] == 0) ? 1 : 0);
-
-    // Save the new value 
-    $this->Event->id = $id;
-    $this->Event->saveField('Archived', $archiveVal);
-
-    $this->set(array(
-      'archived' => $archiveVal,
-      '_serialize' => array('archived')
-    ));
-  }
-
-  public function getMaxScoreAlarmFrameId($id = null) {
-    $this->Event->recursive = -1;
-
-    if (!$this->Event->exists($id)) {
-      throw new NotFoundException(__('Invalid event'));
-    }
-
-    $event = $this->Event->find('first', array(
-      'conditions' => array('Id' => $id)
-    ));
-
-    // Find the max Frame for this Event.  Error out otherwise.
-    $this->loadModel('Frame');
-
-    if (! $frame = $this->Frame->find('first', array(
-      'conditions' => array(
-        'EventId' => $event['Event']['Id'],
-        'Score' => $event['Event']['MaxScore']
-      )
-    ))) {
-      throw new NotFoundException(__("Can not find Frame for Event " . $event['Event']['Id']));
-    }
-    return $frame['Frame']['Id'];
-  }
 } // end class EventsController


### PR DESCRIPTION
EventsController has a search action this is so far unused. Its pretty powerful as a general purpose search. This PR adds a limit feature to it, with the following motivation:

1. zmNinja today uses `find ('neighbors')`  for navigation of events --> this feature is deprecated for Cake 3, I need to move away from it. This action can replace it, but for performance, I need to add a limit

2. Its backwards compatible - doesn't break anything and lets me replace 'neighbors' find with search more efficiently

3.  query params seems more flexible than passed params https://www.dereuromark.de/2013/05/04/passed-named-or-query-string-params/