### PR TITLE
Fixes 2478 Remove overrun possibility

### DIFF
--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -89,13 +89,13 @@ bool User::canAccess( int monitor_id ) {
 // Please note that in auth relay mode = none, password is NULL
 User *zmLoadUser( const char *username, const char *password ) {
   char sql[ZM_SQL_MED_BUFSIZ] = "";
-  char safer_username[65]; // current db username size is 32
+  char *safer_username = new char[(strlen(username) * 2) + 1];
 
   // According to docs, size of safer_whatever must be 2*length+1 due to unicode conversions + null terminator.
   mysql_real_escape_string(&dbconn, safer_username, username, strlen( username ) );
 
   if ( password ) {
-    char safer_password[129]; // current db password size is 64
+    char *safer_password = new char[(strlen(password) * 2) +1];
     mysql_real_escape_string(&dbconn, safer_password, password, strlen( password ) );
     snprintf(sql, sizeof(sql),
         "SELECT Id, Username, Password, Enabled, Stream+0, Events+0, Control+0, Monitors+0, System+0, MonitorIds"


### PR DESCRIPTION
Safer_username and safer_login should be based on the username and login (lengths * 2)+1. Control input lengths at user input