### PR TITLE
Extract generated part of zm_config.h into zm_config_data.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ src/CMakeFiles/
 src/cmake_install.cmake
 src/libzm.a
 src/nph-zms
-src/zm_config.h
+src/zm_config_data.h
 src/zm_config_defines.h
 src/zma
 src/zmc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt for the ZoneMinder binaries
 
 # Create files from the .in files
-configure_file(zm_config.h.in "${CMAKE_CURRENT_BINARY_DIR}/zm_config.h" @ONLY)
+configure_file(zm_config_data.h.in "${CMAKE_CURRENT_BINARY_DIR}/zm_config_data.h" @ONLY)
 
 # Group together all the source files that are used by all the binaries (zmc, zma, zmu, zms etc)
 set(ZM_BIN_SRC_FILES zm_box.cpp zm_buffer.cpp zm_camera.cpp zm_comms.cpp zm_config.cpp zm_coord.cpp zm_curl_camera.cpp zm.cpp zm_db.cpp zm_logger.cpp zm_event.cpp zm_frame.cpp zm_eventstream.cpp zm_exception.cpp zm_file_camera.cpp zm_ffmpeg_input.cpp zm_ffmpeg_camera.cpp zm_group.cpp zm_image.cpp zm_jpeg.cpp zm_libvlc_camera.cpp zm_libvnc_camera.cpp zm_local_camera.cpp zm_monitor.cpp zm_monitorstream.cpp zm_ffmpeg.cpp zm_mpeg.cpp zm_packet.cpp zm_packetqueue.cpp zm_poly.cpp zm_regexp.cpp zm_remote_camera.cpp zm_remote_camera_http.cpp zm_remote_camera_nvsocket.cpp zm_remote_camera_rtsp.cpp zm_rtp.cpp zm_rtp_ctrl.cpp zm_rtp_data.cpp zm_rtp_source.cpp zm_rtsp.cpp zm_rtsp_auth.cpp zm_sdp.cpp zm_signal.cpp zm_stream.cpp zm_swscale.cpp zm_thread.cpp zm_time.cpp zm_timer.cpp zm_user.cpp zm_utils.cpp zm_video.cpp zm_videostore.cpp zm_zone.cpp zm_storage.cpp zm_fifo.cpp zm_crypt.cpp)

--- a/src/zm_config.h
+++ b/src/zm_config.h
@@ -1,21 +1,21 @@
 //
 // ZoneMinder Configuration, $Date$, $Revision$
 // Copyright (C) 2001-2008 Philip Coombes
-// 
+//
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-// 
+//
 
 #ifndef ZM_CONFIG_H
 #define ZM_CONFIG_H
@@ -23,18 +23,12 @@
 #if !defined(PATH_MAX)
 #define PATH_MAX 1024
 #endif
+
 #include "config.h"
 #include "zm_config_defines.h"
+#include "zm_config_data.h"
 
 #include <string>
-
-#define ZM_CONFIG        "@ZM_CONFIG@"  // Path to config file
-#define ZM_CONFIG_SUBDIR "@ZM_CONFIG_SUBDIR@"  // Path to the ZoneMinder config subfolder
-#define ZM_VERSION        "@VERSION@"  // ZoneMinder Version
-
-#define ZM_HAS_V4L1       @ZM_HAS_V4L1@
-#define ZM_HAS_V4L2       @ZM_HAS_V4L2@
-#define ZM_HAS_V4L        @ZM_HAS_V4L@
 
 #ifdef HAVE_LIBAVFORMAT
 #define ZM_HAS_FFMPEG       1

--- a/src/zm_config_data.h.in
+++ b/src/zm_config_data.h.in
@@ -1,0 +1,31 @@
+//
+// ZoneMinder Configuration, $Date$, $Revision$
+// Copyright (C) 2001-2008 Philip Coombes
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+// 
+
+#ifndef ZM_CONFIG_DATA_H
+#define ZM_CONFIG_DATA_H
+
+#define ZM_CONFIG        "@ZM_CONFIG@"  // Path to config file
+#define ZM_CONFIG_SUBDIR "@ZM_CONFIG_SUBDIR@"  // Path to the ZoneMinder config subfolder
+#define ZM_VERSION        "@VERSION@"  // ZoneMinder Version
+
+#define ZM_HAS_V4L1       @ZM_HAS_V4L1@
+#define ZM_HAS_V4L2       @ZM_HAS_V4L2@
+#define ZM_HAS_V4L        @ZM_HAS_V4L@
+
+#endif // ZM_CONFIG_DATA_H


### PR DESCRIPTION
With this change IDEs have it easier to correctly reference the
variable/class declarations. Additionally one does not have to
regenerate the zm_config.h file when changing the code.