### PR TITLE
Do not require mariadb/mysqld in systemd service file - database serv…

### DIFF
--- a/distros/redhat/nginx/zoneminder.service.in
+++ b/distros/redhat/nginx/zoneminder.service.in
@@ -4,7 +4,7 @@
 [Unit]
 Description=ZoneMinder CCTV recording and security system
 After=network.target mariadb.service nginx.service php-fpm.service fcgiwrap.service
-Requires=mariadb.service nginx.service php-fpm.service fcgiwrap.service
+Requires=nginx.service php-fpm.service fcgiwrap.service
 
 [Service]
 User=@WEB_USER@

--- a/distros/redhat/systemd/zoneminder.service.in
+++ b/distros/redhat/systemd/zoneminder.service.in
@@ -3,7 +3,7 @@
 [Unit]
 Description=ZoneMinder CCTV recording and security system
 After=network.target mariadb.service httpd.service
-Requires=mariadb.service httpd.service
+Requires=httpd.service
 
 [Service]
 User=@WEB_USER@

--- a/misc/zoneminder.service.in
+++ b/misc/zoneminder.service.in
@@ -4,7 +4,7 @@
 [Unit]
 Description=ZoneMinder CCTV recording and security system
 After=network.target mysqld.service httpd.service
-Requires=mysqld.service httpd.service
+Requires=httpd.service
 
 [Service]
 User=@WEB_USER@


### PR DESCRIPTION
…er may be remote

Without mariadb installed locally, on EL7 you get the very unhelpful error message:
```
Failed to start zoneminder.service: Unit not found.
```
If the database is installed locally, After=mariadb.service is sufficient to do what you want - start zoneminder after mariadb.