### PR TITLE
use short header on montage

### DIFF
--- a/web/skins/classic/views/montage.php
+++ b/web/skins/classic/views/montage.php
@@ -132,10 +132,21 @@ foreach( $displayMonitors as &$row ) {
 xhtmlHeaders(__FILE__, translate('Montage'));
 ?>
 <body>
-  <div id="page">
-    <?php echo getNavBarHTML() ?>
+  <div id="page">   
+    <div class="navbar navbar-inverse navbar-static-top"> <!-- Begin Short Header -->
+      <div class="navbar-brand">
+        <a href="<?php echo ZM_HOME_URL?>" target="<?php echo ZM_WEB_TITLE ?>"><?php echo ZM_HOME_CONTENT ?></a>
+      </div>
+      <ul class="nav navbar-nav">
+        <li><a class="nav navbar-nav" href="?view=console"><?php echo translate('Console') ?></a></li>
+        <li><a href="?view=options"><?php echo translate('Options') ?></a></li>
+      </ul>
+      <button data-toggle="collapse" data-target="#collapseHeader" class="btn btn-default navbar-btn pull-right"><span class="glyphicon glyphicon-menu-hamburger"></span></button>
+    </div> <!-- End Short Header -->
+
     <div id="header">
-      <div id="headerButtons">
+      <div id="collapseHeader" class="collapse in">
+        <div id="headerButtons">
 <?php
 if ( $showControl ) {
 ?>
@@ -188,8 +199,9 @@ if ( $showZones ) {
         </form>
       </div>
     </div>
-    <div id="content">
-      <div id="monitors">
+  </div>
+  <div id="content">
+    <div id="monitors">
 <?php
 foreach ( $monitors as $monitor ) {
   $connkey = $monitor->connKey(); // Minor hack


### PR DESCRIPTION
This PR makes an attempt to recover some screen real estate from the montage view. 

Two things have been done:
1) The ZoneMinder navbar has been stripped down to just a few items
2) A hamburger icon has been added to the right, which allows the user to collapse the layout editing fields.

The decision to keep some navbar items and remove others was mostly subjective. 
Some items, like the running status and version of zoneminder, didn't make it because they required additional logic, which muddied up montage.php even further.

Feedback is welcome. 
Optionally, I could remove the remaining navbar items and just have a "back" link to go back to the console.

Screenshot showing the new menu with layout fields expanded (default):
![short-header-expanded](https://user-images.githubusercontent.com/5150042/45268886-844c3800-b449-11e8-986c-fd74e73e5b37.png)

Screenshot showing the new menu with layout fields collapsed:
![short-header-collapsed](https://user-images.githubusercontent.com/5150042/45268889-8e6e3680-b449-11e8-8154-26e9058f2782.png)
