### PR TITLE
implement timezone check function

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2276,6 +2276,9 @@ function check_timezone() {
   if ( $sys_tzoffset != $mysql_tzoffset )
         Error("ZoneMinder is not installed properly: mysql's timezone does not match the system timezone! Event lists will display incorrect times.");
 
+  if (!ini_get('date.timezone') || !date_default_timezone_set(ini_get('date.timezone')))
+    Fatal( "ZoneMinder is not installed properly: php's date.timezone is not set to a valid timezone" );
+
 }
 
 function unparse_url($parsed_url, $substitutions = array() ) { 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2261,7 +2261,6 @@ function csrf_startup() {
 function check_timezone() {
   $now = new DateTime();
 
-  # Probably need to check the results of these for errors
   $sys_tzoffset = trim(shell_exec('date "+%z"'));
   $php_tzoffset = trim($now->format('O'));
   $mysql_tzoffset = trim(dbFetchOne("SELECT TIME_FORMAT(TIMEDIFF(NOW(), UTC_TIMESTAMP),'%H%i');",'TIME_FORMAT(TIMEDIFF(NOW(), UTC_TIMESTAMP),\'%H%i\')'));

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2271,10 +2271,10 @@ function check_timezone() {
                ");
 
   if ( $sys_tzoffset != $php_tzoffset )
-        Fatal("ZoneMinder is not installed properly: php's date.timezone does not match the system timezone!");
+    Fatal("ZoneMinder is not installed properly: php's date.timezone does not match the system timezone!");
 
   if ( $sys_tzoffset != $mysql_tzoffset )
-        Error("ZoneMinder is not installed properly: mysql's timezone does not match the system timezone! Event lists will display incorrect times.");
+    Error("ZoneMinder is not installed properly: mysql's timezone does not match the system timezone! Event lists will display incorrect times.");
 
   if (!ini_get('date.timezone') || !date_default_timezone_set(ini_get('date.timezone')))
     Fatal( "ZoneMinder is not installed properly: php's date.timezone is not set to a valid timezone" );

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2258,6 +2258,27 @@ function csrf_startup() {
     csrf_conf('rewrite-js', 'includes/csrf/csrf-magic.js');
 }
 
+function check_timezone() {
+  $now = new DateTime();
+
+  # Probably need to check the results of these for errors
+  $sys_tzoffset = trim(shell_exec('date "+%z"'));
+  $php_tzoffset = trim($now->format('O'));
+  $mysql_tzoffset = trim(dbFetchOne("SELECT TIME_FORMAT(TIMEDIFF(NOW(), UTC_TIMESTAMP),'%H%i');",'TIME_FORMAT(TIMEDIFF(NOW(), UTC_TIMESTAMP),\'%H%i\')'));
+
+  Logger::Debug("System timezone offset determine to be: $sys_tzoffset,\x20 
+                 PHP timezone offset determine to be: $php_tzoffset,\x20 
+                 Mysql timezone offset determine to be: $mysql_tzoffset
+               ");
+
+  if ( $sys_tzoffset != $php_tzoffset )
+        Fatal("ZoneMinder is not installed properly: php's date.timezone does not match the system timezone!");
+
+  if ( $sys_tzoffset != $mysql_tzoffset )
+        Error("ZoneMinder is not installed properly: mysql's timezone does not match the system timezone! Event lists will display incorrect times.");
+
+}
+
 function unparse_url($parsed_url, $substitutions = array() ) { 
   $fields = array('scheme','host','port','user','pass','path','query','fragment');
 

--- a/web/index.php
+++ b/web/index.php
@@ -69,11 +69,9 @@ define('ZM_BASE_PROTOCOL', $protocol);
 // Use relative URL's instead
 define('ZM_BASE_URL', '');
 
-// Check time zone is set
-if (!ini_get('date.timezone') || !date_default_timezone_set(ini_get('date.timezone'))) {
-  date_default_timezone_set('UTC');
-  Fatal( "ZoneMinder is not installed properly: php's date.timezone is not set to a valid timezone" );
-}
+// Verify the system, php, and mysql timezones all match
+require_once('includes/functions.php');
+check_timezone();
 
 if ( isset($_GET['skin']) ) {
   $skin = $_GET['skin'];
@@ -155,7 +153,6 @@ if ( ZM_OPT_USE_AUTH ) {
 session_write_close();
 
 require_once('includes/lang.php');
-require_once('includes/functions.php');
 
 # Running is global but only do the daemonCheck if it is actually needed
 $running = null;


### PR DESCRIPTION
fixes #2354 
supersedes #2378 

This implements a timezone check function that compares the system timezone to php and mysql timezones. It does this in a way that is compatible with any Linux or BSD type system without looking at specific file paths on the filesystem. 

If a discrepancy is found between the three timezones, an appropriate error is logged to alert the end user to fix the problem.

This is meant as a short term solution to #2354. A redesign of how times are stored in ZoneMinder is planned for a future release.