### PR TITLE
fix_class_PTZ_presets_almost_invisible

### DIFF
--- a/web/skins/classic/css/base/views/control.css
+++ b/web/skins/classic/css/base/views/control.css
@@ -15,7 +15,7 @@
 .ptzControls input.ptzTextBtn {
     margin-top: 2px;
 }
-.ptzControls button {
+.ptzControls .pantiltPanel button {
   border: none;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .ptzControls input[type=image] {
-    border: 0px;
+    border: none;
 }
 
 .ptzControls .controlsPanel .arrowControl {
@@ -140,10 +140,7 @@
     background: url("../skins/classic/graphics/arrow-dr.png") no-repeat 0 0;
 }
 
-.ptzControls .controlsPanel .powerControls {
-    margin: 5px auto;
-}
-
+.ptzControls .controlsPanel .powerControls,
 .ptzControls .presetControls div {
     margin: 5px 200px 5px 180px;
 }
@@ -153,8 +150,5 @@
 }
 
 .ptzControls .presetControls button.ptzNumBtn {
-    padding: 1px 2px;
     width: 45px;
-    color: #ffffff;
-    text-align: center;
 }

--- a/web/skins/classic/css/classic/views/control.css
+++ b/web/skins/classic/css/classic/views/control.css
@@ -134,10 +134,7 @@
     background: url("../skins/classic/graphics/arrow-dr.png") no-repeat 0 0;
 }
 
-.ptzControls .controlsPanel .powerControls {
-    margin: 5px auto;
-}
-
+.ptzControls .controlsPanel .powerControls,
 .ptzControls .presetControls {
     margin: 5px 200px 5px 180px;
 }
@@ -146,10 +143,9 @@
     margin: 1px;
 }
 
-.ptzControls .presetControls input.ptzNumBtn {
-    padding: 1px 2px;
-    width: 24px;
-    color: #ffffff;
-    text-align: center;
+.ptzControls .presetControls button.ptzNumBtn {
+  /*
     background-color: #016A9D;
+    */
+  border: 1px solid #7f7fb2;
 }

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -99,10 +99,9 @@ if ( $css != 'base' )
 <link rel="stylesheet" href="skins/classic/js/chosen/chosen.min.css" type="text/css"/>
 <?php
   if ( $basename == 'watch' ) {
-    echo output_link_if_exists( array(
-      '/css/base/views/control.css',
-      '/css/'.$css.'/views/control.css'
-    ) );
+    echo output_link_if_exists(array('/css/base/views/control.css'));
+    if ( $css != 'base' )
+      echo output_link_if_exists(array('/css/'.$css.'/views/control.css'));
   }
 ?>
   <style type="text/css">


### PR DESCRIPTION
Don't include controls.css twice if css is base. 
Don't use special styles for ptz buttons, so that they look like all the other buttons.
Fixes #2849