### PR TITLE
Improve group permissions (mode 660)

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -557,7 +557,7 @@ bool Monitor::connect() {
   Debug(3, "Connecting to monitor.  Purpose is %d", purpose );
 #if ZM_MEM_MAPPED
   snprintf(mem_file, sizeof(mem_file), "%s/zm.mmap.%d", staticConfig.PATH_MAP.c_str(), id);
-  map_fd = open(mem_file, O_RDWR|O_CREAT, (mode_t)0600);
+  map_fd = open(mem_file, O_RDWR|O_CREAT, (mode_t)0660);
   if ( map_fd < 0 ) {
     Error("Can't open memory map file %s, probably not enough space free: %s", mem_file, strerror(errno));
     return false;


### PR DESCRIPTION
Creates mode 660 sockets and /dev/shm files.
Allows processes with different UIDs to share sockets/shm.

Allows systems like Alpine Linux to keep default configs and improves process separation.

```
  UID USER       PID RGROUP   COMMAND
    0 root         1 root     /sbin/init
    0 root       242 wheel    /sbin/syslogd -t
    0 root       364 root     /sbin/getty 38400 console
    0 root     10773 root     nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf
  101 nginx    10774 nginx    nginx: worker process
  101 nginx    10775 nginx    nginx: worker process
  101 nginx    10776 nginx    nginx: worker process
  101 nginx    10777 nginx    nginx: worker process
    0 root     10809 root     php-fpm: master process (/etc/php7/php-fpm.conf)
  102 fcgiwrap 10836 www-data /usr/bin/fcgiwrap -c 4 -s unix:/run/fcgiwrap/fcgiwrap.sock
  102 fcgiwrap 10841 www-data /usr/bin/fcgiwrap -c 4 -s unix:/run/fcgiwrap/fcgiwrap.sock
  102 fcgiwrap 10842 www-data /usr/bin/fcgiwrap -c 4 -s unix:/run/fcgiwrap/fcgiwrap.sock
  102 fcgiwrap 10843 www-data /usr/bin/fcgiwrap -c 4 -s unix:/run/fcgiwrap/fcgiwrap.sock
  102 fcgiwrap 10844 www-data /usr/bin/fcgiwrap -c 4 -s unix:/run/fcgiwrap/fcgiwrap.sock
  103 zonemin+ 11677 www-data php-fpm: pool zoneminder
  103 zonemin+ 11681 www-data php-fpm: pool zoneminder
  100 mysql    11926 mysql    /usr/bin/mariadbd --basedir=/usr --datadir=/tmp/mysql
    0 root     11927 root     logger -t mysqld -p daemon.error
  103 zonemin+ 11984 www-data /usr/bin/perl -wT /usr/bin/zmdc.pl startup
  103 zonemin+ 12012 www-data /usr/bin/zmc -m 1
  103 zonemin+ 12021 www-data /usr/bin/perl -wT /usr/bin/zmfilter.pl --filter_id=1 --daemon
  103 zonemin+ 12022 www-data /usr/bin/zma -m 1
  103 zonemin+ 12027 www-data /usr/bin/perl -wT /usr/bin/zmfilter.pl --filter_id=2 --daemon
  103 zonemin+ 12032 www-data /usr/bin/perl -wT /usr/bin/zmfilter.pl --filter_id=5 --daemon
  103 zonemin+ 12042 www-data /usr/bin/perl -wT /usr/bin/zmwatch.pl
  103 zonemin+ 12049 www-data /usr/bin/perl -wT /usr/bin/zmstats.pl
  103 zonemin+ 12257 www-data php-fpm: pool zoneminder
```