### PR TITLE
update detaint $command

### DIFF
--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -993,6 +993,7 @@ sub patchDB {
   $command .= '/zm_update-'.$version.'.sql';
 
   print("Executing '$command'\n") if logDebugging();
+  ($command ) = $ command =~ /(.*)/; # detaint
   my $output = qx($command);
   my $status = $? >> 8;
   if ( $status || logDebugging() ) {


### PR DESCRIPTION
updating the way executing a command with perl -T switch
I got below on freenas/freebsd plugin/jail
Insecure dependency in exec while running with -T switch at /usr/local/bin/zmupdate.pl line 992.
Ref: http://www.novosial.org/perl/backticks/index.html