### PR TITLE
Delete the selected event, not the most recent one (#2579)

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -523,7 +523,7 @@ function getEventCmdResponse( respObj, respText ) {
     } );
 
     for ( var i = 0; i < dbEvents.length; i++ ) {
-      let event = dbEvents[i];
+      const event = dbEvents[i];
       var row = $('event'+event.Id);
       var newEvent = (row == null ? true : false);
       if ( newEvent ) {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -523,7 +523,7 @@ function getEventCmdResponse( respObj, respText ) {
     } );
 
     for ( var i = 0; i < dbEvents.length; i++ ) {
-      var event = dbEvents[i];
+      let event = dbEvents[i];
       var row = $('event'+event.Id);
       var newEvent = (row == null ? true : false);
       if ( newEvent ) {


### PR DESCRIPTION
The click event uses a closure to call deleteEvent with event.Id as parameter. At the end of the loop the value of event.Id is always equal to the id of the most recent event, so trying to delete any row always results in deleting the most recent event. 

Making the event block scoped instead of function scoped fixes this.