### PR TITLE
make sure auth is regenerated each time we call login.json

### DIFF
--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -71,7 +71,8 @@ class HostController extends AppController {
       $zmAuthRelay = $this->Config->find('first',array('conditions' => array('Config.' . $this->Config->primaryKey => 'ZM_AUTH_RELAY')))['Config']['Value'];
       if ( $zmAuthRelay == 'hashed' ) {
         $zmAuthHashIps = $this->Config->find('first',array('conditions' => array('Config.' . $this->Config->primaryKey => 'ZM_AUTH_HASH_IPS')))['Config']['Value'];
-        $credentials = 'auth='.generateAuthHash($zmAuthHashIps);
+        // make sure auth is regenerated each time we call this API
+        $credentials = 'auth='.generateAuthHash($zmAuthHashIps,true);
       } else {
         // user will need to append the store password here
         $credentials = 'user='.$this->Session->read('user.Username').'&pass=';


### PR DESCRIPTION
Fixes https://github.com/pliablepixels/zmNinja/issues/758

As of today, `login.json` generate an auth hash the first time to create a session but reuses that same auth till PHP land code decides its time for a new auth. This is incorrect behavior as a "login" action  should _always_ reset the session timer or apps will have no way to refresh auth