### PR TITLE
Bug fix Montage page: Allows for proper functionality if MultiPort isn't configured

### DIFF
--- a/web/skins/classic/views/js/montage.js.php
+++ b/web/skins/classic/views/js/montage.js.php
@@ -35,7 +35,7 @@ monitorData[monitorData.length] = {
   'connKey': <?php echo $monitor->connKey() ?>, 
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,
-  'url': '<?php echo $monitor->UrlToIndex( $monitor->Id() + ZM_MIN_STREAMING_PORT) ?>',
+  'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'onclick': function(){createPopup( '?view=watch&mid=<?php echo $monitor->Id() ?>', 'zmWatch<?php echo $monitor->Id() ?>', 'watch', <?php echo reScale( $monitor->ViewWidth(), $monitor->PopupScale() ); ?>, <?php echo reScale( $monitor->ViewHeight(), $monitor->PopupScale() ); ?> );},
   'type': '<?php echo $monitor->Type() ?>',
   'refresh': '<?php echo $monitor->Refresh() ?>'


### PR DESCRIPTION
…config value assigned

Without this edit a vanilla install's (or an upgraded install who doesn't used MultiPort) montage page would render with a "A non-numeric value encountered" inside of the monitordata block, breaking functionality.