### PR TITLE
Don't scroll to the top of the page when force/cancel alarm is clicked

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -448,10 +448,16 @@ function cmdEnableAlarms() {
 
 function cmdForceAlarm() {
   alarmCmdReq.send(alarmCmdParms+"&command=forceAlarm");
+  if (window.event) {
+    window.event.preventDefault();
+  }
 }
 
 function cmdCancelForcedAlarm() {
   alarmCmdReq.send(alarmCmdParms+"&command=cancelForcedAlarm");
+  if (window.event) {
+    window.event.preventDefault();
+  }
   return false;
 }
 


### PR DESCRIPTION
I think this is a regression from removing inline event handlers. Changing to addEventListener is complicated because of the many modes of the page.