### PR TITLE
align to native instead hardcoded value

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
@@ -207,7 +207,8 @@ sub zmMemInit {
           || $member_data->{type} eq 'uint64'
           || $member_data->{type} eq 'time_t64'
           ) {
-        $member_data->{size} = $member_data->{align} = 8;
+        $member_data->{size} = 8;
+        $member_data->{align} = $native;
       } elsif ( $member_data->{type} eq 'int32'
           || $member_data->{type} eq 'uint32'
           || $member_data->{type} eq 'bool4'


### PR DESCRIPTION
Solved error "zmwatch[5843]: ERR [Shared data size conflict in shared_data for monitor demisol, expected 608, got 604]" pn 23bit, change looks to be 64bit compatible, but someone needs to check it first.