### PR TITLE
Fix iOS autocapitalizing username field on login

### DIFF
--- a/web/skins/classic/views/login.php
+++ b/web/skins/classic/views/login.php
@@ -19,7 +19,7 @@ xhtmlHeaders(__FILE__, translate('Login') );
         <h1><i class="material-icons md-36">account_circle</i> <?php echo validHtmlStr(ZM_WEB_TITLE) . ' ' . translate('Login') ?></h1>
 	
 				<label for="inputUsername" class="sr-only"><?php echo translate('Username') ?></label>
-				<input type="text" id="inputUsername" name="username" class="form-control" placeholder="Username" required autofocus autocomplete="username"/>
+				<input type="text" id="inputUsername" name="username" class="form-control" autocapitalize="none" placeholder="Username" required autofocus autocomplete="username"/>
 	
 				<label for="inputPassword" class="sr-only"><?php echo translate('Password') ?></label>
 				<input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required autocomplete="current-password"/>


### PR DESCRIPTION
I propose removing the auto-capitalization from the username field for Safari under iOS by adding autocapitalize="none" to the username form field. Usernames rarely start with a capital letter, so I think this would be a usability improvement for users logging in through iPhones or iPads, and might also fix for Android users too.

Having to login to ZM under iOS, I've been frustrated at the need to always press on the Caps Lock key on the virtual keyboard to disable the capitalization of the first letter. This is because iOS auto capitalized non-password and non-email HTML form fields. ZM is also case sensitive, so "Admin" will not work if the main user is "admin".