### PR TITLE
zm_config: Fix a -Wwrite-string warning

### DIFF
--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -107,7 +107,7 @@ void zmLoadConfig() {
   snprintf(staticConfig.video_file_format, sizeof(staticConfig.video_file_format), "%%s/%%s");
 }
 
-void process_configfile(char* configFile) {
+void process_configfile(char const *configFile) {
   FILE *cfg;
   char line[512];
   if ( (cfg = fopen(configFile, "r")) == NULL ) {

--- a/src/zm_config.h.in
+++ b/src/zm_config.h.in
@@ -62,7 +62,7 @@
 
 extern void zmLoadConfig();
 
-extern void process_configfile( char* configFile );
+extern void process_configfile(char const *configFile);
 
 struct StaticConfig {
   std::string DB_HOST;


### PR DESCRIPTION
For reference:
`/home/peterke/DEV/zoneminder/build/src/zm_config.h:31:26: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]`