### PR TITLE
Touch lockfile

### DIFF
--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -755,6 +755,12 @@ void EventStream::runStream() {
     // commands may set send_frame to true
     while(checkCommandQueue());
 
+    // Update modified time of the socket .lock file so that we can tell which ones are stale.
+    if ( now.tv_sec - last_comm_update.tv_sec > 3600 ) {
+      touch(sock_path_lock);
+      last_comm_update = now;
+    }
+
     if ( step != 0 )
       curr_frame_id += step;
 

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -531,6 +531,12 @@ void MonitorStream::runStream() {
 Debug(2, "Have checking command Queue for connkey: %d", connkey );
         got_command = true;
       }
+      // Update modified time of the socket .lock file so that we can tell which ones are stale.
+      if ( now.tv_sec - last_comm_update.tv_sec > 3600 ) {
+        touch(sock_path_lock);
+        last_comm_update = now;
+      }
+
     }
 
     if ( paused ) {

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -313,6 +313,8 @@ void StreamBase::openComms() {
     snprintf(rem_sock_path, sizeof(rem_sock_path), "%s/zms-%06dw.sock", staticConfig.PATH_SOCKS.c_str(), connkey);
     strncpy(rem_addr.sun_path, rem_sock_path, sizeof(rem_addr.sun_path)-1);
     rem_addr.sun_family = AF_UNIX;
+
+    gettimeofday(&last_comm_update, NULL);
   } // end if connKey > 0
 	Debug(2, "comms open");
 } // end void StreamBase::openComms()

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -85,6 +85,7 @@ protected:
   int step;
 
   struct timeval now;
+  struct timeval last_comm_update;
 
   double base_fps;
   double effective_fps;

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <fcntl.h> /* Definition of AT_* constants */
+#include <sys/stat.h>
 #if defined(__arm__)
 #include <sys/auxv.h>
 #endif
@@ -412,5 +414,24 @@ std::string UriDecode( const std::string &encoded ) {
 Warning("ZM Compiled without LIBCURL.  UriDecoding not implemented.");
   return encoded;
 #endif
+}
+
+void touch(const char *pathname) {
+  int fd = open(pathname,
+      O_WRONLY|O_CREAT|O_NOCTTY|O_NONBLOCK,
+      0666);
+  if ( fd < 0 ) {
+    // Couldn't open that path.
+    Error("Couldn't open() path \"%s in touch", pathname);
+    return;
+  }
+  int rc = utimensat(AT_FDCWD,
+      pathname,
+      nullptr,
+      0);
+  if ( rc ) {
+    Error("Couldn't utimensat() path %s in touch", pathname);
+    return;
+  }
 }
 

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -63,5 +63,5 @@ extern unsigned int neonversion;
 
 char *timeval_to_string( struct timeval tv );
 std::string UriDecode( const std::string &encoded );
-
+void touch( const char *pathname );
 #endif // ZM_UTILS_H


### PR DESCRIPTION
zms clutters up ZM_SOCK_DIR with .lock files.  This code touches these files every hour while zms is running, so that we can clean out anything older than that.