### PR TITLE
event.js: Wait for delete request to succeed before navigating.

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -901,8 +901,19 @@ function actQuery( action, parms ) {
 
 function deleteEvent() {
   pauseClicked(); //Provides visual feedback that your click happened.
-  actQuery( 'delete' );
-  streamNext( true );
+
+  var deleteReq = new Request.JSON({
+    url: thisUrl,
+    method: 'post',
+    timeout: AJAX_TIMEOUT,
+    onSuccess: function onDeleteSuccess(respObj, respText) {
+      getActResponse(respObj, respText);
+      // We must wait for the deletion to happen before navigating to the next
+      // event or this request will be cancelled.
+      streamNext( true );
+    },
+  });
+  deleteReq.send("view=request&request=event&id="+eventData.Id+"&action=delete");
 }
 
 function renameEvent() {


### PR DESCRIPTION
Regression from https://github.com/ZoneMinder/zoneminder/commit/9ec415b30a0d996381c61b76b828342e651a0196#diff-c594902fd3897e5ff750c632a30a7b8cR413

I think there are other actions on the same page that suffer from the same issue but wanted to fix this one first to see what you thought.

Fixes #2384