### PR TITLE
When writing MP4 sample, save buffer.size() into a temporary variable

### DIFF
--- a/src/zm_video.cpp
+++ b/src/zm_video.cpp
@@ -101,7 +101,7 @@ X264MP4Writer::X264MP4Writer(
     Error("Failed init swscaleobj");
     return;
   }
-    
+
   swscaleobj.SetDefaults(zm_pf, codec_pf, width, height);
 
   /* Calculate the image sizes. We will need this for parameter checking */
@@ -458,11 +458,12 @@ int X264MP4Writer::x264encodeloop(bool bFlush) {
 
       /* Write the sample */
       if ( !buffer.empty() ) {
+        unsigned int bufSize = buffer.size();
         if ( !MP4WriteSample(
               mp4h,
               mp4vtid,
-              buffer.extract(buffer.size()),
-              buffer.size(),
+              buffer.extract(bufSize),
+              bufSize,
               duration,
               offset,
               prevKeyframe) ) {


### PR DESCRIPTION
This is a fix for https://github.com/ZoneMinder/zoneminder/issues/2403

After a lot of debugging it turned out that after calling `buffer.extract()`, the `buffer.size()` method starts to return 0, which is then passed to mp4v2.