### PR TITLE
API - Disable E_NOTICE from php error reporting in cake debug

### DIFF
--- a/web/api/app/Config/core.php.default
+++ b/web/api/app/Config/core.php.default
@@ -50,7 +50,7 @@
  */
 	Configure::write('Error', array(
 		'handler' => 'ErrorHandler::handleError',
-		'level' => E_ALL & ~E_DEPRECATED,
+		'level' => E_ALL & ~E_DEPRECATED & ~E_NOTICE,
 		'trace' => true
 	));
 


### PR DESCRIPTION
Using zmNinja, the API reports E_NOTICE errors

```
Notice (8): compact(): Undefined variable: subject [CORE/Cake/Utility/ObjectCollection.php, line 128]
Notice (8): compact() [<a href='http://php.net/function.compact'>function.compact</a>]: Undefined variable: subject [CORE/Cake/Utility/ObjectCollection.php, line 128]
Notice (8): compact() [<a href='http://php.net/function.compact'>function.compact</a>]: Undefined variable: subject [CORE/Cake/Utility/ObjectCollection.php, line 128]
Notice (8): compact() [<a href='http://php.net/function.compact'>function.compact</a>]: Undefined variable: subject [CORE/Cake/Utility/ObjectCollection.php, line 128]
```

and zmNinja will not work...
there is a better way, but i think disabling E_NOTICE error is way easier

see: https://github.com/ZoneMinder/zoneminder/pull/2269