### PR TITLE
Set CSRF on as the default for new installs. Fixes #2507

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -375,7 +375,7 @@ our @options = (
       this, the attacker must write a very specific web page and get
       you to navigate to it, while you are logged into the ZoneMinder
       web console at the same time. Enabling ZM_ENABLE_CSRF_MAGIC will
-      help mitigate these kinds of attackes.
+      help mitigate these kinds of attacks.
       `,
     type        => $types{boolean},
     category    => 'system',

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -366,7 +366,7 @@ our @options = (
   },
   {
     name        => 'ZM_ENABLE_CSRF_MAGIC',
-    default     => 'no',
+    default     => 'yes',
     description => 'Enable csrf-magic library',
     help        => q`
       CSRF stands for Cross-Site Request Forgery which, under specific
@@ -375,11 +375,7 @@ our @options = (
       this, the attacker must write a very specific web page and get
       you to navigate to it, while you are logged into the ZoneMinder
       web console at the same time. Enabling ZM_ENABLE_CSRF_MAGIC will
-      help mitigate these kinds of attackes. Be warned this feature
-      is experimental and may cause problems, particularly with the API.
-      If you find a false positive and can document how to reproduce it,
-      then please report it. This feature defaults to OFF currently due to
-      its experimental nature.
+      help mitigate these kinds of attackes.
       `,
     type        => $types{boolean},
     category    => 'system',


### PR DESCRIPTION
As discussed by @mnoorenberghe, to set CSRF on by default. Not sure we can impact config on existing installations. We probably need to call it out in the release notes to get people to turn it on.

Please discuss...