### PR TITLE
Fix unreadable input text when OS theme dark

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -150,6 +150,7 @@ input,textarea,select,button,.btn-primary {
     font-weight: 400;
     font-size: 100%;
     color: #333333;
+    background-color: #f8f8f8;
     text-align: left;
     border-radius:4px;
 }

--- a/web/skins/classic/css/classic/skin.css
+++ b/web/skins/classic/css/classic/skin.css
@@ -85,7 +85,8 @@ input,textarea,select,button {
     border: 1px #7f7fb2 solid;
     font-family: inherit;
     font-size: 100%;
-    color: #333333;
+    color: #333333;  
+    background-color: #eeeeee;
 }
 
 input[type=text], input[type=password], textarea {


### PR DESCRIPTION
The skins `classic/base` and `classic/classic` override the text color in input boxes, but don't override the background color. If the OS / browser theme is set to dark, default text is light and default background is dark. Overriding only the text creates dark-on-dark input boxes.

I'm no designer - this just sets some light color value so that things become readable...