### PR TITLE
Grant access to the new cache directory in Apache on Ubuntu

### DIFF
--- a/distros/ubuntu1204/conf/apache2/zoneminder.conf
+++ b/distros/ubuntu1204/conf/apache2/zoneminder.conf
@@ -9,7 +9,17 @@ ScriptAlias /zm/cgi-bin "/usr/lib/zoneminder/cgi-bin"
 # Order matters. This Alias must come first
 Alias /zm/cache /var/cache/zoneminder/cache
 <Directory /var/cache/zoneminder/cache>
-  Options -Indexes +FollowSymLinks
+    Options -Indexes +FollowSymLinks
+    AllowOverride None
+    <IfModule mod_authz_core.c>
+        # Apache 2.4
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        # Apache 2.2
+        Order deny,allow
+        Allow from all
+    </IfModule>
 </Directory>
 
 Alias /zm /usr/share/zoneminder/www
@@ -45,4 +55,3 @@ Alias /zm /usr/share/zoneminder/www
     RewriteRule ^ index.php [L]
     RewriteBase /zm/api
 </Directory>
-

--- a/distros/ubuntu1604/conf/apache2/zoneminder.conf
+++ b/distros/ubuntu1604/conf/apache2/zoneminder.conf
@@ -9,7 +9,17 @@ ScriptAlias /zm/cgi-bin "/usr/lib/zoneminder/cgi-bin"
 # Order matters. This alias must come first.
 Alias /zm/cache /var/cache/zoneminder/cache
 <Directory /var/cache/zoneminder/cache>
-  Options -Indexes +FollowSymLinks
+    Options -Indexes +FollowSymLinks
+    AllowOverride None
+    <IfModule mod_authz_core.c>
+        # Apache 2.4
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        # Apache 2.2
+        Order deny,allow
+        Allow from all
+    </IfModule>
 </Directory>
 
 Alias /zm /usr/share/zoneminder/www


### PR DESCRIPTION
This fixes a regression from #2083 and aligns with generate_apache_config.pl and the changes for Debian