### PR TITLE
Fix DiskSpace default arg

### DIFF
--- a/web/includes/Event.php
+++ b/web/includes/Event.php
@@ -262,7 +262,7 @@ class Event extends ZM_Object {
     return $streamSrc;
   } // end function getStreamSrc
 
-  function DiskSpace( $new='' ) {
+  function DiskSpace( $new=null ) {
     if ( is_null($new) or ( $new != '' ) ) {
       $this->{'DiskSpace'} = $new;
     }


### PR DESCRIPTION
#3007 

The UI passes null to DiskSpace(), which means take the default arg, an empty string.

In this case, the folder_size() is only calculated on the first call, and not subsequent calls.

I still don't think this functions logic is correct as any value passed to DiskSpace() ($new != '') will be reported in the UI but won't be updated in the database.  Not quite sure of the use case here.

