### PR TITLE
fix #2771.  

### DIFF
--- a/web/api/app/Controller/GroupsController.php
+++ b/web/api/app/Controller/GroupsController.php
@@ -77,16 +77,24 @@ class GroupsController extends AppController {
       }
 
 			$this->Group->create();
-			if ( $this->Group->save($this->request->data) ) {
+
+      if ( $this->request->data['Group']['MonitorIds'] and ! isset($this->request->data['Monitor']) ) {
+        $this->request->data['Monitor'] = explode(',', $this->request->data['Group']['MonitorIds']);
+        unset($this->request->data['Group']['MonitorIds']);
+      }
+      if ( $this->Group->saveAssociated($this->request->data, array('atomic'=>true)) ) {
         return $this->flash(
           __('The group has been saved.'),
           array('action' => 'index')
         );
-			}
-		}
-		$monitors = $this->Group->Monitor->find('list');
+      } else {
+        ZM\Error("Failed to save Group");
+        debug($this->Group->invalidFields());
+      }
+    } # end if post
+    $monitors = $this->Group->Monitor->find('list');
 		$this->set(compact('monitors'));
-	}
+	} # end add
 
 /**
  * edit method

--- a/web/api/app/Model/Group.php
+++ b/web/api/app/Model/Group.php
@@ -59,7 +59,7 @@ class Group extends AppModel {
  *
  * @var array
  */
-	public $hasMany = array(
+	public $hasAndBelongsToMany = array(
 		'Monitor' => array(
 			'className' => 'Monitor',
       'joinTable' =>  'Groups_Monitors',


### PR DESCRIPTION
Correct relationship from hasMany to hasAndBelongsToMany for Monitors in Group Model.  Use saveAssociated in Controller instead of save, and add code to handle backwards compatibility by turning MonitorIds into the appropriate Monitor array