### PR TITLE
Fixed unquoted variable which was failing to correctly detect error case

### DIFF
--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -175,7 +175,7 @@ cd ../
 
 VERSION=`cat ${GITHUB_FORK}_zoneminder_release/version`
 
-if [ $VERSION == "" ]; then
+if [ -z "$VERSION" ]; then
   exit 1;
 fi;
 if [ "$SNAPSHOT" != "stable" ] && [ "$SNAPSHOT" != "" ]; then


### PR DESCRIPTION
This was discovered when there was a DNS failure (it's always DNS) and
it caused a syntax error on line 178.  I changed it to use -z to check
for a zero length string, as suggested by the man page.  Putting $VERSION
in double quotes would also be a valid fix.

Here's what the script looks like when it fails:

./do_debian_package.sh --snapshot=stable --type=local --interactive=no
Doing local build
Defaulting to bionic for distribution
Defaulting to ZoneMinder upstream git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
Latest stable branch is
git clone https://github.com/ZoneMinder/ZoneMinder.git ZoneMinder_zoneminder_release
Cloning into 'ZoneMinder_zoneminder_release'...
fatal: unable to access 'https://github.com/ZoneMinder/ZoneMinder.git/': Could not resolve host: github.com
./do_debian_package.sh: line 172: cd: ZoneMinder_zoneminder_release: No such file or directory
fatal: not a git repository (or any of the parent directories): .git
cat: ZoneMinder_zoneminder_release/version: No such file or directory
./do_debian_package.sh: line 178: [: ==: unary operator expected
Doing local release zoneminder_
mv: cannot stat 'ZoneMinder_zoneminder_release': No such file or directory
Error status code is: 0
Setting up build dir failed.