### PR TITLE
Fix #2391 by defining monitor variable

### DIFF
--- a/web/skins/classic/views/cycle.php
+++ b/web/skins/classic/views/cycle.php
@@ -38,6 +38,7 @@ ob_end_clean();
 
 $monIdx = 0;
 $monitors = array();
+$monitor = NULL;
 foreach( $displayMonitors as &$row ) {
   if ( $row['Function'] == 'None' )
     continue;


### PR DESCRIPTION
See #2391; this PR simply defines the undefined variable (which occurred if no monitors were available or yet set up)