### PR TITLE
CI: Make sure the Travis build fails if packpack exits with an error code

### DIFF
--- a/utils/packpack/startpackpack.sh
+++ b/utils/packpack/startpackpack.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -o pipefail
+
 # packpack setup file for the ZoneMinder project
 # Written by Andrew Bauer
 
@@ -249,6 +252,13 @@ execpackpack () {
         fi
     else
         packpack/packpack $parms
+    fi
+
+    if [ $? -ne 0 ]; then
+      echo
+      echo "ERROR: An error occurred while executing packpack."
+      echo
+      exit 1
     fi
 }
 


### PR DESCRIPTION
Currently CI jobs do not fail when packpack exits with a non-zero error code.

Example of a recent build which should have failed: https://travis-ci.org/github/ZoneMinder/zoneminder/jobs/720731480

This PR leads to following CI job failures:

- [ ]  Ubuntu Trusty [Log](https://travis-ci.org/github/Carbenium/zoneminder/jobs/720794011)
- [ ]  Ubuntu Xenial [Log](https://travis-ci.org/github/Carbenium/zoneminder/jobs/720794012)
- [ ]  Ubuntu Disco [Log](https://travis-ci.org/github/Carbenium/zoneminder/jobs/720794014)
- [ ]  Debian Jessie [Log](https://travis-ci.org/github/Carbenium/zoneminder/jobs/720794016)

