### PR TITLE
test for error code from db creation and die on error

### DIFF
--- a/distros/debian/postinst
+++ b/distros/debian/postinst
@@ -31,6 +31,10 @@ if [ "$1" = "configure" ]; then
                 # test if database if already present...
                 if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
                     cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+                    if [ $? -ne 0 ]; then
+                      echo "Error creating db."
+                      exit 1;
+                    fi
                     # This creates the user.
                     echo "grant lock tables, alter,select,insert,update,delete,create,index on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
                 else

--- a/distros/ubuntu1204/zoneminder.postinst
+++ b/distros/ubuntu1204/zoneminder.postinst
@@ -34,6 +34,10 @@ if [ "$1" = "configure" ]; then
         # test if database if already present...
         if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
           cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+          if [ $? -ne 0 ]; then
+            echo "Error creating db."
+            exit 1;
+          fi
           # This creates the user.
           echo "grant lock tables, alter,drop,select,insert,update,delete,create,index,alter routine,create routine, trigger,execute on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
         else

--- a/distros/ubuntu1604/zoneminder.postinst
+++ b/distros/ubuntu1604/zoneminder.postinst
@@ -56,6 +56,10 @@ if [ "$1" = "configure" ]; then
         if ! $(echo quit | mysql --defaults-file=/etc/mysql/debian.cnf zm > /dev/null 2> /dev/null) ; then
             echo "Creating zm db"
             cat /usr/share/zoneminder/db/zm_create.sql | mysql --defaults-file=/etc/mysql/debian.cnf
+            if [ $? -ne 0 ]; then
+              echo "Error creating db."
+              exit 1;
+            fi
             # This creates the user.
             echo "grant lock tables,alter,drop,select,insert,update,delete,create,index,alter routine,create routine, trigger,execute  on ${ZM_DB_NAME}.* to '${ZM_DB_USER}'@localhost identified by \"${ZM_DB_PASS}\";" | mysql --defaults-file=/etc/mysql/debian.cnf mysql
         else


### PR DESCRIPTION
If there is an error populating the db the dpkg scripts don't notice and continue like it's a successful install, which it isn't. 

This adds the necessary lines to exit the postinst scripts with an error code if the db population fails.
