### PR TITLE
Fix 2229 get disk percent

### DIFF
--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -107,21 +107,17 @@ class HostController extends AppController {
       }
     }
 
-    $zm_dir_events = $this->Config->find('list', array(
-      'conditions' => array('Name' => 'ZM_DIR_EVENTS'),
-      'fields' => array('Name', 'Value')
-    ));
-    $zm_dir_events = $zm_dir_events['ZM_DIR_EVENTS' ];
+    $zm_dir_events = ZM_DIR_EVENTS;
 
     // Test to see if $zm_dir_events is relative or absolute
     if ('/' === "" || strrpos($zm_dir_events, '/', -strlen($zm_dir_events)) !== TRUE) {
       // relative - so add the full path
-      $zm_dir_events = Configure::read('ZM_PATH_WEB') . '/' . $zm_dir_events;
+      $zm_dir_events = ZM_PATH_WEB . '/' . $zm_dir_events;
     }
 
-    if ($mid) {
+    if ( $mid ) {
       // Get disk usage for $mid
-      $usage = shell_exec ("du -sh0 $zm_dir_events/$mid | awk '{print $1}'");
+      $usage = shell_exec("du -sh0 $zm_dir_events/$mid | awk '{print $1}'");
     } else {
       $monitors = $this->Monitor->find('all', array(
         'fields' => array('Id', 'Name', 'WebColour')

--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -101,8 +101,8 @@ class HostController extends AppController {
     $this->loadModel('Monitor');
 
     // If $mid is passed, see if it is valid
-    if ($mid) {
-      if (!$this->Monitor->exists($mid)) {
+    if ( $mid ) {
+      if ( !$this->Monitor->exists($mid) ) {
         throw new NotFoundException(__('Invalid monitor'));
       }
     }
@@ -110,14 +110,16 @@ class HostController extends AppController {
     $zm_dir_events = ZM_DIR_EVENTS;
 
     // Test to see if $zm_dir_events is relative or absolute
-    if ('/' === "" || strrpos($zm_dir_events, '/', -strlen($zm_dir_events)) !== TRUE) {
+    #if ('/' === "" || strrpos($zm_dir_events, '/', -strlen($zm_dir_events)) !== TRUE) {
+    if ( substr($zm_dir_events, 0, 1) != '/' ) {
       // relative - so add the full path
       $zm_dir_events = ZM_PATH_WEB . '/' . $zm_dir_events;
     }
 
     if ( $mid ) {
       // Get disk usage for $mid
-      $usage = shell_exec("du -sh0 $zm_dir_events/$mid | awk '{print $1}'");
+      Logger::Debug("Executing du -s0 $zm_dir_events/$mid | awk '{print $1}'");
+      $usage = shell_exec("du -s0 $zm_dir_events/$mid | awk '{print $1}'");
     } else {
       $monitors = $this->Monitor->find('all', array(
         'fields' => array('Id', 'Name', 'WebColour')


### PR DESCRIPTION
Fixes #2229 

Please note that this also fixes one inconsistency. When specifying mid, the output was in human format (112K for example).  This now returns it without the K, in Kb.

This does not fix the inconsistency that if mid is not specified, the outputs are in Mb.

Further it does not fix the fact that the data returned is NOT a percentage of anything.  Further, since we can now have multiple storage areas, a percentage would be meaningless unless broken down into per-storage area data.

A better way to get this data is to query the monitor or storage area or event data specifically.
http://localhost/zm/api/monitors/1.json will return a # of fields like TotalEvents and TotalEventDiskSpace.
http://localhost/zm/api/events/.json will return a list of events data, each event will have a DiskSpace piece of data and a storageId that can be used to generate totals and percentages.