### PR TITLE
support for forwarded proto/port in Server.php

### DIFF
--- a/web/includes/Server.php
+++ b/web/includes/Server.php
@@ -62,7 +62,12 @@ class Server {
     if ( isset($this->{'Protocol'}) and ( $this->{'Protocol'} != '' ) ) {
       return $this->{'Protocol'};
     }
-    return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? 'https' : 'http';
+
+    return  ( 
+              ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' )
+              or
+              ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and ( $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) )
+            ) ? 'https' : 'http';
   }
 
   public function Port( $new = '' ) {
@@ -72,6 +77,11 @@ class Server {
     if ( isset($this->{'Port'}) and $this->{'Port'} ) {
       return $this->{'Port'};
     }
+
+    if ( isset($_SERVER['HTTP_X_FORWARDED_PORT']) ) {
+      return $_SERVER['HTTP_X_FORWARDED_PORT'];
+    }
+
     return $_SERVER['SERVER_PORT'];
   }
 


### PR DESCRIPTION
I've been having the same problems as in #2339, where I can't view streams behind a reverse proxy.  I've updated the Protocol and Port functions in Server.php to respect HTTP_X_FORWARDED_PROTO and HTTP_X_FORWARDED_PORT and everything works OK for me (although, it'd be nice if HTTP_X_FORWARDED_PORT wasn't necessary because it's rarely set in a reverse proxy situation).