### PR TITLE
don't throw exception if frame ID for max score not found

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -434,14 +434,11 @@ class EventsController extends AppController {
     // Find the max Frame for this Event.  Error out otherwise.
     $this->loadModel('Frame');
 
-    if (! $frame = $this->Frame->find('first', array(
+    $frame = $this->Frame->find('first', array(
       'conditions' => array(
-        'EventId' => $event['Event']['Id'],
-        'Score' => $event['Event']['MaxScore']
-      )
-    ))) {
-      throw new NotFoundException(__('Can not find Frame for Event ' . $event['Event']['Id']));
-    }
+      'EventId' => $event['Event']['Id'],
+      'Score' => $event['Event']['MaxScore']
+    )));
     return $frame['Frame']['Id'];
   }
 } // end class EventsController


### PR DESCRIPTION
Should fix https://github.com/pliablepixels/zmNinja/issues/972
Events API errors out if it can't find a frame with max score. This condition may occur if there was an error during event recording - frame was never written, etc. This should not break all of events.json