### PR TITLE
force overloadframes and ExtendAlarmFrames to int

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -288,7 +288,13 @@ if ( !empty($_REQUEST['mid']) && canEdit('Monitors', $_REQUEST['mid']) ) {
     }
 
     unset( $_REQUEST['newZone']['Points'] );
-    $types = array();
+
+    # convert these fields to integer e.g. NULL -> 0
+    $types = array(
+        'OverloadFrames' => 'integer',
+        'ExtendAlarmFrames' => 'integer',
+        );
+
     $changes = getFormChanges($zone, $_REQUEST['newZone'], $types);
 
     if ( count($changes) ) {

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -608,6 +608,11 @@ function getFormChanges( $values, $newValues, $types=false, $columns=false ) {
           }
         }
         break;
+      case 'integer' :
+        if ( (!isset($values[$key])) or $values[$key] != $value ) {
+          $changes[$key] = $key . ' = '.intval($value);
+        }
+        break;
       default :
         {
           if ( !isset($values[$key]) || ($values[$key] != $value) ) {


### PR DESCRIPTION
This fixes a sql Integrity constraint violation which can occur in some environments when either overloadframes or ExtendAlarmFrames are NULL. This happens when the end user tries to create a new zone but does not place a value into one of these two fields. This PR converts the NULL value to 0, which avoids the constraint violation.