### PR TITLE
show object detected file, if object detection in place

### DIFF
--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -194,7 +194,23 @@ while ( $event_row = dbFetchNext($results) ) {
               <td class="colName"><a href="?view=event&amp;eid=<?php echo $event->Id().$filterQuery.$sortQuery.'&amp;page=1">'.validHtmlStr($event->Name()).($event->Archived()?'*':'') ?></a></td>
               <td class="colMonitorName"><?php echo makePopupLink( '?view=monitor&amp;mid='.$event->MonitorId(), 'zmMonitor'.$event->Monitorid(), 'monitor', $event->MonitorName(), canEdit( 'Monitors' ) ) ?></td>
               <td class="colCause"><?php echo makePopupLink( '?view=eventdetail&amp;eid='.$event->Id(), 'zmEventDetail', 'eventdetail', validHtmlStr($event->Cause()), canEdit( 'Events' ), 'title="'.htmlspecialchars($event->Notes()).'"' ) ?>
-                    <?php if ($event->Notes() && ($event->Notes() != 'Forced Web: ')) echo "<br/><div class=\"small text-nowrap text-muted\">".$event->Notes()."</div>" ?></td>
+                    <?php
+                        # display notes as small text
+                        if ($event->Notes()) {
+                            # if notes include detection objects, then link it to objdetect.jpg
+                            if (strpos($event->Notes(),"detected:")!== false){
+                             # make a link
+                                echo makePopupLink( '?view=image&amp;eid='.$event->Id().'&amp;fid=objdetect', 'zmImage',
+                                     array('image', reScale($event->Width(), $scale), reScale($event->Height(), $scale)),
+                                     "<div class=\"small text-nowrap text-muted\"><u>".$event->Notes()."</u></div>");
+                            }
+                            elseif ($event->Notes() != 'Forced Web: ') {
+                                echo "<br/><div class=\"small text-nowrap text-muted\">".$event->Notes()."</div>";
+                            }
+                        }
+                ?>
+
+              </td>
               <td class="colTime"><?php echo strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->StartTime())) . 
 ( $event->EndTime() ? ' until ' . strftime(STRF_FMT_DATETIME_SHORTER, strtotime($event->EndTime()) ) : '' ) ?>
               </td>


### PR DESCRIPTION
(Think I got the recent changes this time)

Allows us to see the objects detected, if ES is in use and notes contains object detection.

Screenshots:

Elements with object detection are hyperlinked:

<img width="1205" alt="screen shot 2019-02-10 at 4 25 04 pm" src="https://user-images.githubusercontent.com/4116654/52539820-7c722600-2d50-11e9-84ee-3da4051f0694.png">

On click:
<img width="837" alt="screen shot 2019-02-10 at 4 25 21 pm" src="https://user-images.githubusercontent.com/4116654/52539828-93b11380-2d50-11e9-970a-49d1057bfc8e.png">
