### PR TITLE
FIXED operand error for NOT IN SQL statement

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
@@ -322,7 +322,7 @@ sub Sql {
               $self->{Sql} .= ' IS NOT '.$value;
             } elsif ( $term->{op} eq '=[]' ) {
               $self->{Sql} .= ' IN ('.join(',', @value_list).')';
-            } elsif ( $term->{op} eq '!~' ) {
+            } elsif ( $term->{op} eq '![]' ) {
               $self->{Sql} .= ' NOT IN ('.join(',', @value_list).')';
             } elsif ( $term->{op} eq 'LIKE' ) {
               $self->{Sql} .= ' LIKE '.$value;


### PR DESCRIPTION
Switched operand from !~ to ![] for NOT IN SQL statement.
Web version was fine but zmfilter.pl had suffered from this error, preventing deletion of old events, causing storage to fill.