### PR TITLE
fix tar invocation for *BSD platforms

### DIFF
--- a/web/skins/classic/includes/export_functions.php
+++ b/web/skins/classic/includes/export_functions.php
@@ -940,6 +940,8 @@ function exportEvents(
   $archive = '';
   if ( $exportFormat == 'tar' ) {
     $archive = ZM_DIR_EXPORTS.'/'.$export_root.($connkey?'_'.$connkey:'').'.tar';
+    $version = shell_exec('tar -v');
+
     $command = 'tar --create --dereference';
     if ( $exportCompressed ) {
       $archive .= '.gz';
@@ -947,8 +949,11 @@ function exportEvents(
       $exportFormat .= '.gz';
     }
     if ( $exportStructure == 'flat' ) {
-      //strip file paths if we 
-      $command .= " --xform='s#^.+/##x'";
+      if (preg_match("/BSD/i", $version)) {
+        $command .= " -s '#^.*/##'";
+      } else {
+        $command .= " --xform='s#^.+/##x'";
+      }
     }
     $command .= ' --file='.escapeshellarg($archive);
   } elseif ( $exportFormat == 'zip' ) {


### PR DESCRIPTION
"--xform" switch is not supported by tar on BSD platforms i.e. *BSD,
MacOS, etc. As such, use "-s" switch on these platforms, with a
similar regexp.

Fixes #2389, thanks to @davidjb for suggesting the fix.
Tested on Ubuntu 18.04 x86_64 and nothing seems broken for the event exports