### PR TITLE
Include the remoteAddr in the session authhash cache, so that a chang…

### DIFF
--- a/web/includes/auth.php
+++ b/web/includes/auth.php
@@ -116,7 +116,7 @@ function generateAuthHash($useRemoteAddr, $force=false) {
     $time = time();
     $mintime = $time - ( ZM_AUTH_HASH_TTL * 1800 );
 
-    if ( $force or ( !isset($_SESSION['AuthHash']) ) or ( $_SESSION['AuthHashGeneratedAt'] < $mintime ) ) {
+    if ( $force or ( !isset($_SESSION['AuthHash'.$_SESSION['remoteAddr']]) ) or ( $_SESSION['AuthHashGeneratedAt'] < $mintime ) ) {
       # Don't both regenerating Auth Hash if an hour hasn't gone by yet
       $local_time = localtime();
       $authKey = '';
@@ -133,7 +133,7 @@ function generateAuthHash($useRemoteAddr, $force=false) {
           session_start();
           $close_session = 1;
         }
-        $_SESSION['AuthHash'] = $auth;
+        $_SESSION['AuthHash'.$_SESSION['remoteAddr']] = $auth;
         $_SESSION['AuthHashGeneratedAt'] = $time;
         session_write_close();
       } else {
@@ -143,7 +143,7 @@ function generateAuthHash($useRemoteAddr, $force=false) {
       #} else {
       #Logger::Debug("Using cached auth " . $_SESSION['AuthHash'] ." beacuse generatedat:" . $_SESSION['AuthHashGeneratedAt'] . ' < now:'. $time . ' - ' .  ZM_AUTH_HASH_TTL . ' * 1800 = '. $mintime);
     } # end if AuthHash is not cached
-    return $_SESSION['AuthHash'];
+    return $_SESSION['AuthHash'.$_SESSION['remoteAddr']];
   } # end if using AUTH and AUTH_RELAY
   return '';
 }


### PR DESCRIPTION
…e of ip won't allow the same useless auth hash.

If your remote ip changes, but your session id cookie doesn't, we won't recalculate the auth hash.
This fixes that by including the remote ip in the key into the session. Thus a new auth hash will be generated on ip change.