### PR TITLE
Camera reboot function

### DIFF
--- a/db/zm_create.sql.in
+++ b/db/zm_create.sql.in
@@ -68,6 +68,7 @@ CREATE TABLE `Controls` (
   `CanWake` tinyint(3) unsigned NOT NULL default '0',
   `CanSleep` tinyint(3) unsigned NOT NULL default '0',
   `CanReset` tinyint(3) unsigned NOT NULL default '0',
+  `CanReboot` tinyint(3) unsigned NOT NULL default '0',
   `CanZoom` tinyint(3) unsigned NOT NULL default '0',
   `CanAutoZoom` tinyint(3) unsigned NOT NULL default '0',
   `CanZoomAbs` tinyint(3) unsigned NOT NULL default '0',

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Dahua.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Dahua.pm
@@ -444,7 +444,7 @@ sub reboot
 {
     my $self = shift;
     Debug( "Camera Reboot" );
-    my $cmd = "cgi-bin/magicBox.cgi?action=reboot";
+    my $cmd = "/cgi-bin/magicBox.cgi?action=reboot";
     $self->_sendGetRequest($cmd);
 }
 

--- a/web/lang/ba_ba.php
+++ b/web/lang/ba_ba.php
@@ -216,6 +216,7 @@ $SLANG = array(
     'CanMoveRel'            => 'Podržava Relativno kretanje',
     'CanPan'                => 'Podržava Pomak' ,
     'CanReset'              => 'PodržavaReset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => 'Podržava presetove',
     'CanSleep'              => 'Podržava Sleep',
     'CanTilt'               => 'Podržava nagib',

--- a/web/lang/big5_big5.php
+++ b/web/lang/big5_big5.php
@@ -209,6 +209,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relative',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/cn_zh.php
+++ b/web/lang/cn_zh.php
@@ -205,6 +205,7 @@ $SLANG = array(
     'CanMoveRel'            => '可以相对移动',
     'CanPan'                => '可以平移' ,
     'CanReset'              => '可以复位',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => '可以进行预设',
     'CanSleep'              => '可以休眠',
     'CanTilt'               => '可以倾斜',

--- a/web/lang/cs_cz.php
+++ b/web/lang/cs_cz.php
@@ -205,6 +205,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Umí relativní pohyb',
     'CanPan'               => 'Umí otáčení',
     'CanReset'             => 'Umí reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Umí navolit předvolby',
     'CanSleep'             => 'Může spát',
     'CanTilt'              => 'Umí náklon',

--- a/web/lang/de_de.php
+++ b/web/lang/de_de.php
@@ -207,6 +207,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Kann relative Bewegung',
     'CanPan'               => 'Kann Pan' ,
     'CanReset'             => 'Kann Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Kann Voreinstellungen setzen',
     'CanSleep'             => 'Kann Sleep',
     'CanTilt'              => 'Kann Neigung',

--- a/web/lang/dk_dk.php
+++ b/web/lang/dk_dk.php
@@ -206,6 +206,7 @@ $SLANG = array(
     'CanMoveRel'            => 'Can Move Relative',
     'CanPan'                => 'Can Pan' ,
     'CanReset'              => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => 'Can Set Presets',
     'CanSleep'              => 'Can Sleep',
     'CanTilt'               => 'Can Tilt',

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -216,6 +216,7 @@ $SLANG = array(
     'CanMoveRel'            => 'Can Move Relative',
     'CanPan'                => 'Can Pan' ,
     'CanReset'              => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => 'Can Set Presets',
     'CanSleep'              => 'Can Sleep',
     'CanTilt'               => 'Can Tilt',

--- a/web/lang/es_ar.php
+++ b/web/lang/es_ar.php
@@ -156,6 +156,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relative',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/es_es.php
+++ b/web/lang/es_es.php
@@ -205,6 +205,7 @@ $SLANG = array(
     'CanMoveRel'            => 'Puede moverse de forma relativa',
     'CanPan'                => 'Puede desplazarse' ,
     'CanReset'              => 'Puede restablecerse',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => 'Puede fefinir programaciones',
     'CanSleep'              => 'Puede dormirse',
     'CanTilt'               => 'Puede inclinarse',

--- a/web/lang/et_ee.php
+++ b/web/lang/et_ee.php
@@ -212,6 +212,7 @@ $SLANG = array(
     'CanMoveRel'            => 'Can Move Relative',
     'CanPan'                => 'Can Pan' ,
     'CanReset'              => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'         => 'Can Set Presets',
     'CanSleep'              => 'Can Sleep',
     'CanTilt'               => 'Can Tilt',

--- a/web/lang/fr_fr.php
+++ b/web/lang/fr_fr.php
@@ -211,6 +211,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Relatif',
     'CanPan'               => 'Panoramique' ,
     'CanReset'             => 'RàZ',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Stockage prépos.',
     'CanSleep'             => 'Veille',
     'CanTilt'              => 'Inclinaison',

--- a/web/lang/he_il.php
+++ b/web/lang/he_il.php
@@ -205,6 +205,7 @@ $SLANG = array(
     'CanMoveRel'           => 'àôùø úæåæä éçñéú',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'àôùø àúçåì',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'àôùø îöá ùéðä',
     'CanTilt'              => 'àôùø æòæåò',

--- a/web/lang/hu_hu.php
+++ b/web/lang/hu_hu.php
@@ -248,6 +248,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Relatíven tud mozogni',
     'CanPan'               => 'Tud jobb-bal mozgást' ,
     'CanReset'             => 'Tud alaphelyzetbe jönni',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Tud menteni profilokat',
     'CanSleep'             => 'Tud phihenő üzemmódot',
     'CanTilt'              => 'Tud fel-le mozgást',

--- a/web/lang/it_it.php
+++ b/web/lang/it_it.php
@@ -210,6 +210,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Puo\' Mov. Relativo',
     'CanPan'               => 'Puo\' Pan' ,
     'CanReset'             => 'Puo\' Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Puo\' impostare preset',
     'CanSleep'             => 'Puo\' andare in sleep',
     'CanTilt'              => 'Puo\' Tilt',

--- a/web/lang/ja_jp.php
+++ b/web/lang/ja_jp.php
@@ -206,6 +206,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relative',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/nl_nl.php
+++ b/web/lang/nl_nl.php
@@ -206,6 +206,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relatief',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/pl_pl.php
+++ b/web/lang/pl_pl.php
@@ -220,6 +220,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relative',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/pt_br.php
+++ b/web/lang/pt_br.php
@@ -145,6 +145,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Can Move Relative',
     'CanPan'               => 'Can Pan' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Can Tilt',

--- a/web/lang/ro_ro.php
+++ b/web/lang/ro_ro.php
@@ -176,6 +176,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Mi&#351;care relativ&#259;',
     'CanPan'               => 'Rotativ' ,
     'CanReset'             => 'Can Reset',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Can Set Presets',
     'CanSleep'             => 'Can Sleep',
     'CanTilt'              => 'Se poate &#238;nclina',

--- a/web/lang/ru_ru.php
+++ b/web/lang/ru_ru.php
@@ -206,6 +206,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Относительное перемещение',
     'CanPan'               => 'Панорама' ,
     'CanReset'             => 'Сброс',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Создание предустановок',
     'CanSleep'             => 'Сон',
     'CanTilt'              => 'Наклон',

--- a/web/lang/se_se.php
+++ b/web/lang/se_se.php
@@ -206,6 +206,7 @@ $SLANG = array(
     'CanMoveRel'           => 'Har relativ förflyttning',
     'CanPan'               => 'Har panorering',
     'CanReset'             => 'Har återställning',
+	'CanReboot'             => 'Can Reboot',
     'CanSetPresets'        => 'Har förinställningar',
     'CanSleep'             => 'Kan vila',
     'CanTilt'              => 'Kan tilta',

--- a/web/skins/classic/includes/control_functions.php
+++ b/web/skins/classic/includes/control_functions.php
@@ -24,6 +24,7 @@ function getControlCommands( $monitor ) {
   $cmds['Wake'] = 'wake';
   $cmds['Sleep'] = 'sleep';
   $cmds['Reset'] = 'reset';
+  $cmds['Reboot'] = 'reboot';
 
   $cmds['PresetSet'] = 'presetSet';
   $cmds['PresetGoto'] = 'presetGoto';
@@ -319,6 +320,11 @@ function controlPower( $monitor, $cmds ) {
   if ( $monitor->CanReset() ) {
 ?>
     <button type="button" class="ptzTextBtn" value="Reset" onclick="controlCmd('<?php echo $cmds['Reset'] ?>')"><?php echo translate('Reset') ?></button>
+<?php
+  }
+  if ( $monitor->CanReboot() ) {
+?>
+    <button type="button" class="ptzTextBtn" value="Reset" onclick="controlCmd('<?php echo $cmds['Reboot'] ?>')"><?php echo translate('Reboot') ?></button>
 <?php
   }
 ?>

--- a/web/skins/classic/includes/control_functions.php
+++ b/web/skins/classic/includes/control_functions.php
@@ -324,7 +324,7 @@ function controlPower( $monitor, $cmds ) {
   }
   if ( $monitor->CanReboot() ) {
 ?>
-    <button type="button" class="ptzTextBtn" value="Reset" onclick="controlCmd('<?php echo $cmds['Reboot'] ?>')"><?php echo translate('Reboot') ?></button>
+    <button type="button" class="ptzTextBtn" value="Reboot" onclick="controlCmd('<?php echo $cmds['Reboot'] ?>')"><?php echo translate('Reboot') ?></button>
 <?php
   }
 ?>

--- a/web/skins/classic/views/controlcap.php
+++ b/web/skins/classic/views/controlcap.php
@@ -59,6 +59,7 @@ else
             'CanWake' => "",
             'CanSleep' => "",
             'CanReset' => "",
+            'CanReboot' => "",
             'CanMove' => "",
             'CanMoveDiag' => "",
             'CanMoveMap' => "",
@@ -352,6 +353,7 @@ switch ( $tab )
             <tr><th scope="row"><?php echo translate('CanWake') ?></th><td><input type="checkbox" name="newControl[CanWake]" value="1"<?php if ( !empty($newControl['CanWake']) ) { ?> checked="checked"<?php } ?>/></td></tr>
             <tr><th scope="row"><?php echo translate('CanSleep') ?></th><td><input type="checkbox" name="newControl[CanSleep]" value="1"<?php if ( !empty($newControl['CanSleep']) ) { ?> checked="checked"<?php } ?>/></td></tr>
             <tr><th scope="row"><?php echo translate('CanReset') ?></th><td><input type="checkbox" name="newControl[CanReset]" value="1"<?php if ( !empty($newControl['CanReset']) ) { ?> checked="checked"<?php } ?>/></td></tr>
+            <tr><th scope="row"><?php echo translate('CanReboot') ?></th><td><input type="checkbox" name="newControl[CanReboot]" value="1"<?php if ( !empty($newControl['CanReboot']) ) { ?> checked="checked"<?php } ?>/></td></tr>
 <?php
         break;
     }


### PR DESCRIPTION
Dahua cameras support a "Reboot" function. Other's may as well. This series of commits adds a reboot function option to the camera control configuration as well as a reboot button to the control UI.