### PR TITLE
Refresh event list instead of page reload

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -462,12 +462,6 @@ function cmdCancelForcedAlarm() {
 }
 
 function getActResponse( respObj, respText ) {
-  if ( respObj.result == 'Ok' ) {
-    if ( respObj.refreshParent ) {
-      console.log('refreshing');
-      window.opener.location.reload();
-    }
-  }
   eventCmdQuery();
 }
 


### PR DESCRIPTION
There seems to be no need to reload the page. Refreshing the event list seems sufficient and prevents flicker and/or scroll position changes.