### PR TITLE
Log CSP violations in ZM logs in supported browsers

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -13,7 +13,7 @@ switch ( $_REQUEST['task'] ) {
 
       $string = $_POST['message'];
 
-      $file = !empty($_POST['file']) ? preg_replace( '/\w+:\/\/\w+\//', '', $_POST['file'] ) : '';
+      $file = !empty($_POST['file']) ? preg_replace( '/\w+:\/\/[\w.:]+\//', '', $_POST['file'] ) : '';
       if ( !empty( $_POST['line'] ) )
         $line = $_POST['line'];
       else

--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -47,7 +47,7 @@ function logReport( level, message, file, line ) {
     return;
   }
   /* eslint-disable no-caller */
-  if ( arguments && arguments.callee && arguments.callee.caller && arguments.callee.caller.name ) {
+  if ( arguments && arguments.callee && arguments.callee.caller && arguments.callee.caller.caller && arguments.callee.caller.caller.name ) {
     message += ' - '+arguments.callee.caller.caller.name+'()';
   }
   /* eslint-enable no-caller */
@@ -117,3 +117,12 @@ window.onerror =
     function( message, url, line ) {
       logReport( "ERR", message, url, line );
     };
+
+window.addEventListener("securitypolicyviolation", function logCSP(evt) {
+  var level = evt.disposition == "enforce" ? "ERR" : "DBG";
+  var message = evt.blockedURI + " violated CSP " + evt.violatedDirective;
+  if (evt.sample) {
+    message += " (Sample: " + evt.sample + ")";
+  }
+  logReport(level, message, evt.sourceFile, evt.lineNumber);
+});


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent

The log.php fix is to handle colons for ports and periods for subdomains.