### PR TITLE
add area definition to zone creation via API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -482,6 +482,7 @@ Create a Zone
   &Zone[Units]=Percent\
   &Zone[NumCoords]=4\
   &Zone[Coords]=0,0 639,0 639,479 0,479\
+  &Zone[Area]=307200\
   &Zone[AlarmRGB]=16711680\
   &Zone[CheckMethod]=Blobs\
   &Zone[MinPixelThreshold]=25\


### PR DESCRIPTION
I believe this is needed if you're using the percentage method.  When I looked at zones created automatically via the UI, I noticed this was set.

In the example, 640 * 480 = 307200