### PR TITLE
add model validation so that we don't create empty monitors

### DIFF
--- a/web/api/app/Controller/MonitorsController.php
+++ b/web/api/app/Controller/MonitorsController.php
@@ -124,14 +124,17 @@ class MonitorsController extends AppController {
         throw new UnauthorizedException(__('Insufficient privileges'));
         return;
       }
-
       $this->Monitor->create();
-      if ( $this->Monitor->save($this->request->data) ) {
+      if ($this->Monitor->save($this->request->data) ) {
         $this->daemonControl($this->Monitor->id, 'start');
         //return $this->flash(__('The monitor has been saved.'), array('action' => 'index'));
         $message = 'Saved';
       } else {
         $message = 'Error';
+        // if there is a validation message, use it
+        if (!$this->Monitor->validates()) {
+          $message = $this->Monitor->validationErrors;
+       }
       }
       $this->set(array(
         'message' => $message,

--- a/web/api/app/Model/Monitor.php
+++ b/web/api/app/Model/Monitor.php
@@ -47,7 +47,16 @@ class Monitor extends AppModel {
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
 		),
-	);
+    'Name' => array(
+       'required' => array(
+         'on'         => 'create',
+         'rule'       => 'notEmpty',
+         'message'    => 'Monitor Name must be specified for creation',
+         'required'   => true,
+       ),
+     )
+
+  );
 
 	//The Associations below have been created with all possible keys, those that are not needed can be removed
 


### PR DESCRIPTION
It is possible to add a monitor via the API without a name. When we then try and delete the monitor from the UI, the code removes the full events directory for all monitors (as `Name` is empty). 