### PR TITLE
Ffmpeg logs optional

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -1202,6 +1202,20 @@ our @options = (
     category    => 'logging',
   },
   {
+    name        => 'ZM_LOG_FFMPEG',
+    default     => 'yes',
+    description => 'Log FFMPEG messages',
+    help        => q`
+       When enabled (default is on), this option will log FFMPEG messages.
+       FFMPEG messages can be useful when debugging streaming issues. However,
+       depending on your distro and FFMPEG version, this may also result in 
+       more logs than you'd typically like to see. If all your streams are working
+       well, you may choose to turn this off.
+      `,
+    type        => $types{boolean},
+    category    => 'logging',
+  },
+{
     name        => 'ZM_LOG_DEBUG',
     default     => 'no',
     description => 'Switch debugging on',

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -76,7 +76,7 @@ void FFMPEGInit() {
     if ( config.log_ffmpeg ) 
         av_log_set_callback(log_libav_callback); 
     else
-        Log("Not enabling ffmpeg logs, as LOG_FFMPEG is disabled in options");
+        Info("Not enabling ffmpeg logs, as LOG_FFMPEG is disabled in options");
     av_register_all();
     avformat_network_init();
     bInit = true;

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -73,7 +73,10 @@ void FFMPEGInit() {
       av_log_set_level( AV_LOG_DEBUG ); 
     else
       av_log_set_level( AV_LOG_QUIET ); 
-    av_log_set_callback(log_libav_callback); 
+    if ( config.log_ffmpeg ) 
+        av_log_set_callback(log_libav_callback); 
+    else
+        Log("Not enabling ffmpeg logs, as LOG_FFMPEG is disabled in options");
     av_register_all();
     avformat_network_init();
     bInit = true;


### PR DESCRIPTION
Makes FFMPEG logging optional. On by default, so it doesn't change current behavior but lets those who don't want it turn it off. Specifically my logs are flooded with #2341 and also `invalid SAR` warnings.