### PR TITLE
Support quoting config variables

### DIFF
--- a/conf.d/01-system-paths.conf.in
+++ b/conf.d/01-system-paths.conf.in
@@ -50,4 +50,4 @@ ZM_PATH_SWAP=@ZM_TMPDIR@
 
 # Full path to optional arp binary
 # ZoneMinder will find the arp binary automatically on most systems
-ZM_PATH_ARP=@ZM_PATH_ARP@
+ZM_PATH_ARP="@ZM_PATH_ARP@"

--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -77,8 +77,7 @@ BEGIN {
   process_configfile($config_file);
 
   # Search for user created config files. If one or more are found then
-  # update the Config hash with those v
-    $server_id = dbFetchOne('SELECT Id FROM Servers WHERE Name=?', 'Id', array(ZM_SERVER_NAME));alues
+  # update the Config hash with those values
   if ( -d ZM_CONFIG_SUBDIR ) {
     if ( -R ZM_CONFIG_SUBDIR ) {
       foreach my $filename ( glob ZM_CONFIG_SUBDIR."/*.conf" ) {

--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -77,7 +77,8 @@ BEGIN {
   process_configfile($config_file);
 
   # Search for user created config files. If one or more are found then
-  # update the Config hash with those values
+  # update the Config hash with those v
+    $server_id = dbFetchOne('SELECT Id FROM Servers WHERE Name=?', 'Id', array(ZM_SERVER_NAME));alues
   if ( -d ZM_CONFIG_SUBDIR ) {
     if ( -R ZM_CONFIG_SUBDIR ) {
       foreach my $filename ( glob ZM_CONFIG_SUBDIR."/*.conf" ) {
@@ -149,7 +150,7 @@ BEGIN {
       foreach my $str ( <$CONFIG> ) {
         next if ( $str =~ /^\s*$/ );
         next if ( $str =~ /^\s*#/ );
-        my ( $name, $value ) = $str =~ /^\s*([^=\s]+)\s*=\s*(.*?)\s*$/;
+        my ( $name, $value ) = $str =~ /^\s*([^=\s]+)\s*=\s*[\'"]*(.*?)[\'"]*\s*$/;
         if ( ! $name ) {
           print( STDERR "Warning, bad line in $config_file: $str\n" );
           next;

--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -123,9 +123,9 @@ void process_configfile( char* configFile) {
     if ( *line_ptr == '\0' || *line_ptr == '#' )
       continue;
 
-    // Remove trailing white space
+    // Remove trailing white space and trailing quotes
     char *temp_ptr = line_ptr+strlen(line_ptr)-1;
-    while ( *temp_ptr == ' ' || *temp_ptr == '\t' ) {
+    while ( *temp_ptr == ' ' || *temp_ptr == '\t' || *temp_ptr == '\'' || *temp_ptr == '\"') {
       *temp_ptr-- = '\0';
       temp_ptr--;
     }
@@ -147,8 +147,9 @@ void process_configfile( char* configFile) {
       temp_ptr--;
     } while ( *temp_ptr == ' ' || *temp_ptr == '\t' );
 
-    // Remove leading white space from the value part
+    // Remove leading white space and leading quotes from the value part
     white_len = strspn( val_ptr, " \t" );
+    white_len += strspn( val_ptr, "\'\"" );
     val_ptr += white_len;
 
     if ( strcasecmp( name_ptr, "ZM_DB_HOST" ) == 0 )

--- a/web/includes/config.php.in
+++ b/web/includes/config.php.in
@@ -212,7 +212,7 @@ function process_configfile($configFile) {
         continue;
       elseif ( preg_match( '/^\s*#/', $str ))
         continue;
-      elseif ( preg_match( '/^\s*([^=\s]+)\s*=\s*(.*?)\s*$/', $str, $matches ))
+      elseif ( preg_match( '/^\s*([^=\s]+)\s*=\s*[\'"]*(.*?)[\'"]*\s*$/', $str, $matches ))
         $configvals[$matches[1]] = $matches[2];
     }
     fclose( $cfg );


### PR DESCRIPTION
Looking into the following issue in the user forum revealed that ZoneMinder treats quotes as part of the string: https://forums.zoneminder.com/viewtopic.php?f=37&t=27435

This pr allows proper handling of quoted strings. It also surrounds zm_path_arp in quotes in the default config file because cmake can populate this at build time with "/path/to/ip neigh". 

One could make an argument that we should surround all config variables in  quotes by default, but I stopped short of doing that.
