### PR TITLE
Replace MooTools usage for adding window event listeners

### DIFF
--- a/web/js/overlay.js
+++ b/web/js/overlay.js
@@ -51,16 +51,14 @@ var Overlay = new Class({
   },
   show: function() {
     this.mask.show();
-    $(window).addEvent( 'resize', this.update.bind(this) );
-    $(window).addEvent( 'scroll', this.update.bind(this) );
+    window.addEventListener( 'resize', this.update.bind(this) );
+    window.addEventListener( 'scroll', this.update.bind(this) );
     this.element.tween( 'opacity', [0, 1.0] );
     this.element.show();
     this.element.position();
     this.mask.position();
   },
   hideComplete: function() {
-    $(window).removeEvent( 'resize', this.update.bind(this) );
-    $(window).removeEvent( 'scroll', this.update.bind(this) );
     this.element.hide();
     this.mask.hide();
   },
@@ -82,12 +80,10 @@ var Overlay = new Class({
     }
     updateOverlayLoading();
     this.loading.setStyle( 'display', 'block' );
-    $(window).addEvent( 'resize', this.update.bind(this) );
-    $(window).addEvent( 'scroll', this.update.bind(this) );
+    window.addEventListener( 'resize', this.update.bind(this) );
+    window.addEventListener( 'scroll', this.update.bind(this) );
   },
   hideAnimation: function() {
-    $(window).removeEvent( 'resize', this.update.bind(this) );
-    $(window).removeEvent( 'scroll', this.update.bind(this) );
     if ( this.loading ) {
       this.loading.setStyle( 'display', 'none' );
     }
@@ -119,4 +115,4 @@ function setupOverlays() {
   }
 }
 
-window.addEvent( 'domready', setupOverlays );
+window.addEventListener( 'DOMContentLoaded', setupOverlays );

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -378,7 +378,7 @@ if ( closePopup ) {
   closeWindow();
 }
 
-window.addEvent( 'domready', checkSize );
+window.addEventListener( 'DOMContentLoaded', checkSize );
 
 function convertLabelFormat(LabelFormat, monitorName) {
   //convert label format from strftime to moment's format (modified from

--- a/web/skins/classic/views/js/add_monitors.js
+++ b/web/skins/classic/views/js/add_monitors.js
@@ -103,4 +103,4 @@ function initPage() {
     probe(url);
   }
 }
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -146,4 +146,4 @@ function applySort(event, ui) {
   ajax.send();
 } // end function applySort(event,ui)
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/controlpreset.js
+++ b/web/skins/classic/views/js/controlpreset.js
@@ -9,4 +9,4 @@ function updateLabel() {
     form.newLabel.value = '';
   }
 }
-window.addEvent('domready', updateLabel);
+window.addEventListener('DOMContentLoaded', updateLabel);

--- a/web/skins/classic/views/js/cycle.js
+++ b/web/skins/classic/views/js/cycle.js
@@ -6,4 +6,4 @@ function initCycle() {
   nextCycleView.periodical(cycleRefreshTimeout);
 }
 
-window.addEvent('domready', initCycle);
+window.addEventListener('DOMContentLoaded', initCycle);

--- a/web/skins/classic/views/js/download.js
+++ b/web/skins/classic/views/js/download.js
@@ -35,4 +35,4 @@ function initPage() {
   }
 }
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1068,4 +1068,4 @@ function initPage() {
 }
 
 // Kick everything off
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/export.js
+++ b/web/skins/classic/views/js/export.js
@@ -51,4 +51,4 @@ function initPage() {
   }
 }
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -254,4 +254,4 @@ function init() {
   $j("#sortTable [name$='sort_field\\]']").chosen();
 }
 
-window.addEvent( 'domready', init );
+window.addEventListener( 'DOMContentLoaded', init );

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -314,4 +314,4 @@ function initPage() {
 }
 
 // Kick everything off
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/login.js
+++ b/web/skins/classic/views/js/login.js
@@ -1,4 +1,4 @@
-window.addEvent( 'domready', function() {
+window.addEventListener( 'DOMContentLoaded', function() {
   if ( failed == true ) {
     $('loginError').removeClass( 'hidden' );
   }

--- a/web/skins/classic/views/js/monitor.js
+++ b/web/skins/classic/views/js/monitor.js
@@ -48,4 +48,4 @@ function initPage() {
   //updateMethods( $(protocolSelector) );
 }
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -447,4 +447,4 @@ function initPage() {
   }
 }
 // Kick everything off
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -943,4 +943,4 @@ function initPage() {
 }
 window.addEventListener("resize", redrawScreen, {passive: true});
 // Kick everything off
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/plugin.js
+++ b/web/skins/classic/views/js/plugin.js
@@ -19,4 +19,4 @@ function initPage() {
   return ( true );
 }
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/report_event_audit.js
+++ b/web/skins/classic/views/js/report_event_audit.js
@@ -56,4 +56,4 @@ function initPage() {
   });
 }
 // Kick everything off
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -775,4 +775,4 @@ function initPage() {
 }
 
 // Kick everything off
-window.addEvent('domready', initPage);
+window.addEventListener('DOMContentLoaded', initPage);

--- a/web/skins/classic/views/js/zone.js
+++ b/web/skins/classic/views/js/zone.js
@@ -733,4 +733,4 @@ function Polygon_calcArea( coords ) {
   return Math.round( Math.abs( float_area ) );
 }
 
-window.addEvent( 'domready', initPage );
+window.addEventListener( 'DOMContentLoaded', initPage );


### PR DESCRIPTION
It's not necessary for modern browsers and adds indirection/noise in the browser developer tools when inspecting event listeners.