### PR TITLE
Use zm_session_start() for API auth. Fixes #2547

### DIFF
--- a/web/includes/auth.php
+++ b/web/includes/auth.php
@@ -211,7 +211,7 @@ global $user;
 if ( ZM_OPT_USE_AUTH ) {
   $close_session = 0;
   if ( !is_session_started() ) {
-    session_start();
+    zm_session_start();
     $close_session = 1;
   }
 


### PR DESCRIPTION
I'm not sure if the `session_write_close();` should also change.