### PR TITLE
optionhelp - support links markdown style

### DIFF
--- a/web/skins/classic/views/optionhelp.php
+++ b/web/skins/classic/views/optionhelp.php
@@ -22,6 +22,7 @@ $optionHelpIndex = preg_replace( '/^ZM_/', '', $_REQUEST['option'] );
 $optionHelpText = !empty($OLANG[$optionHelpIndex])?$OLANG[$optionHelpIndex]['Help']:$config[$_REQUEST['option']]['Help'];
 $optionHelpText = validHtmlStr($optionHelpText);
 $optionHelpText = preg_replace( "/~~/", "<br/>", $optionHelpText );
+$optionHelpText = preg_replace( "/\[(.+)\]\((.+)\)/", "<a href=\"$2\" target=\"_blank\">$1</a>", $optionHelpText );
 
 $focusWindow = true;
 


### PR DESCRIPTION
This one-liner adds support for html links, markdown style, embedded in ZoneMinder's Option Help text.

Post 1.32 release, this could be expanded to use a php markdown library if we want make full use of markdown, but I don't want to open up a bigger can of worms than I have to right now.

This PR is being driven by a need to allow users to re-read the new Privacy text, after they have already accepted/declined it, by clicking on a link embedded in the ZM_TELEMETRY_DATA help text.

@connortechnology @pliablepixels Thoughts? I am all for any other ways to navigate to the privacy view.