### PR TITLE
check for __ARM_PCS_VFP instead of __armel__

### DIFF
--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -3317,11 +3317,11 @@ __attribute__((noinline)) void std_fastblend(const uint8_t* col1, const uint8_t*
 }
 
 /* FastBlend Neon for AArch32 */
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_fastblend(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count, double blendpercent) {
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
   static int8_t divider = 0;
   static double current_blendpercent = 0.0;
 
@@ -3708,11 +3708,11 @@ __attribute__((noinline)) void std_delta8_abgr(const uint8_t* col1, const uint8_
 }
 
 /* Grayscale Neon for AArch32 */
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_delta8_gray8(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count) {
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
 
   /* Q0(D0,D1)   = col1+0 */
   /* Q1(D2,D3)   = col1+16 */
@@ -3784,11 +3784,11 @@ __attribute__((noinline)) void neon64_armv8_delta8_gray8(const uint8_t* col1, co
 }
 
 /* RGB32 Neon for AArch32 */
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
 __attribute__((noinline,__target__("fpu=neon")))
 #endif
 void neon32_armv7_delta8_rgb32(const uint8_t* col1, const uint8_t* col2, uint8_t* result, unsigned long count, uint32_t multiplier) {
-#if (defined(__arm__) && !defined(__armel__) && !defined(ZM_STRIP_NEON))
+#if (defined(__arm__) && defined(__ARM_PCS_VFP) && !defined(ZM_STRIP_NEON))
 
   /* Q0(D0,D1)   = col1+0 */
   /* Q1(D2,D3)   = col1+16 */


### PR DESCRIPTION
According to the Debian wiki, `__ARM_PCS_VFP` flag is set for armhf but not armel, so let's use this pre-processor macro instead of `__armel__` .
https://wiki.debian.org/ArchitectureSpecificsMemo

Please don't merge until we heard from @onlyjob this works.

I checked my raspi3 running fedora 28 and the __ARM_PCS_VFP flag is set also (what we want) so it does not appear this will exclude neon instructions in situations where the cpu supports it. @mastertheknife if you could spare a moment, it would be nice to know if you agree.

