### PR TITLE
fixed getCredentials not working if called directly

### DIFF
--- a/web/api/app/Controller/AppController.php
+++ b/web/api/app/Controller/AppController.php
@@ -72,10 +72,8 @@ class AppController extends Controller {
     }
   // We need to reject methods that are not authenticated
   // besides login and logout
-    if (strcasecmp($this->params->controller, "host") && 
-        strcasecmp($this->params->action, "login") &&
+    if ( strcasecmp($this->params->action, "login") &&
         strcasecmp($this->params->action,"logout")) {
-
           if (!$this->Session->read('user.Username')) {
                 throw new UnauthorizedException(__('Not Authenticated'));
                 return;

--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -39,8 +39,8 @@ class HostController extends AppController {
     $zmOptAuth = $config['Config']['Value'];
 
     if ( $zmOptAuth == '1' ) {
-      require_once "../../../includes/auth.php";
 
+      require_once "../../../includes/auth.php";
       global $user;
       $user = $this->Session->read('user');
 
@@ -152,6 +152,8 @@ class HostController extends AppController {
     $isZmAuth = $this->Config->find('first',array('conditions' => array('Config.' . $this->Config->primaryKey => 'ZM_OPT_USE_AUTH')))['Config']['Value'];
 
     if ( $isZmAuth ) {
+      require_once "../../../includes/auth.php"; # in the event we directly call getCredentials.json
+      $this->Session->read('user'); # this is needed for command line/curl to recognize a session
       $zmAuthRelay = $this->Config->find('first',array('conditions' => array('Config.' . $this->Config->primaryKey => 'ZM_AUTH_RELAY')))['Config']['Value'];
       if ( $zmAuthRelay == 'hashed' ) {
         $zmAuthHashIps= $this->Config->find('first',array('conditions' => array('Config.' . $this->Config->primaryKey => 'ZM_AUTH_HASH_IPS')))['Config']['Value'];


### PR DESCRIPTION
Fixes following:
- If we directly call `getCredentails.json` as an API, it would fail as auth.php was not included
- Also turns out that for command line curl to work, the magic code is `$this->Session->read('user'); `
