### PR TITLE
show event notes in same event view

### DIFF
--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -191,7 +191,8 @@ while ( $event_row = dbFetchNext($results) ) {
               <td class="colId"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1"> '.$event->Id().($event->Archived()?'*':'') ?></a></td>
               <td class="colName"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1"> '.validHtmlStr($event->Name()).($event->Archived()?'*':'') ?></a></td>
               <td class="colMonitorName"><?php echo makePopupLink( '?view=monitor&amp;mid='.$event->MonitorId(), 'zmMonitor'.$event->Monitorid(), 'monitor', $event->MonitorName(), canEdit( 'Monitors' ) ) ?></td>
-              <td class="colCause"><?php echo makePopupLink( '?view=eventdetail&amp;eid='.$event->Id(), 'zmEventDetail', 'eventdetail', validHtmlStr($event->Cause()), canEdit( 'Events' ), 'title="'.htmlspecialchars($event->Notes()).'"' ) ?></td>
+              <td class="colCause"><?php echo makePopupLink( '?view=eventdetail&amp;eid='.$event->Id(), 'zmEventDetail', 'eventdetail', validHtmlStr($event->Cause()), canEdit( 'Events' ), 'title="'.htmlspecialchars($event->Notes()).'"' ) ?>
+                    <?php if ($event->Notes() && ($event->Notes() != 'Forced Web: ')) echo "<br/><div class=\"small text-nowrap text-muted\">".$event->Notes()."</div>" ?></td>
               <td class="colTime"><?php echo strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->StartTime())) . 
 ( $event->EndTime() ? ' until ' . strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->EndTime()) ) : '' ) ?>
               </td>


### PR DESCRIPTION
This PR adds the notes field along with cause. I think its important to show the reason along with the cause. ZM adds useful information like "Motion: <zonename>" and with the ES object detection add on , its even more useful. Doesn't warrant a new column as it will take up space when there is no need.

I've excluded "Forced Web: " as this gets repeated in Cause and Notes which is of no use. This text is not language translated. Its [part of ](https://github.com/ZoneMinder/zoneminder/blob/10531df54312f52f0f32adec3d4720c063897b62/src/zmu.cpp#L562) zmu.cpp

Screenshot enhanced with object detection notes:

![screen shot 2018-10-16 at 11 55 14 am](https://user-images.githubusercontent.com/4116654/47030003-c8aeb000-d13a-11e8-8c72-7da317ffaa81.png)

Regular ZM screenshot:

![screen shot 2018-10-16 at 12 00 19 pm](https://user-images.githubusercontent.com/4116654/47030140-1a573a80-d13b-11e8-8f6c-f2b58a401847.png)
