### PR TITLE
daemonize zmcontrol

### DIFF
--- a/scripts/zmcontrol.pl.in
+++ b/scripts/zmcontrol.pl.in
@@ -63,8 +63,8 @@ GetOptions(
   'autostop'      =>\$options{autostop},
 ) or pod2usage(-exitstatus => -1);
 
-if ( !$id || !$options{command} ) {
-  print( STDERR "Please give a valid monitor id and command\n" );
+if ( !$id ) {
+  print( STDERR "Please give a valid monitor id\n" );
   pod2usage(-exitstatus => -1);
 }
 
@@ -201,8 +201,10 @@ if ( !$server_up ) {
 #print( "Writing commands\n" );
 CLIENT->autoflush();
 
-my $message = jsonEncode(\%options);
-print(CLIENT $message);
+if ( $options{command} ) {
+  my $message = jsonEncode(\%options);
+  print(CLIENT $message);
+}
 shutdown(CLIENT, 1);
 
 exit(0);
@@ -216,7 +218,7 @@ zmcontrol.pl - ZoneMinder control script
 
 =head1 SYNOPSIS
 
- zmcontrol.pl --id {monitor_id} --command={command} [various options]
+ zmcontrol.pl --id {monitor_id} [--command={command}] [various options]
 
 =head1 DESCRIPTION
 

--- a/scripts/zmdc.pl.in
+++ b/scripts/zmdc.pl.in
@@ -101,6 +101,7 @@ my @daemons = (
     'zmupdate.pl',
     'zmstats.pl',
     'zmtrack.pl',
+    'zmcontrol.pl',
     'zmtelemetry.pl'
     );
 

--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -220,14 +220,17 @@ if ( $command =~ /^(?:start|restart)$/ ) {
             runCommand("zmdc.pl start zma -m $monitor->{Id}");
           }
           if ( $Config{ZM_OPT_CONTROL} ) {
-            if ( $monitor->{Controllable} && $monitor->{TrackMotion} ) {
-              if ( $monitor->{Function} eq 'Modect' || $monitor->{Function} eq 'Mocord' ) {
-                runCommand("zmdc.pl start zmtrack.pl -m $monitor->{Id}");
-              } else {
-                Warning('Monitor is set to track motion, but does not have motion detection enabled.');
-              } # end if Has motion enabled
-            } # end if track motion
-          } # end if ZM_OPT_CONTROL
+            if ( $monitor->{Controllable} ) {
+              runCommand("zmdc.pl start zmcontrol.pl --id $monitor->{Id}");
+              if ( $monitor->{TrackMotion} ) {
+                if ( $monitor->{Function} eq 'Modect' || $monitor->{Function} eq 'Mocord' ) {
+                  runCommand("zmdc.pl start zmtrack.pl -m $monitor->{Id}");
+                } else {
+                  Warning('Monitor is set to track motion, but does not have motion detection enabled.');
+                } # end if Has motion enabled
+              } # end if track motion
+            } # end if controllable
+          } # end if ZM_OPT_CONTROL        
         } # end if function is not none or Website
       } # end foreach monitor
       $sth->finish();


### PR DESCRIPTION
Fixes #2555 

Previously zmcontrol was started on the fly by the web php when a ptz command was sent. This created a process not managed by zmpkg/zmdc. Thus when zoneminder was stopped the process was left running.

This PR attempts to properly daemonize zmcontrol. If a monitor is controllable, zmpkg will spawn a zmcontrol process during startup for that monitor. Zmcontrol has been added to zmdc's list of daemons, which results in proper shutdown of the process when ZoneMinder is stopped.

Accomplishing this required modifying zmcontrol to startup w/o a ptz command. 
I am monitoring my test system for side affects caused by this change 
- Watching to see if zmcontrol stays running and does not time out
- Verify proper management of the socket (e.g. make sure we don't delete the socket immediately after creating, things like that)
