### PR TITLE
CI: Do not try to run deploy when building from a fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,4 @@ deploy:
   script: utils/packpack/rsync_xfer.sh
   on:
     branch: master
+    condition: fork = false


### PR DESCRIPTION
The deploy step fails on forks since the deploy key is obviously not present.