### PR TITLE
add event file system path to API

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -35,6 +35,7 @@ class EventsController extends AppController {
     $this->Event->recursive = -1;
 
     global $user;
+    require_once __DIR__ .'/../../../includes/Event.php';
     $allowedMonitors = $user ? preg_split('@,@', $user['MonitorIds'], NULL, PREG_SPLIT_NO_EMPTY) : null;
 
     if ( $allowedMonitors ) {
@@ -87,9 +88,13 @@ class EventsController extends AppController {
     $events = $this->Paginator->paginate('Event');
 
     // For each event, get the frameID which has the largest score
+    // also add FS path
+
     foreach ( $events as $key => $value ) {
+      $EventObj = new ZM\Event($value['Event']['Id']);
       $maxScoreFrameId = $this->getMaxScoreAlarmFrameId($value['Event']['Id']);
       $events[$key]['Event']['MaxScoreFrameId'] = $maxScoreFrameId;
+      $events[$key]['Event']['FileSystemPath'] = $EventObj->Path();
     }
 
     $this->set(compact('events'));
@@ -130,6 +135,9 @@ class EventsController extends AppController {
 
     $event['Event']['fileExists'] = $this->Event->fileExists($event['Event']);
     $event['Event']['fileSize'] = $this->Event->fileSize($event['Event']);
+
+    $EventObj = new ZM\Event($id);
+    $event['Event']['FileSystemPath'] = $EventObj->Path();
 
     # Also get the previous and next events for the same monitor
     $event_monitor_neighbors = $this->Event->find('neighbors', array(


### PR DESCRIPTION
This PR adds the file system path for events to both the event summary API and individual events API. This is useful for 3rd party programs, like object detection and zmMagik for video annotation overwrites.