### PR TITLE
Allow selection of different source column filtering on the console

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -2964,6 +2964,37 @@ our @options = (
     category    => 'web',
   },
   {
+    name        => 'ZM_WEB_FILTER_SOURCE',
+    default     => 'Hostname',
+    description => 'How to filter information in the source column.',
+    help        => q`
+      This option only affects monitors with a source type of Ffmpeg,
+      Libvlc, or WebSite. This setting controls what information is
+      displayed in the Source column on the console. Selecting 'None'
+      will not filter anything. The entire source string will be
+      displayed, which may contain sensitive information. Selecting
+      'NoCredentials' will strip out usernames and passwords from the
+      string. If there are any port numbers in the string and they are
+      common (80, 554, etc) then those will be removed as well.
+      Selecting 'Hostname' will filter out all information except for
+      the hostname or ip address. When in doubt, stay with the default
+      'Hostname'. This feature uses the php function 'url_parts' to
+      identify the various pieces of the url. If the url in question
+      is unusual or not standard in some way, then filtering may not
+      produce the desired results.
+      `,
+    type        => {
+      db_type     =>'string',
+      hint        =>'None|Hostname|NoCredentials',
+      pattern     =>qr|^([NH])|i,
+      format      =>q( ($1 =~ /^Non/)
+          ? 'None'
+          : ($1 =~ /^H/ ? 'Hostname' : 'NoCredentials' )
+          )
+    },
+    category    => 'web',
+  },
+  {
     name        => 'ZM_WEB_H_REFRESH_MAIN',
     default     => '60',
     introduction => q`

--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -487,14 +487,20 @@ private $control_fields = array(
       $source = preg_replace( '/^.*\//', '', $this->{'Path'} );
     } elseif ( $this->{'Type'} == 'Ffmpeg' || $this->{'Type'} == 'Libvlc' || $this->{'Type'} == 'WebSite' ) {
       $url_parts = parse_url( $this->{'Path'} );
-      unset($url_parts['user']);
-      unset($url_parts['pass']);
-      #unset($url_parts['scheme']);
-      unset($url_parts['query']);
-      #unset($url_parts['path']);
-      if ( isset($url_parts['port']) and ( $url_parts['port'] == '80' or $url_parts['port'] == '554' ) )
-        unset($url_parts['port']);
-      $source = unparse_url($url_parts);
+      if ( ZM_WEB_FILTER_SOURCE == "Hostname" ) { # Filter out everything but the hostname
+        $source = $url_parts['host'];
+      } elseif ( ZM_WEB_FILTER_SOURCE == "NoCredentials" ) { # Filter out sensitive and common items
+        unset($url_parts['user']);
+        unset($url_parts['pass']);
+        #unset($url_parts['scheme']);
+        unset($url_parts['query']);
+        #unset($url_parts['path']);
+        if ( isset($url_parts['port']) and ( $url_parts['port'] == '80' or $url_parts['port'] == '554' ) )
+          unset($url_parts['port']);
+        $source = unparse_url($url_parts);
+      } else { # Don't filter anything 
+        $source = $this->{'Path'};
+      }
     }
     if ( $source == '' ) {
       $source = 'Monitor ' . $this->{'Id'};


### PR DESCRIPTION
This PR adds a new variable WEB_FILTER_SOURCE to Options -> Web.

This option filters the information shown on the web console source column in different ways.

It presents three levels of filtering to choose from:
- None
- NoCredentials
- Hostname

Selecting None does no filtering as you might expect. Selecting NoCredentials filters in the same way that the master branch filters right now, and selecting Hostname filters the same way the previous 1.30.4 release does its filtering.
