### PR TITLE
don't zmMemInvalidate when reloading monitors

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -323,12 +323,6 @@ sub loadMonitors {
   my $res = $sth->execute( $Config{ZM_SERVER_ID} ? $Config{ZM_SERVER_ID} : () )
     or Fatal( "Can't execute: ".$sth->errstr() );
   while( my $monitor = $sth->fetchrow_hashref() ) {
-# Check shared memory ok
-    if ( !zmMemVerify( $monitor ) ) {
-      zmMemInvalidate( $monitor );
-      next;
-    }
-
     $monitor->{LastState} = zmGetMonitorState( $monitor );
     $monitor->{LastEvent} = zmGetLastEvent( $monitor );
     $new_monitors{$monitor->{Id}} = $monitor;

--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -323,8 +323,10 @@ sub loadMonitors {
   my $res = $sth->execute( $Config{ZM_SERVER_ID} ? $Config{ZM_SERVER_ID} : () )
     or Fatal( "Can't execute: ".$sth->errstr() );
   while( my $monitor = $sth->fetchrow_hashref() ) {
-    $monitor->{LastState} = zmGetMonitorState( $monitor );
-    $monitor->{LastEvent} = zmGetLastEvent( $monitor );
+    if ( zmMemVerify( $monitor ) ) {
+        $monitor->{LastState} = zmGetMonitorState( $monitor );
+        $monitor->{LastEvent} = zmGetLastEvent( $monitor );
+    }
     $new_monitors{$monitor->{Id}} = $monitor;
   } # end while fetchrow
   %monitors = %new_monitors;


### PR DESCRIPTION
Zmtrigger has been observed to miss monitors that have been recently restarted as discuess in this forum thread and others: https://forums.zoneminder.com/viewtopic.php?p=107334

This PR resolves that by removing a redundant call to zmMemVerify in loadMonitors(). Calling zmMemVerify is handled in the main loop.

This PR should be tested as it seems possible this could cause other problems during different or abnormal conditions.