### PR TITLE
update viewImagePatch

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -845,13 +845,7 @@ function getImageSrc( $event, $frame, $scale=SCALE_BASE, $captureOnly=false, $ov
 }
 
 function viewImagePath( $path, $querySep='&amp;' ) {
-  if ( strncmp( $path, ZM_DIR_IMAGES, strlen(ZM_DIR_IMAGES) ) == 0 ) {
-    // Thumbnails
-    return( $path );
-  } elseif ( strpos( ZM_DIR_EVENTS, '/' ) === 0 ) {
-    return( '?view=image'.$querySep.'path='.$path );
-  }
-  return( ZM_DIR_EVENTS.'/'.$path );
+  return( '?view=image'.$querySep.'path='.$path );
 }
 
 function createListThumbnail( $event, $overwrite=false ) {


### PR DESCRIPTION
This function is only ever used in frame.php, which is used twice to call up diagnostic images, if they exist, for a particular frame.

Since we have removed symlinks from the webroot and diagnostic images are stored with the event, the only legitimate return for this function is `'?view=image'.$querySep.'path='.$path`