### PR TITLE
Add shutdown capability

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -466,7 +466,10 @@ our @options = (
     name        =>  'ZM_SYSTEM_SHUTDOWN',
     default     =>  'true',
     description =>  'Allow Admin users to power off or restart the system from the ZoneMinder UI.',
-    help        =>  'The system will need to have a polkit file installed to enable the apache user
+    help        =>  'The system will need to have sudo installed and the following added to /etc/sudoers~~
+    ~~
+    @ZM_WEB_USER@ ALL=NOPASSWD: /sbin/shutdown~~
+    ~~
       to perform the shutdown or reboot',
     type      =>  $types{boolean},
     category  =>  'system',

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -463,6 +463,15 @@ our @options = (
     category    => 'system',
   },
   {
+    name        =>  'ZM_SYSTEM_SHUTDOWN',
+    default     =>  'true',
+    description =>  'Allow Admin users to power off or restart the system from the ZoneMinder UI.',
+    help        =>  'The system will need to have a polkit file installed to enable the apache user
+      to perform the shutdown or reboot',
+    type      =>  $types{boolean},
+    category  =>  'system',
+  },
+  {
     name        => 'ZM_USE_DEEP_STORAGE',
     default     => 'yes',
     description => 'Use a deep filesystem hierarchy for events',

--- a/web/includes/actions/shutdown.php
+++ b/web/includes/actions/shutdown.php
@@ -1,0 +1,44 @@
+<?php
+//
+// ZoneMinder web action file
+// Copyright (C) 2019 ZoneMinder LLC
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+
+if ( !canEdit('System') ) {
+  ZM\Warning('Need System permissions to shutdown server');
+  return;
+}
+if ( $action ) {
+  $when = isset($_POST['when']) and $_POST['when'] == 'now' ? 'now' : '+1';
+  if ( $action == 'shutdown' ) {
+    $output = array();
+    $rc = 0;
+    exec("sudo -n /sbin/shutdown -P $when 2>&1", $output, $rc);
+    #exec('sudo -n /bin/systemctl poweroff -i 2>&1', $output, $rc);
+    ZM\Logger::Debug("Shutdown output $rc " . implode("\n",$output));
+    #ZM\Logger::Debug("Shutdown output " . shell_exec('/bin/systemctl poweroff -i 2>&1'));
+  } else if ( $action == 'restart' ) {
+    $output = array();
+    exec("sudo -n /sbin/shutdown -r $when 2>&1", $output);
+    #exec('sudo -n /bin/systemctl reboot -i 2>&1', $output);
+    ZM\Logger::Debug("Shutdown output " . implode("\n",$output));
+  } else if ( $action == 'cancel' ) {
+    $output = array();
+    exec('sudo /sbin/shutdown -c 2>&1', $output);
+  }
+} # end if action
+?>

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -689,6 +689,7 @@ $SLANG = array(
     'Settings'              => 'Settings',
     'ShowFilterWindow'      => 'Show Filter Window',
     'ShowTimeline'          => 'Show Timeline',
+    'Shutdown'              => 'Shutdown',
     'SignalCheckColour'     => 'Signal Check Colour',
     'SignalCheckPoints'     => 'Signal Check Points',
     'Size'                  => 'Size',

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -324,7 +324,9 @@ if (isset($_REQUEST['filter']['Query']['terms']['attr'])) {
 
 <?php if ( canEdit('System') ) { ?>
 		<button type="button" class="btn btn-default navbar-btn" data-toggle="modal" data-target="#modalState"><?php echo $status ?></button>
-
+<?php if ( ZM_SYSTEM_SHUTDOWN ) { ?>
+<?php echo makePopupLink('?view=shutdown', 'zmShutdown', 'shutdown', '<i class="material-icons md-18">power_settings_new</i></button>' ) ?>
+<?php } ?>
 <?php } else if ( canView('System') ) { ?>
 		<p class="navbar-text"> <?php echo $status ?></p>
 <?php } ?>

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -321,12 +321,13 @@ if (isset($_REQUEST['filter']['Query']['terms']['attr'])) {
 <?php if ( ZM_OPT_USE_AUTH and $user ) { ?>
 	<p class="navbar-text"><i class="material-icons">account_circle</i> <?php echo makePopupLink( '?view=logout', 'zmLogout', 'logout', $user['Username'], (ZM_AUTH_TYPE == "builtin") ) ?> </p>
 <?php } ?>
-
 <?php if ( canEdit('System') ) { ?>
 		<button type="button" class="btn btn-default navbar-btn" data-toggle="modal" data-target="#modalState"><?php echo $status ?></button>
-<?php if ( ZM_SYSTEM_SHUTDOWN ) { ?>
-<?php echo makePopupLink('?view=shutdown', 'zmShutdown', 'shutdown', '<i class="material-icons md-18">power_settings_new</i></button>' ) ?>
-<?php } ?>
+  <?php if ( ZM_SYSTEM_SHUTDOWN ) { ?>
+  <p class="navbar-text">
+  <?php echo makePopupLink('?view=shutdown', 'zmShutdown', 'shutdown', '<i class="material-icons md-18">power_settings_new</i></button>' ) ?>
+  </p>
+  <?php } ?>
 <?php } else if ( canView('System') ) { ?>
 		<p class="navbar-text"> <?php echo $status ?></p>
 <?php } ?>

--- a/web/skins/classic/js/base.js
+++ b/web/skins/classic/js/base.js
@@ -60,6 +60,7 @@ var popupSizes = {
   'preset':       {'width': 300, 'height': 220},
   'server':       {'width': 600, 'height': 405},
   'settings':     {'width': 220, 'height': 235},
+  'shutdown':     {'width': 400, 'height': 400},
   'state':        {'width': 400, 'height': 170},
   'stats':        {'width': 840, 'height': 200},
   'storage':      {'width': 600, 'height': 405},

--- a/web/skins/classic/views/shutdown.php
+++ b/web/skins/classic/views/shutdown.php
@@ -1,0 +1,69 @@
+<?php
+//
+// ZoneMinder web shutdown view file
+// Copyright (C) 2019 ZoneMinder LLC
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+
+if ( !canEdit('System') ) {
+  $view = 'error';
+  return;
+}
+
+$focusWindow = true;
+
+xhtmlHeaders(__FILE__, translate('Shutdown').' '.translate('Restart'));
+?>
+<body>
+  <div id="page">
+    <div id="header">
+      <h2><?php echo translate('Shutdown').' '.translate('Restart') ?></h2>
+    </div>
+    <div id="content">
+      <form name="contentForm" id="contentForm" method="post" action="?">
+        <input type="hidden" name="view" value="shutdown"/>
+<?php
+  if ( isset($output) ) {
+    echo '<p>'.implode('<br/>', $output).'</p>';
+  }
+  if ( isset($_POST['when']) and ($_POST['when'] != 'NOW') and ($action != 'cancel') ) {
+    echo '<p>You may cancel this shutdown by clicking '.translate('Cancel').'</p>';
+  }
+?>
+        <p class="warning"><h2>Warning</h2>
+          This command will either shutdown or restart all ZoneMinder Servers<br/>
+        </p>
+        <p>
+          <input type="radio" name="when" value="now" id="whennow"/><label for="whennow">Now</label>
+          <input type="radio" name="when" value="1min" id="when1min" checked="checked"/><label for="when1min">1 Minute</label>
+        </p>
+        <div id="contentButtons">
+<?php 
+  if ( isset($_POST['when']) and ($_POST['when'] != 'NOW') and ($action != 'cancel') ) {
+?>
+          <button type="submit" name="action" value="cancel"><?php echo translate('Cancel') ?></button>
+<?php 
+  }
+?>
+          <button type="submit" name="action" value="restart"><?php echo translate('Restart') ?></button>
+          <button type="submit" name="action" value="shutdown"><?php echo translate('Shutdown') ?></button>
+          <button type="button" data-on-click="closeWindow"><?php echo translate('Close') ?></button>
+        </div>
+      </form>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a power icon at the top right that pops up and allows the user to either shutdown or restart the ZM server.   This feature would mostly be useful for ZM appliances, but might be of interest to others as well.

![powerbutton](https://user-images.githubusercontent.com/925519/56059645-80abc700-5d32-11e9-8fd6-96d0f129e824.png)

![shutdownpopup](https://user-images.githubusercontent.com/925519/56059745-c8325300-5d32-11e9-81da-03267eb9af02.png)
![shutdownhelp](https://user-images.githubusercontent.com/925519/56059785-f152e380-5d32-11e9-84c7-00d725284bd5.png)
