### PR TITLE
fix for zone overlay scaling issues in montage

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -206,7 +206,7 @@ function Monitor(monitorData) {
 
 /**
  * called when the layoutControl select element is changed, or the page
- * is rendered??
+ * is rendered
  * @return null
  */
 function selectLayout(element) {
@@ -270,10 +270,7 @@ function selectLayout(element) {
           // APPLET's and OBJECTS need to be re-initialized
         }
         streamImg.style.width = '100%';
-
-        updateZoneSvg(monitor, streamImg.getSize().x, streamImg.getSize().y);
       }
-
     } // end foreach monitor
   }
 } // end function selectLayout(element)
@@ -316,12 +313,7 @@ function changeSize() {
       streamImg.style.width = width ? width : null;
       streamImg.style.height = height ? height : null;
       //streamImg.style.height = '';
-
-      // not sure how the above block works... so rescale zone if img changed??
-      updateZoneSvg(monitor, streamImg.getSize().x, streamImg.getSize().y);
     }
-
-
   }
   $('scale').set('value', '');
   Cookie.write('zmMontageScale', '', {duration: 10*365});
@@ -337,7 +329,6 @@ function changeSize() {
 function changeScale() {
   var scale = $('scale').get('value');
   $('width').set('value', 'auto');
-  // console.dir($('width'));
   $('height').set('value', 'auto');
   Cookie.write('zmMontageScale', scale, {duration: 10*365});
   Cookie.write('zmMontageWidth', '', {duration: 10*365});
@@ -348,10 +339,6 @@ function changeScale() {
   }
   for ( var i = 0, length = monitors.length; i < length; i++ ) {
     var monitor = monitors[i];
-
-    // console.log("scale = "+scale);
-    // console.log("SCALE_BASE = " + SCALE_BASE);
-
     var newWidth = ( monitorData[i].width * scale ) / SCALE_BASE;
     var newHeight = ( monitorData[i].height * scale ) / SCALE_BASE;
 
@@ -384,124 +371,7 @@ function changeScale() {
       streamImg.style.width = newWidth + "px";
       streamImg.style.height = newHeight + "px";
     }
-
-    // console.log("monitor_frame.height = " + monitor_frame.height());
-    // console.log("newHeight = " + newHeight);
-
-    updateZoneSvg(monitor, newWidth, newHeight);
   }
-}
-
-
-// 
-// function updateZoneSvg(monitor, monitor_frame) {
-
-/**
- * cause the zone overlay Svg to track dims of associated monitor frame
- * @arg monitor_frame is a jQuery element object
- */
-function updateZoneSvg(monitor, newWidth, newHeight) {
-  console.log("calling updateZoneSvg");
-  // console.dir(monitor_frame);
-
-  // newWidth = monitor_frame.width();
-  // newHeight = monitor_frame.height();
-
-  if (!newWidth)
-    debugger;
-  if (!newHeight || newHeight < 10)
-    debugger;
-  if (!monitor)
-    monitor;
-
-  // zonesSVG is a mootools object
-  var zonesSVG = $('zones' + monitor.id);
-  if (zonesSVG) {
-
-    console.log("newWidth = " + newWidth);
-    console.log("newHeight = " + newHeight);
-    orig_scale = zonesSVG.getProperty('data-scale-orig');
-
-    //debugger;
-    //console.log("zonesSVG.style.width =" + zonesSVG.style.width);
-    zonesSVG.style.width = newWidth + "px";
-    //console.log("newWidth = " + newWidth + "px");
-    //console.log("zonesSVG.style.width = " + zonesSVG.style.width);
-    zonesSVG.style.height = newHeight + "px";
-
-    polygons = zonesSVG.getElements("polygon");
-
-    for (let index = 0; index < polygons.length; index++) {
-      const polygon = polygons[index];
-      //console.dir(polygon);
-
-      points = coordsToPoints(polygon.getProperty("data-coords-orig"));
-      //console.dir(points);
-
-      newPoints = scaleZonePoints(points,
-        newWidth / monitorData[index].width,
-        newHeight / monitorData[index].height);
-
-      //console.dir(newPoints);
-
-      //console.dir(newPoints);
-      //console.dir();
-      //console.dir(pointsToCoords(newPoints));
-
-      polygon.setProperty("points", pointsToCoords(newPoints));
-      
-    }
-  }
-}
-
-/**
- * 
- * @param {*} points 
- * @param {*} scale 
- */
-function scaleZonePoints(points, scalex, scaley) {
-  if (!points)
-    debugger;
-  if (!scalex)
-    debugger;
-  if (!scaley)
-    debugger;
-  // console.dir(points);
-  //debugger;
-  var newPoints = [];
-  for (let index = 0; index < points.length; index++) {
-    const point = points[index];
-    newPoints.push([point[0] * scalex, point[1] * scaley ]);
-  }
-  // console.dir(newPoints);
-  return newPoints;
-}
-
-/**
- * convery coords string - "37,411 1246,542 1263,694 ..." to js array
- * @param {*} coords
- */
-function coordsToPoints(coords) {
-  var points = [];
-  points = coords.split(" ").map(function (item) {
-    return item.split(",").map(Math.round);
-  });
-  // console.dir(points);
-  return points;
-}
-
-/**
- * convery points array to string - "37,411 1246,542 1263,694 ..."
- * @param {*} coords
- */
-function pointsToCoords(points) {
-  // console.dir(points);
-  var coords = [];
-  coords = points.map(function (item) {
-    return item.map(Math.round).join(",");
-  }).join(",");
-  // console.dir(coords);
-  return coords;
 }
 
 function toGrid(value) {

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -207,9 +207,11 @@ function Monitor(monitorData) {
 /**
  * called when the layoutControl select element is changed, or the page
  * is rendered
- * @return null
+ * @param {*} element - the event data passed by onchange callback
  */
 function selectLayout(element) {
+
+  console.dir(element);
   layout = $j(element).val();
 
   if ( layout_id = parseInt(layout) ) {
@@ -277,7 +279,6 @@ function selectLayout(element) {
 
 /**
  * called when the widthControl|heightControl select elements are changed
- * @return null
  */
 function changeSize() {
   var width = $('width').get('value');
@@ -324,7 +325,6 @@ function changeSize() {
 
 /**
  * called when the scaleControl select element is changed
- * @return null
  */
 function changeScale() {
   var scale = $('scale').get('value');

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -210,7 +210,6 @@ function Monitor(monitorData) {
  * @param {*} element - the event data passed by onchange callback
  */
 function selectLayout(element) {
-
   console.dir(element);
   layout = $j(element).val();
 

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -204,6 +204,11 @@ function Monitor(monitorData) {
   }
 } // end function Monitor
 
+/**
+ * called when the layoutControl select element is changed, or the page
+ * is rendered??
+ * @return null
+ */
 function selectLayout(element) {
   layout = $j(element).val();
 
@@ -265,15 +270,18 @@ function selectLayout(element) {
           // APPLET's and OBJECTS need to be re-initialized
         }
         streamImg.style.width = '100%';
+
+        updateZoneSvg(monitor, streamImg.getSize().x, streamImg.getSize().y);
       }
-      var zonesSVG = $('zones'+monitor.id);
-      if ( zonesSVG ) {
-        zonesSVG.style.width = '';
-      }
+
     } // end foreach monitor
   }
 } // end function selectLayout(element)
 
+/**
+ * called when the widthControl|heightControl select elements are changed
+ * @return null
+ */
 function changeSize() {
   var width = $('width').get('value');
   var height = $('height').get('value');
@@ -308,12 +316,12 @@ function changeSize() {
       streamImg.style.width = width ? width : null;
       streamImg.style.height = height ? height : null;
       //streamImg.style.height = '';
+
+      // not sure how the above block works... so rescale zone if img changed??
+      updateZoneSvg(monitor, streamImg.getSize().x, streamImg.getSize().y);
     }
-    var zonesSVG = $('zones'+monitor.id);
-    if ( zonesSVG ) {
-      zonesSVG.style.width = width ? width : '100%';
-      zonesSVG.style.height = height;
-    }
+
+
   }
   $('scale').set('value', '');
   Cookie.write('zmMontageScale', '', {duration: 10*365});
@@ -322,9 +330,14 @@ function changeSize() {
   selectLayout('#zmMontageLayout');
 } // end function changeSize()
 
+/**
+ * called when the scaleControl select element is changed
+ * @return null
+ */
 function changeScale() {
   var scale = $('scale').get('value');
   $('width').set('value', 'auto');
+  // console.dir($('width'));
   $('height').set('value', 'auto');
   Cookie.write('zmMontageScale', scale, {duration: 10*365});
   Cookie.write('zmMontageWidth', '', {duration: 10*365});
@@ -335,6 +348,10 @@ function changeScale() {
   }
   for ( var i = 0, length = monitors.length; i < length; i++ ) {
     var monitor = monitors[i];
+
+    // console.log("scale = "+scale);
+    // console.log("SCALE_BASE = " + SCALE_BASE);
+
     var newWidth = ( monitorData[i].width * scale ) / SCALE_BASE;
     var newHeight = ( monitorData[i].height * scale ) / SCALE_BASE;
 
@@ -367,12 +384,124 @@ function changeScale() {
       streamImg.style.width = newWidth + "px";
       streamImg.style.height = newHeight + "px";
     }
-    var zonesSVG = $('zones'+monitor.id);
-    if ( zonesSVG ) {
-      zonesSVG.style.width = newWidth + "px";
-      zonesSVG.style.height = newHeight + "px";
+
+    // console.log("monitor_frame.height = " + monitor_frame.height());
+    // console.log("newHeight = " + newHeight);
+
+    updateZoneSvg(monitor, newWidth, newHeight);
+  }
+}
+
+
+// 
+// function updateZoneSvg(monitor, monitor_frame) {
+
+/**
+ * cause the zone overlay Svg to track dims of associated monitor frame
+ * @arg monitor_frame is a jQuery element object
+ */
+function updateZoneSvg(monitor, newWidth, newHeight) {
+  console.log("calling updateZoneSvg");
+  // console.dir(monitor_frame);
+
+  // newWidth = monitor_frame.width();
+  // newHeight = monitor_frame.height();
+
+  if (!newWidth)
+    debugger;
+  if (!newHeight || newHeight < 10)
+    debugger;
+  if (!monitor)
+    monitor;
+
+  // zonesSVG is a mootools object
+  var zonesSVG = $('zones' + monitor.id);
+  if (zonesSVG) {
+
+    console.log("newWidth = " + newWidth);
+    console.log("newHeight = " + newHeight);
+    orig_scale = zonesSVG.getProperty('data-scale-orig');
+
+    //debugger;
+    //console.log("zonesSVG.style.width =" + zonesSVG.style.width);
+    zonesSVG.style.width = newWidth + "px";
+    //console.log("newWidth = " + newWidth + "px");
+    //console.log("zonesSVG.style.width = " + zonesSVG.style.width);
+    zonesSVG.style.height = newHeight + "px";
+
+    polygons = zonesSVG.getElements("polygon");
+
+    for (let index = 0; index < polygons.length; index++) {
+      const polygon = polygons[index];
+      //console.dir(polygon);
+
+      points = coordsToPoints(polygon.getProperty("data-coords-orig"));
+      //console.dir(points);
+
+      newPoints = scaleZonePoints(points,
+        newWidth / monitorData[index].width,
+        newHeight / monitorData[index].height);
+
+      //console.dir(newPoints);
+
+      //console.dir(newPoints);
+      //console.dir();
+      //console.dir(pointsToCoords(newPoints));
+
+      polygon.setProperty("points", pointsToCoords(newPoints));
+      
     }
   }
+}
+
+/**
+ * 
+ * @param {*} points 
+ * @param {*} scale 
+ */
+function scaleZonePoints(points, scalex, scaley) {
+  if (!points)
+    debugger;
+  if (!scalex)
+    debugger;
+  if (!scaley)
+    debugger;
+  // console.dir(points);
+  //debugger;
+  var newPoints = [];
+  for (let index = 0; index < points.length; index++) {
+    const point = points[index];
+    newPoints.push([point[0] * scalex, point[1] * scaley ]);
+  }
+  // console.dir(newPoints);
+  return newPoints;
+}
+
+/**
+ * convery coords string - "37,411 1246,542 1263,694 ..." to js array
+ * @param {*} coords
+ */
+function coordsToPoints(coords) {
+  var points = [];
+  points = coords.split(" ").map(function (item) {
+    return item.split(",").map(Math.round);
+  });
+  // console.dir(points);
+  return points;
+}
+
+/**
+ * convery points array to string - "37,411 1246,542 1263,694 ..."
+ * @param {*} coords
+ */
+function pointsToCoords(points) {
+  // console.dir(points);
+  var coords = [];
+  coords = points.map(function (item) {
+    return item.map(Math.round).join(",");
+  }).join(",");
+  // console.dir(coords);
+  return coords;
 }
 
 function toGrid(value) {

--- a/web/skins/classic/views/montage.php
+++ b/web/skins/classic/views/montage.php
@@ -269,7 +269,7 @@ foreach ( $monitors as $monitor ) {
     } // end foreach Zone
 ?>
 
-<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: <?php echo $width ?>px; height: <?php echo $height ?>px;">
+<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: <?php echo $width ?>; height: <?php echo $height ?>;">
 <?php
 foreach( array_reverse($zones) as $zone ) {
   echo '<polygon points="'. $zone['AreaCoords'] .'" class="'. $zone['Type'].'" />';

--- a/web/skins/classic/views/montage.php
+++ b/web/skins/classic/views/montage.php
@@ -254,13 +254,9 @@ foreach ( $monitors as $monitor ) {
     $zones = array();
     foreach( dbFetchAll('SELECT * FROM Zones WHERE MonitorId=? ORDER BY Area DESC', NULL, array($monitor->Id()) ) as $row ) {
       $row['Points'] = coordsToPoints($row['Coords']);
-      $row['Points_orig'] = $row['Points'];
-      $row['Coords_orig'] = $row['Coords'];
-      // $monitor.orig_points = $row['Points'];
 
       if ( $scale ) {
         limitPoints($row['Points'], 0, 0, $monitor->Width(), $monitor->Height());
-        scalePoints($row['Points'], $scale);
       } else {
         limitPoints($row['Points'], 0, 0, 
             ( $width ? $width-1 : $monitor->Width()-1 ),
@@ -273,11 +269,10 @@ foreach ( $monitors as $monitor ) {
     } // end foreach Zone
 ?>
 
-<!-- track original values from when page is loaded with data-x-orig -->
-<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: <?php echo $width ?>; height: <?php echo $height ?>;" data-width-orig="<?php echo $width ?>" data-height-orig="<?php echo $height ?>" data-scale-orig="<?php echo $scale ? $scale : 100 ?>">
+<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: 100%; height: 100%;" viewBox="0 0 <?php echo  $monitor->Width() ?> <?php echo  $monitor->Height() ?>" preserveAspectRatio="none">
 <?php
 foreach( array_reverse($zones) as $zone ) {
-  echo '<polygon points="'. $zone['AreaCoords'] .'" data-areacoords-orig="'. $zone['AreaCoords'] .'" data-coords-orig="'. $zone['Coords_orig'] .'" class="'. $zone['Type'].'" />';
+  echo '<polygon points="'. $zone['AreaCoords'] .'" class="'. $zone['Type'].'" />';
 } // end foreach zone
 ?>
   Sorry, your browser does not support inline SVG

--- a/web/skins/classic/views/montage.php
+++ b/web/skins/classic/views/montage.php
@@ -43,6 +43,7 @@ $widths = array(
 $heights = array( 
   'auto'  => 'auto',
   '240px' => '240px',
+  '320px' => '320px',
   '480px' => '480px',
   '720px' => '720px',
   '1080px' => '1080px',
@@ -253,6 +254,9 @@ foreach ( $monitors as $monitor ) {
     $zones = array();
     foreach( dbFetchAll('SELECT * FROM Zones WHERE MonitorId=? ORDER BY Area DESC', NULL, array($monitor->Id()) ) as $row ) {
       $row['Points'] = coordsToPoints($row['Coords']);
+      $row['Points_orig'] = $row['Points'];
+      $row['Coords_orig'] = $row['Coords'];
+      // $monitor.orig_points = $row['Points'];
 
       if ( $scale ) {
         limitPoints($row['Points'], 0, 0, $monitor->Width(), $monitor->Height());
@@ -269,10 +273,11 @@ foreach ( $monitors as $monitor ) {
     } // end foreach Zone
 ?>
 
-<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: <?php echo $width ?>; height: <?php echo $height ?>;">
+<!-- track original values from when page is loaded with data-x-orig -->
+<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="position:absolute; top: 0; left: 0; background: none; width: <?php echo $width ?>; height: <?php echo $height ?>;" data-width-orig="<?php echo $width ?>" data-height-orig="<?php echo $height ?>" data-scale-orig="<?php echo $scale ? $scale : 100 ?>">
 <?php
 foreach( array_reverse($zones) as $zone ) {
-  echo '<polygon points="'. $zone['AreaCoords'] .'" class="'. $zone['Type'].'" />';
+  echo '<polygon points="'. $zone['AreaCoords'] .'" data-areacoords-orig="'. $zone['AreaCoords'] .'" data-coords-orig="'. $zone['Coords_orig'] .'" class="'. $zone['Type'].'" />';
 } // end foreach zone
 ?>
   Sorry, your browser does not support inline SVG


### PR DESCRIPTION
Currently the zone overlay svg is mis-sized due to extra "px" suffixed to the height and width

![2019-06-19_21-17-06](https://user-images.githubusercontent.com/91288/59797758-65cc7480-92d8-11e9-975a-d88df11a7721.png)

it's due to the extra "px" being appended, it messes up the values...


![2019-06-19_21-17-51](https://user-images.githubusercontent.com/91288/59797757-65cc7480-92d8-11e9-9438-44d550f5281d.png)

After fix....

![2019-06-19_21-20-46](https://user-images.githubusercontent.com/91288/59797756-65cc7480-92d8-11e9-96a1-9e4dac134b21.png)

