### PR TITLE
Re-enable fragmented MP4, allow previews while event is recorded

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -110,10 +110,8 @@ Event::Event(
   id = mysql_insert_id(&dbconn);
   //
 
-  /* Now update event with DefaultVideo name if applicable, so index.php
-    can read frames while the video is being recorded, since MP4 is created
-    using fragments */
-  
+  /* Update event record with DefaultVideo name if possible so image.php can extract frames 
+     if needed, while recording is in progress */
   if ( monitor->GetOptVideoWriter() != 0 ) {
     video_name[0] = 0;
     snprintf(video_name, sizeof(video_name), "%" PRIu64 "-%s", id, "video.mp4");
@@ -123,7 +121,7 @@ Event::Event(
       Error("Can't update event: %s. sql was (%s)", mysql_error(&dbconn), sql);
       db_mutex.unlock();
       return;
-  }
+    }
   } else {
     Debug (1, "GetOptVideoWriter() returned 0, not updating DefaultVideo");
   }

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -120,9 +120,9 @@ Event::Event(
     Debug(1, "Updating inserted event with DefaultVideo=%s",video_name);
     snprintf(sql, sizeof(sql), "UPDATE Events SET DefaultVideo = '%s' WHERE Id=%" PRIu64, video_name,id);
     if ( mysql_query(&dbconn, sql) ) {
-    Error("Can't update event: %s. sql was (%s)", mysql_error(&dbconn), sql);
-    db_mutex.unlock();
-    return;
+      Error("Can't update event: %s. sql was (%s)", mysql_error(&dbconn), sql);
+      db_mutex.unlock();
+      return;
   }
   } else {
     Debug (1, "GetOptVideoWriter() returned 0, not updating DefaultVideo");

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -409,7 +409,7 @@ bool VideoStore::open() {
   AVDictionary *opts = NULL;
   // av_dict_set(&opts, "movflags", "frag_custom+dash+delay_moov", 0);
   // Shiboleth reports that this may break seeking in mp4 before it downloads
-  //av_dict_set(&opts, "movflags", "frag_keyframe+empty_moov", 0);
+  av_dict_set(&opts, "movflags", "frag_keyframe+empty_moov", 0);
   // av_dict_set(&opts, "movflags",
   // "frag_keyframe+empty_moov+default_base_moof", 0);
   if ( (ret = avformat_write_header(oc, &opts)) < 0 ) {


### PR DESCRIPTION
Motivation for this PR is to allow ZM to show recorded frames and interim videos(?) while the event is still being recorded.

I did the following tests on Chrome and Safari, for an in progress event:

a) Each MP4 burst (every 20 frames) seems to be viewable correctly when played if you copy over the video and try to play it
b) Frames display via ffmpeg slicing through image.php instead of showing broken thumbnails like it does now for an in progress video
c) Video playback may or may not work via ZM console using `view=video` URL - I assume that it because the video is constantly being written to, and possibly because the metadata is at the end. Worked in chrome (took time to load), seemed to keep loading in Safari (did not investigate further)

@connortechnology mentioned in Slack that this might have caused issues earlier about seek/download. There is a [somewhat unclear comment](https://github.com/ZoneMinder/zoneminder/blob/fdf5150a16ac9486d30a14cf9486709e7b2219f2/src/zm_videostore.cpp#L411-L412) in `zm_videostore.cpp` about this as well. Not sure what the exact issue is, but given the benefits, warrants a discussion.
