### PR TITLE
add thumbnail support on the backend for watch view

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -329,6 +329,17 @@ function collectData() {
         foreach ( dbFetchAll($sql, NULL, $values) as $sqlData ) {
           foreach ( $postFuncs as $element=>$func )
             $sqlData[$element] = eval('return( '.$func.'( $sqlData ) );');
+
+          // Create parameters used to build the event thumbnail html
+          $event = new ZM\Event($sqlData['Id']);
+          $scale = intval(5*100*ZM_WEB_LIST_THUMB_WIDTH / $event->Width());
+          $imgSrc = $event->getThumbnailSrc(array(),'&amp;');
+          $streamSrc = $event->getStreamSrc(array(
+            'mode'=>'jpeg', 'scale'=>$scale, 'maxfps'=>ZM_WEB_VIDEO_MAXFPS, 'replay'=>'single', 'rate'=>'400'), '&amp;');
+
+          // Build the thumbnail html
+          $sqlData['imgHtml'] = '<img id="thumbnail' .$event->Id(). '" src="' .$imgSrc. '" alt="' .validHtmlStr('Event ' .$event->Id()). '" style="width:' .validInt($event->ThumbnailWidth()). 'px;height:' .validInt($event->ThumbnailHeight()).'px;" stream_src="' .$streamSrc. '" still_src="' .$imgSrc. '"/>';
+
           $data[] = $sqlData;
           if ( isset($limit) && ++$count >= $limit )
             break;


### PR DESCRIPTION
This adds php backend support for event thumbnails in the watch view. Frontend javascript & php will be added after this is merged.

@connortechnology Please review. Status.php is used by more than just the watch view. I'm looking for a second set of eyes before merging.