### PR TITLE
Update zm_update-1.35.11.sql

### DIFF
--- a/db/zm_update-1.35.11.sql
+++ b/db/zm_update-1.35.11.sql
@@ -10,7 +10,7 @@ set @exist := (select count(*) FROM information_schema.key_column_usage where ta
 
 set @sqlstmt := if( @exist > 1, "SELECT 'You have more than 1 FOREIGN KEY. Please do manual cleanup'", "SELECT 'Ok'");
 set @sqlstmt := if( @exist = 1, "SELECT 'FOREIGN KEY EventId in Frames already exists'", @sqlstmt);
-set @sqlstmt := if( @exist = 0, "SELECT 'Adding foreign key for EventId to Frames", @sqlstmt);
+set @sqlstmt := if( @exist = 0, "SELECT 'Adding foreign key for EventId to Frames'", @sqlstmt);
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 


### PR DESCRIPTION
Missing " ' " simbol that generates a MariaDB problem:
ERROR 1064 (42000) at line 14: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''Adding foreign key for EventId to Frames' at line 1