### PR TITLE
Validate zmu Username and Password lengths

### DIFF
--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -245,3 +245,18 @@ User *zmLoadAuthUser( const char *auth, bool use_remote_addr ) {
   Debug(1, "No user found for auth_key %s", auth );
   return 0;
 }
+
+//Function to check Username length
+bool checkUser ( const char *username) {
+  if ( strlen(username) > 32) {
+    return false;
+  }
+  return true;
+}
+//Function to check password length
+bool checkPass (const char *password) {
+  if ( strlen(password) > 64) {
+    return false;
+  }
+  return true;
+}

--- a/src/zm_user.h
+++ b/src/zm_user.h
@@ -77,5 +77,7 @@ public:
 
 User *zmLoadUser( const char *username, const char *password=0 );
 User *zmLoadAuthUser( const char *auth, bool use_remote_addr );
+bool checkUser ( const char *username);
+bool checkPass (const char *password);
 
 #endif // ZM_USER_H

--- a/src/zms.cpp
+++ b/src/zms.cpp
@@ -191,9 +191,12 @@ int main( int argc, const char *argv[] ) {
     User *user = 0;
 
     if ( strcmp(config.auth_relay, "none") == 0 ) {
-      if ( username.length() ) {
+      if ( checkUser(username.c_str()) ) {
         user = zmLoadUser(username.c_str());
+      } else {
+        Error("")
       }
+
     } else {
       //if ( strcmp( config.auth_relay, "hashed" ) == 0 )
       {

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -425,7 +425,7 @@ int main(int argc, char *argv[]) {
 
   if ( config.opt_use_auth ) {
     if ( strcmp(config.auth_relay, "none") == 0 ) {
-      if ( strlen(username) > 32) {
+      if ( !checkUser(username)) {
         fprintf(stderr, "Error, username greater than allowed 32 characters\n");
         exit_zmu(-1);
       }
@@ -442,11 +442,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error, username and password or auth string must be supplied\n");
         exit_zmu(-1);
       }
-      if ( strlen(username) > 32) {
+      if ( !checkUser(username)) {
         fprintf(stderr, "Error, username greater than allowed 32 characters\n");
         exit_zmu(-1);
       }
-      if ( strlen(password) > 64) {
+      if ( !checkPass(password)) {
         fprintf(stderr, "Error, password greater than allowed 64 characters\n");
         exit_zmu(-1);
       }

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -425,6 +425,10 @@ int main(int argc, char *argv[]) {
 
   if ( config.opt_use_auth ) {
     if ( strcmp(config.auth_relay, "none") == 0 ) {
+      if ( strlen(username) > 32) {
+        fprintf(stderr, "Error, username greater than allowed 32 characters\n");
+        exit_zmu(-1);
+      }
       if ( !username ) {
         fprintf(stderr, "Error, username must be supplied\n");
         exit_zmu(-1);
@@ -438,7 +442,14 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error, username and password or auth string must be supplied\n");
         exit_zmu(-1);
       }
-
+      if ( strlen(username) > 32) {
+        fprintf(stderr, "Error, username greater than allowed 32 characters\n");
+        exit_zmu(-1);
+      }
+      if ( strlen(password) > 64) {
+        fprintf(stderr, "Error, password greater than allowed 64 characters\n");
+        exit_zmu(-1);
+      }
       //if ( strcmp( config.auth_relay, "hashed" ) == 0 )
       {
         if ( auth ) {


### PR DESCRIPTION
Ensure user provided values are not larger than allowed and error if
they are, therefore further preventing overflow.