### PR TITLE
CI: Remove EOL distro version from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,9 @@ env:
   - SMPFLAGS=-j4 OS=el DIST=8 DOCKER_REPO=knnniggett/packpack
   - SMPFLAGS=-j4 OS=fedora DIST=31 DOCKER_REPO=knnniggett/packpack
   - SMPFLAGS=-j4 OS=fedora DIST=32 DOCKER_REPO=knnniggett/packpack
-  - SMPFLAGS=-j4 OS=ubuntu DIST=trusty DOCKER_REPO=iconzm/packpack
   - SMPFLAGS=-j4 OS=ubuntu DIST=xenial DOCKER_REPO=iconzm/packpack
   - SMPFLAGS=-j4 OS=ubuntu DIST=bionic DOCKER_REPO=iconzm/packpack
-  - SMPFLAGS=-j4 OS=ubuntu DIST=disco DOCKER_REPO=iconzm/packpack
   - SMPFLAGS=-j4 OS=ubuntu DIST=focal DOCKER_REPO=iconzm/packpack
-  - SMPFLAGS=-j4 OS=debian DIST=jessie DOCKER_REPO=iconzm/packpack
   - SMPFLAGS=-j4 OS=debian DIST=stretch DOCKER_REPO=iconzm/packpack
   - SMPFLAGS=-j4 OS=debian DIST=buster DOCKER_REPO=iconzm/packpack
 


### PR DESCRIPTION
This commit removes
  * Debian Jessie (LTS support ended June 30, 2020)
  * Ubuntu Trusty (Standard support ended Apr 2019)
  * Ubuntu Disco (Support ended Jan 23, 2020)