### PR TITLE
add options help to linked monitors option

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -1016,6 +1016,18 @@ $OLANG = array(
       for new images. In this case, it is safe to use the field.
       '
 	),
+	'OPTIONS_LINKED_MONITORS' => array(
+    'Help' => '
+      This field allows you to select other monitors on your system that act as 
+      triggers for this monitor. So if you have a camera covering one aspect of 
+      your property you can force all cameras to record while that camera 
+      detects motion or other events.  You can either directly enter a comma 
+      separated list of monitor ids or click on ‘Select’ to choose a selection. 
+      Be very careful not to create circular dependencies with this feature 
+      however you will have infinitely persisting alarms which is almost 
+      certainly not what you want! To unlink monitors you canctrl-click.
+      '
+	),
 
 //    'LANG_DEFAULT' => array(
 //        'Prompt' => "This is a new prompt for this option",

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -1021,11 +1021,10 @@ $OLANG = array(
       This field allows you to select other monitors on your system that act as 
       triggers for this monitor. So if you have a camera covering one aspect of 
       your property you can force all cameras to record while that camera 
-      detects motion or other events.  You can either directly enter a comma 
-      separated list of monitor ids or click on ‘Select’ to choose a selection. 
+      detects motion or other events. Click on ‘Select’ to choose linked monitors. 
       Be very careful not to create circular dependencies with this feature 
-      however you will have infinitely persisting alarms which is almost 
-      certainly not what you want! To unlink monitors you canctrl-click.
+      because you will have infinitely persisting alarms which is almost 
+      certainly not what you want! To unlink monitors you can ctrl-click.
       '
 	),
 

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -716,7 +716,7 @@ switch ( $tab ) {
       if ( $monitor->Type != 'WebSite' ) {
 ?>
         <tr>
-          <td><?php echo translate('LinkedMonitors') ?></td>
+          <td><?php echo translate('LinkedMonitors') ?>&nbsp;(<?php echo makePopupLink('?view=optionhelp&amp;option=OPTIONS_LINKED_MONITORS', 'zmOptionHelp', 'optionhelp', '?' ) ?>)</td>
           <td>
             <select name="monitorIds" class="chosen" multiple="multiple" onchange="updateLinkedMonitors( this )">
 <?php


### PR DESCRIPTION
Add the information about how to create linked monitors to the monitors page as an optionshelp popup

popup link:
![2019-06- 4_13-39-40](https://user-images.githubusercontent.com/91288/58880097-031b8c00-86cf-11e9-8fe6-1d99bd8a9dea.png)

optionshelp page:
![2019-06- 4_13-40-14](https://user-images.githubusercontent.com/91288/58880094-0151c880-86cf-11e9-9570-a937c1bd1524.png)


