### PR TITLE
Workaround for php built without semaphore support

### DIFF
--- a/web/ajax/stream.php
+++ b/web/ajax/stream.php
@@ -10,6 +10,30 @@ if ( !($_REQUEST['connkey'] && $_REQUEST['command']) ) {
   ajaxError( "Unexpected received message type '$type'" );
 }
 
+if (!function_exists('sem_get')) {
+  function sem_get($key) {
+    return fopen(__FILE__ . '.sem.' . $key, 'w+');
+  }
+  function sem_acquire($sem_id) {
+    return flock($sem_id, LOCK_EX);
+  }
+  function sem_release($sem_id) {
+    return flock($sem_id, LOCK_UN);
+  }
+}
+
+if( !function_exists('ftok') ){
+  function ftok($filename = "", $proj = "") {
+    if( empty($filename) || !file_exists($filename) ) {
+      return -1;
+    } else {
+      $filename = $filename . (string) $proj;
+      for($key = array(); sizeof($key) < strlen($filename); $key[] = ord(substr($filename, sizeof($key), 1)));
+      return dechex(array_sum($key));
+    }
+  }
+}
+
 # The file that we point ftok to has to exist, and only exist if zms is running, so we are pointing it at the .sock
 $key = ftok(ZM_PATH_SOCKS.'/zms-'.sprintf('%06d',$_REQUEST['connkey']).'s.sock', 'Z');
 $semaphore = sem_get($key,1);


### PR DESCRIPTION
Not all php builds include support for semaphores.
Since zm now depends on semaphore support, it is necessary to
add facility to support this where it is not possible
to replace the distribution's build of php.