### PR TITLE
implement loadMonitor sub

### DIFF
--- a/scripts/zmtrigger.pl.in
+++ b/scripts/zmtrigger.pl.in
@@ -109,7 +109,7 @@ foreach my $connection ( @in_select_connections ) {
 my %spawned_connections;
 my %monitors;
 my $monitor_reload_time = 0;
-my $needsReload = 0;
+my @needsReload;
 loadMonitors();
 
 $! = undef;
@@ -206,7 +206,7 @@ while( 1 ) {
     if ( ! zmMemVerify($monitor) ) {
       # Our attempt to verify the memory handle failed. We should reload the monitors.
       # Don't need to zmMemInvalidate because the monitor reload will do it.
-      $needsReload = 1;
+      push @needsReload, $monitor;
       next;
     }
 
@@ -293,20 +293,38 @@ while( 1 ) {
     }
   }
 
-# If necessary reload monitors
-  if ( $needsReload || ((time() - $monitor_reload_time) > MONITOR_RELOAD_INTERVAL )) {
+  # Reload all monitors from the dB every MONITOR_RELOAD_INTERVAL
+  if ( (time() - $monitor_reload_time) > MONITOR_RELOAD_INTERVAL ) {
     foreach my $monitor ( values(%monitors) ) {
-# Free up any used memory handle
-      zmMemInvalidate( $monitor );
+      zmMemInvalidate( $monitor ); # Free up any used memory handle
     }
     loadMonitors();
-    $needsReload = 0;
+    @needsReload = (); # We just reloaded all monitors so no need reload a specific monitor
+  # If we have NOT just reloaded all monitors, reload a specific monitor if its shared mem changed
+  } elsif ( @needsReload ) { 
+    foreach my $monitor ( @needsReload ) {
+      loadMonitor($monitor);
+    }
+    @needsReload = ();
   }
+
   # zmDbConnect will ping and reconnect if neccessary
   $dbh = zmDbConnect();
 } # end while ( 1 )
 Info( "Trigger daemon exiting\n" );
 exit;
+
+sub loadMonitor {
+  my $monitor = shift;
+
+  Debug( "Loading monitor $monitor\n" );
+  zmMemInvalidate( $monitor );
+
+  if ( zmMemVerify( $monitor ) ) { # This will re-init shared memory
+    $monitor->{LastState} = zmGetMonitorState( $monitor );
+    $monitor->{LastEvent} = zmGetLastEvent( $monitor );
+  }
+}
 
 sub loadMonitors {
   Debug( "Loading monitors\n" );
@@ -323,7 +341,7 @@ sub loadMonitors {
   my $res = $sth->execute( $Config{ZM_SERVER_ID} ? $Config{ZM_SERVER_ID} : () )
     or Fatal( "Can't execute: ".$sth->errstr() );
   while( my $monitor = $sth->fetchrow_hashref() ) {
-    if ( zmMemVerify( $monitor ) ) {
+    if ( zmMemVerify( $monitor ) ) { # This will re-init shared memory
         $monitor->{LastState} = zmGetMonitorState( $monitor );
         $monitor->{LastEvent} = zmGetLastEvent( $monitor );
     }


### PR DESCRIPTION
When zmtrigger detects a change in shared memory of a single monitor, it reloads all the monitors from the dB and re-inits the shared memory for each.  This causes a problem documented by @asker in our slack channel:

```
https://github.com/ZoneMinder/zoneminder/blob/master/scripts/zmtrigger.pl.in#L224-L225 and why I was missing many events when a monitor kept crashing. Assume a case where M1 keeps crashing.  On every tick, this will result in loadMonitors() being called for all monitors. Lets assume while loadMonitors() is called, M2 creates an alarm. During loadMonitors(), m2->{LastEvent} will contain the event ID. When we get back to the check linked above, the match will indicate that `$last_event` is indeed equal to `m2->{LastEvent}` and trigger won't work. It will assume it was already processed, when it has not processed it. To avoid this, I kept my own list of last events processed in my notification server so they don't get messed up when monitors are reloaded. I now keep my own hash and have changed the condition like so: https://github.com/pliablepixels/zmeventserver/blob/master/zmeventnotification.pl#L615-L616 
```

This PR fixes the problem a little differently that the way @asker fixed it in his eventserver.

Instead of reloading all monitors anytime a single monitor needs to be reloaded, this PR implements `loadMonitor()` *singular*, which reloads just the particular monitor whose shared memory has changed, as the name implies. This should fix the problem where zmtrigger is missing events from the other, unaffected monitors.

This has been tested to run, but this still needs to be tested more thoroughly to verify no new problems are created. For example, there may be a need to slow down the process if zmtrigger is trying too hard to constantly restart a monitor that has been stopped or continually failing.