### PR TITLE
Fix 2213

### DIFF
--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -386,7 +386,7 @@ MAIN: while( $loop ) {
       } # if USE_DEEP_STORAGE
       Debug( 'Got '.int(keys(%$fs_events))." filesystem events for monitor $monitor_dir\n" );
 
-      delete_empty_directories($$Storage{Path}.'/'.$monitor_dir);
+      delete_empty_subdirs($$Storage{Path}.'/'.$monitor_dir);
     } # end foreach monitor
 
     if ( $cleaned ) {
@@ -883,6 +883,24 @@ sub deleteSwapImage {
     Debug( "Deleting $file" );
     unlink( $file );
   }
+}
+
+# Deletes empty sub directories of the given path.
+# Does not delete the path if empty. Is not meant to be recursive.
+sub delete_empty_subdirs {
+  my $DIR;
+  if ( !opendir($DIR, $_[0]) ) {
+    Error("delete_empty_directories: Can't open directory '".getcwd()."/$_[0]': $!" );
+    return;
+  }
+  my @contents = map { ( $_ eq '.' or $_ eq '..' ) ? () : $_ } readdir( $DIR );
+  Debug("delete_empty_subdirectories $_[0] has " . @contents .' entries:' . ( @contents < 2 ? join(',',@contents) : '' ));
+  my @dirs = map { -d $_[0].'/'.$_ ? $_ : () } @contents;
+  Debug("Have " . @dirs . " dirs");
+  foreach ( @dirs ) {
+    delete_empty_directories( $_[0].'/'.$_ );
+  }
+  closedir($DIR);
 }
 
 sub delete_empty_directories {

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -120,9 +120,15 @@ Event::Event(
 
   char id_file[PATH_MAX];
 
+  char *path_ptr = path;
+  path_ptr += snprintf(path_ptr, sizeof(path), "%s/%d", storage->Path(), monitor->Id());
+  // Try to make the Monitor Dir.  Normally this would exist, but in odd cases might not.
+  if ( mkdir(path, 0755) ) {
+    if ( errno != EEXIST )
+      Error("Can't mkdir %s: %s", path, strerror(errno));
+  }
+
   if ( storage->Scheme() == Storage::DEEP ) {
-    char *path_ptr = path;
-    path_ptr += snprintf(path_ptr, sizeof(path), "%s/%d", storage->Path(), monitor->Id());
 
     int dt_parts[6];
     dt_parts[0] = stime->tm_year-100;
@@ -155,28 +161,24 @@ Event::Event(
     if ( symlink(time_path, id_file) < 0 )
       Error("Can't symlink %s -> %s: %s", id_file, path, strerror(errno));
   } else if ( storage->Scheme() == Storage::MEDIUM ) {
-    char *path_ptr = path;
     path_ptr += snprintf(
-        path_ptr, sizeof(path), "%s/%d/%04d-%02d-%02d",
-        storage->Path(), monitor->Id(), stime->tm_year+1900, stime->tm_mon+1, stime->tm_mday
+        path_ptr, sizeof(path), "/%04d-%02d-%02d",
+        stime->tm_year+1900, stime->tm_mon+1, stime->tm_mday
         );
     if ( mkdir(path, 0755) ) {
-      // FIXME This should not be fatal.  Should probably move to a different storage area.
       if ( errno != EEXIST )
         Error("Can't mkdir %s: %s", path, strerror(errno));
     }
     path_ptr += snprintf(path_ptr, sizeof(path), "/%" PRIu64, id);
     if ( mkdir(path, 0755) ) {
-      // FIXME This should not be fatal.  Should probably move to a different storage area.
       if ( errno != EEXIST )
         Error("Can't mkdir %s: %s", path, strerror(errno));
     }
   } else {
-    snprintf(path, sizeof(path), "%s/%d/%" PRIu64, storage->Path(), monitor->Id(), id);
+    path_ptr += snprintf(path, sizeof(path), "/%" PRIu64, id);
     if ( mkdir(path, 0755) ) {
-      if ( errno != EEXIST ) {
+      if ( errno != EEXIST )
         Error("Can't mkdir %s: %s", path, strerror(errno));
-      }
     }
 
     // Create empty id tag file


### PR DESCRIPTION
fix #2213 

Two approaches.  First in zm_event, we will try to create the monitor dir if it doesn't exist.
Second in zmaudit we will use delete_empty_subdirs on the monitor dir, which will NOT delete the monitor dir if it is empty.