### PR TITLE
Fix the scale to fit option that is not persisted on page refresh

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -849,7 +849,7 @@ function initPage() {
     if ( refreshApplet && appletRefreshTime ) {
       appletRefresh.delay(appletRefreshTime*1000);
     }
-    if ( scale == 'auto' ) changeScale();
+    if ( scale == '0' || scale == 'auto' ) changeScale();
     if ( window.history.length == 1 ) {
       $j('#closeControl').html('');
     }


### PR DESCRIPTION
Call to changeScale() on page init when "scale to fit" is selected.

Closes #2949 