### PR TITLE
Allow object detection images to show in events view

### DIFF
--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -190,11 +190,31 @@ while ( $event_row = dbFetchNext($results) ) {
   $scale = max( reScale( SCALE_BASE, $event->DefaultScale(), ZM_WEB_DEFAULT_SCALE ), SCALE_BASE );
 ?>
             <tr<?php if ($event->Archived()) echo ' class="archived"' ?>>
-              <td class="colId"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1">'.$event->Id().($event->Archived()?'*':'') ?></a></td>
-              <td class="colName"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1">'.validHtmlStr($event->Name()).($event->Archived()?'*':'') ?></a></td>
+              <td class="colId"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1"> '.$event->Id().($event->Archived()?'*':'') ?></a></td>
+              <td class="colName"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1"> '.validHtmlStr($event->Name()).($event->Archived()?'*':'') ?></a></td>
               <td class="colMonitorName"><?php echo makePopupLink( '?view=monitor&amp;mid='.$event->MonitorId(), 'zmMonitor'.$event->Monitorid(), 'monitor', $event->MonitorName(), canEdit( 'Monitors' ) ) ?></td>
-              <td class="colCause"><?php echo makePopupLink( '?view=eventdetail&amp;eid='.$event->Id(), 'zmEventDetail', 'eventdetail', validHtmlStr($event->Cause()), canEdit( 'Events' ), 'title="'.htmlspecialchars($event->Notes()).'"' ) ?>
-                    <?php if ($event->Notes() && ($event->Notes() != 'Forced Web: ')) echo "<br/><div class=\"small text-nowrap text-muted\">".$event->Notes()."</div>" ?></td>
+              <td class="colCause">
+                <?php 
+                        echo makePopupLink( '?view=eventdetail&amp;eid='.$event->Id(), 'zmEventDetail', 'eventdetail', 
+                        validHtmlStr($event->Cause()), canEdit( 'Events' ), 'title="'.htmlspecialchars($event->Notes()).'"' ) 
+                ?>
+                <?php 
+                        # display notes as small text
+                        if ($event->Notes()) {
+                            # if notes include detection objects, then link it to objdetect.jpg
+                            # TBD: what if it's not there?
+                            if (strpos($event->Notes(),"detected:")!== false){ 
+                             # make a link
+                                echo makePopupLink( '?view=image&amp;eid='.$event->Id().'&amp;fid=objdetect', 'zmImage',
+                                     array('image', reScale($event->Width(), $scale), reScale($event->Height(), $scale)), 
+                                     "<div class=\"small text-nowrap text-muted\"><u>".$event->Notes()."</u></div>"); 
+                            }
+                            elseif ($event->Notes() != 'Forced Web: ') {
+                                echo "<br/><div class=\"small text-nowrap text-muted\">".$event->Notes()."</div>";
+                            }
+                        }
+                ?>
+</td>
               <td class="colTime"><?php echo strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->StartTime())) . 
 ( $event->EndTime() ? ' until ' . strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->EndTime()) ) : '' ) ?>
               </td>
@@ -227,12 +247,12 @@ while ( $event_row = dbFetchNext($results) ) {
       $streamSrc = $event->getStreamSrc(array(
         'mode'=>'jpeg', 'scale'=>$scale, 'maxfps'=>ZM_WEB_VIDEO_MAXFPS, 'replay'=>'single'));
 
-      $imgHtml = '<img id="thumbnail'.$event->id().'" src="'.$imgSrc.'" alt="'. validHtmlStr('Event '.$event->Id()) .'" style="width:'. validInt($event->ThumbnailWidth()) .'px;height:'. validInt($event->ThumbnailHeight()).'px;" stream_src="'.$streamSrc.'" still_src="'.$imgSrc.'"/>';
+      $imgHtml = '<img id="thumbnail'.$event->id().'" src="'.$imgSrc.'" alt="'. validHtmlStr('Event '.$event->Id()) .'" style="width:'. validInt($event->ThumbnailWidth()) .'px;height:'. validInt($event->ThumbnailHeight()).'px;" onmouseover="this.src=\''.$streamSrc.'\';" onmouseout="this.src=\''.$imgSrc.'\';"/>';
       echo '<a href="?view=event&amp;eid='. $event->Id().$filterQuery.$sortQuery.'&amp;page=1">'.$imgHtml.'</a>';
       echo '</td>';
   } // end if ZM_WEB_LIST_THUMBS
 ?>
-              <td class="colMark"><input type="checkbox" name="markEids[]" value="<?php echo $event->Id() ?>" data-on-click-this="configureButton"/></td>
+              <td class="colMark"><input type="checkbox" name="markEids[]" value="<?php echo $event->Id() ?>" onclick="configureButton(this, 'markEids');"/></td>
             </tr>
 <?php
 }
@@ -274,25 +294,25 @@ if ( $pagination ) {
 }
 ?>
         <div id="contentButtons">
-          <button type="button" name="viewBtn" value="View" data-on-click-this="viewEvents" disabled="disabled">
+          <button type="button" name="viewBtn" value="View" onclick="viewEvents(this, 'markEids');" disabled="disabled">
           <?php echo translate('View') ?>
           </button>
-          <button type="button" name="archiveBtn" value="Archive" data-on-click-this="archiveEvents" disabled="disabled">
+          <button type="button" name="archiveBtn" value="Archive" onclick="archiveEvents(this, 'markEids')" disabled="disabled">
           <?php echo translate('Archive') ?>
           </button>
-          <button type="button" name="unarchiveBtn" value="Unarchive" data-on-click-this="unarchiveEvents" disabled="disabled">
+          <button type="button" name="unarchiveBtn" value="Unarchive" onclick="unarchiveEvents(this, 'markEids');" disabled="disabled">
           <?php echo translate('Unarchive') ?>
           </button>
-          <button type="button" name="editBtn" value="Edit" data-on-click-this="editEvents" disabled="disabled">
+          <button type="button" name="editBtn" value="Edit" onclick="editEvents(this, 'markEids')" disabled="disabled">
           <?php echo translate('Edit') ?>
           </button>
-          <button type="button" name="exportBtn" value="Export" data-on-click-this="exportEvents" disabled="disabled">
+          <button type="button" name="exportBtn" value="Export" onclick="exportEvents(this, 'markEids')" disabled="disabled">
           <?php echo translate('Export') ?>
           </button>
-          <button type="button" name="downloadBtn" value="DownloadVideo" data-on-click-this="downloadVideo" disabled="disabled">
+          <button type="button" name="downloadBtn" value="DownloadVideo" onclick="downloadVideo(this, 'markEids')" disabled="disabled">
           <?php echo translate('DownloadVideo') ?>
           </button>
-          <button type="button" name="deleteBtn" value="Delete" data-on-click-this="deleteEvents" disabled="disabled">
+          <button type="button" name="deleteBtn" value="Delete" onclick="deleteEvents(this, 'markEids');" disabled="disabled">
           <?php echo translate('Delete') ?>
           </button>
         </div>
@@ -301,7 +321,6 @@ if ( $pagination ) {
   </div>
 <script nonce="<?php echo $cspNonce;?>">
   // These are defined in the .js.php but need to be updated down here.
-// This might be better done by selecting through the dom for the archived class
   archivedEvents = <?php echo !empty($archived)?'true':'false' ?>;
   unarchivedEvents = <?php echo !empty($unarchived)?'true':'false' ?>;
 </script>

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -77,7 +77,17 @@ if ( empty($_REQUEST['path']) ) {
       return;
     }
 
-    if ( $_REQUEST['fid'] == 'alarm' ) {
+    if ( $_REQUEST['fid'] == 'objdetect' ) {
+        $Event = new Event($_REQUEST['eid']);
+        $path = $Event->Path().'/objdetect.jpg';
+        unset($Event); # we don't want event object related processing later for this case
+        if ( !file_exists($path)) {
+        header('HTTP/1.0 404 Not Found');
+        Fatal("File ".$path." does not exist. Please make sure store_frame_in_zm is enabled in the object detection config");
+      }
+      
+    }
+    else if ( $_REQUEST['fid'] == 'alarm' ) {
       # look for first alarmed frame
       $Frame = Frame::find_one(array('EventId'=>$_REQUEST['eid'], 'Type'=>'Alarm'),
                                array('order'=>'FrameId ASC'));
@@ -220,6 +230,7 @@ if ( empty($_REQUEST['path']) ) {
   }
 }
 
+# we now load the actual image to send
 $scale = 0;
 if ( !empty($_REQUEST['scale']) ) {
   if ( is_numeric($_REQUEST['scale']) ) {


### PR DESCRIPTION
Allows us to see the objects detected, if ES is in use and notes contains object detection.

Screenshots:

Elements with object detection are hyperlinked:

<img width="1205" alt="screen shot 2019-02-10 at 4 25 04 pm" src="https://user-images.githubusercontent.com/4116654/52539820-7c722600-2d50-11e9-84ee-3da4051f0694.png">

On click:
<img width="837" alt="screen shot 2019-02-10 at 4 25 21 pm" src="https://user-images.githubusercontent.com/4116654/52539828-93b11380-2d50-11e9-970a-49d1057bfc8e.png">
