### PR TITLE
Fix image path

### DIFF
--- a/web/skins/classic/css/classic/views/control.css
+++ b/web/skins/classic/css/classic/views/control.css
@@ -115,7 +115,7 @@
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .centerBtn {
-    background: url("../skins/classic/graphics/graphics/center.png") no-repeat 0 0;
+    background: url("../skins/classic/graphics/center.png") no-repeat 0 0;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .rightBtn {


### PR DESCRIPTION
Change the path of the "center.png" image from skins/classic/graphics/graphics/center.png to skins/classic/graphics/center.png.

Note that the `graphics/` directory was previously duplicated.