### PR TITLE
Av logging

### DIFF
--- a/src/zm.h
+++ b/src/zm.h
@@ -17,9 +17,6 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 // 
 
-#if !defined(PATH_MAX)
-#define PATH_MAX 1024
-#endif
 
 #ifndef ZM_H
 #define ZM_H

--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -20,6 +20,7 @@
 #ifndef ZM_COMMS_H
 #define ZM_COMMS_H
 
+#include "zm_logger.h"
 #include "zm_exception.h"
 
 #include <string.h>

--- a/src/zm_config.h.in
+++ b/src/zm_config.h.in
@@ -20,9 +20,11 @@
 #ifndef ZM_CONFIG_H
 #define ZM_CONFIG_H
 
+#if !defined(PATH_MAX)
+#define PATH_MAX 1024
+#endif
 #include "config.h"
 #include "zm_config_defines.h"
-#include "zm.h"
 
 #include <string>
 

--- a/src/zm_exception.h
+++ b/src/zm_exception.h
@@ -20,8 +20,6 @@
 #ifndef ZM_EXCEPTION_H
 #define ZM_EXCEPTION_H
 
-#include "zm.h"
-
 #include <string>
 
 class Exception

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -24,14 +24,47 @@
 
 #if HAVE_LIBAVCODEC || HAVE_LIBAVUTIL || HAVE_LIBSWSCALE
 
+void log_libav_callback( void *ptr, int level, const char *fmt, va_list vargs ) {
+  Logger *log = Logger::fetch();
+  int log_level = 0;
+  if ( level == AV_LOG_QUIET ) { // -8
+    log_level = Logger::NOLOG;
+  } else if ( level == AV_LOG_PANIC ) { //0
+    log_level = Logger::PANIC;
+  } else if ( level == AV_LOG_FATAL ) { // 8
+    log_level = Logger::FATAL;
+  } else if ( level == AV_LOG_ERROR ) { // 16
+    log_level = Logger::ERROR;
+  } else if ( level == AV_LOG_WARNING ) { //24
+    log_level = Logger::WARNING;
+  } else if ( level == AV_LOG_INFO ) { //32
+    log_level = Logger::INFO;
+  } else if ( level == AV_LOG_VERBOSE ) { //40
+    log_level = Logger::DEBUG1;
+  } else if ( level == AV_LOG_DEBUG ) { //48
+    log_level = Logger::DEBUG2;
+  } else if ( level == AV_LOG_TRACE ) {
+    log_level = Logger::DEBUG8;
+  } else if ( level == AV_LOG_MAX_OFFSET ) {
+    log_level = Logger::DEBUG9;
+  } else {
+    Error("Unknown log level %d", level);
+  }
+
+  if ( log ) {
+    log->logPrint(false, __FILE__, __LINE__, log_level, fmt, vargs);
+  }
+}
+
 void FFMPEGInit() {
   static bool bInit = false;
 
   if ( !bInit ) {
-    //if ( logDebugging() )
-      //av_log_set_level( AV_LOG_DEBUG ); 
-    //else
+    if ( logDebugging() )
+      av_log_set_level( AV_LOG_DEBUG ); 
+    else
       av_log_set_level( AV_LOG_QUIET ); 
+    av_log_set_callback(log_libav_callback); 
     av_register_all();
     avformat_network_init();
     bInit = true;

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -56,7 +56,9 @@ void log_libav_callback( void *ptr, int level, const char *fmt, va_list vargs ) 
   }
 
   if ( log ) {
-    log->logPrint(false, __FILE__, __LINE__, log_level, fmt, vargs);
+    char            logString[8192];
+    vsnprintf(logString, sizeof(logString)-1, fmt, vargs);
+    log->logPrint(false, __FILE__, __LINE__, log_level, logString);
   }
 }
 

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -43,10 +43,14 @@ void log_libav_callback( void *ptr, int level, const char *fmt, va_list vargs ) 
     log_level = Logger::DEBUG1;
   } else if ( level == AV_LOG_DEBUG ) { //48
     log_level = Logger::DEBUG2;
+#ifdef AV_LOG_TRACE
   } else if ( level == AV_LOG_TRACE ) {
     log_level = Logger::DEBUG8;
+#endif
+#ifdef AV_LOG_MAX_OFFSET
   } else if ( level == AV_LOG_MAX_OFFSET ) {
     log_level = Logger::DEBUG9;
+#endif
   } else {
     Error("Unknown log level %d", level);
   }

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -581,6 +581,7 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
   }
 }
 
+
 void logInit(const char *name, const Logger::Options &options) {
   if ( !Logger::smInstance )
     Logger::smInstance = new Logger();

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -444,6 +444,7 @@ void Logger::closeSyslog() {
 void Logger::logPrint( bool hex, const char * const filepath, const int line, const int level, const char *fstring, ... ) {
   if ( level > mEffectiveLevel ) 
     return;
+  log_mutex.lock();
   char            timeString[64];
   char            logString[8192];
   va_list         argPtr;
@@ -579,6 +580,7 @@ void Logger::logPrint( bool hex, const char * const filepath, const int line, co
       abort();
     exit(-1);
   }
+  log_mutex.unlock();
 }
 
 

--- a/src/zm_logger.h
+++ b/src/zm_logger.h
@@ -30,6 +30,8 @@
 #endif // HAVE_SYS_SYSCALL_H
 #include <mysql/mysql.h>
 
+#include "zm_thread.h"
+
 class Logger {
 public:
   enum { 
@@ -81,6 +83,8 @@ public:
 private:
   static bool smInitialised;
   static Logger *smInstance;
+
+  RecursiveMutex log_mutex;
 
   static StringMap smCodes;
   static IntMap smSyslogPriorities;

--- a/src/zm_thread.h
+++ b/src/zm_thread.h
@@ -20,9 +20,12 @@
 #ifndef ZM_THREAD_H
 #define ZM_THREAD_H
 
+class RecursiveMutex;
+
+
+#include "zm_config.h"
 #include <unistd.h>
 #include <pthread.h>
-#include <unistd.h>
 #ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
 #endif // HAVE_SYS_SYSCALL_H


### PR DESCRIPTION
This PR redirects the logging output from libavcodec into our own logging functions.
Along the way, I had to put a mutex in logPrint because multi-threaded codecs will log concurrently.  
This required some cleanup of various includes.