### PR TITLE
don't build neon instructions on armel

### DIFF
--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -3317,11 +3317,11 @@ __attribute__((noinline)) void std_fastblend(const uint8_t* col1, const uint8_t*
 }
 
 /* FastBlend Neon for AArch32 */
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_fastblend(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count, double blendpercent) {
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
   static int8_t divider = 0;
   static double current_blendpercent = 0.0;
 
@@ -3708,11 +3708,11 @@ __attribute__((noinline)) void std_delta8_abgr(const uint8_t* col1, const uint8_
 }
 
 /* Grayscale Neon for AArch32 */
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_delta8_gray8(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count) {
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
 
   /* Q0(D0,D1)   = col1+0 */
   /* Q1(D2,D3)   = col1+16 */
@@ -3784,11 +3784,11 @@ __attribute__((noinline)) void neon64_armv8_delta8_gray8(const uint8_t* col1, co
 }
 
 /* RGB32 Neon for AArch32 */
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_delta8_rgb32(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count, uint32_t multiplier) {
-#if (defined(__arm__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
 
   /* Q0(D0,D1)   = col1+0 */
   /* Q1(D2,D3)   = col1+16 */


### PR DESCRIPTION
fixes #2241 

Neon instructions are not available on armel architecture.

According to the Debian wiki, the `__armel__` preprocessor macro should be set, and we should be able to check for this: https://wiki.debian.org/ArchitectureSpecificsMemo


@onlyjob Note that I do not have a way to test this.