### PR TITLE
Avoid top-scroll when returning from bs_modal objdetect

### DIFF
--- a/web/ajax/modals/objdetect.php
+++ b/web/ajax/modals/objdetect.php
@@ -9,7 +9,7 @@ if ( !validInt($eid) ) {
 }
 
 ?>
-<div id="objdetectModal" class="modal" tabindex="-1">
+<div id="objdetectModal" class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -61,7 +61,7 @@ function processRows(rows) {
     if ( canEdit.Monitors ) row.Monitor = '<a href="?view=monitor&amp;mid=' + mid + '">' + row.Monitor + '</a>';
     if ( canEdit.Events ) row.Cause = '<a href="#" title="' + row.Notes + '" class="eDetailLink" data-eid="' + eid + '">' + row.Cause + '</a>';
     if ( row.Notes.indexOf('detected:') >= 0 ) {
-      row.Cause = row.Cause + '<a href="#" data-on-click-this="objdetectModal" data-event-id=' +eid+ '><div class="small text-nowrap text-muted"><u>' + row.Notes + '</u></div></div></a>';
+      row.Cause = row.Cause + '<a href="#" data-on-click-this="objdetectModal" data-toggle="modal" data-event-id=' +eid+ '><div class="small text-nowrap text-muted"><u>' + row.Notes + '</u></div></div></a>';
     } else if ( row.Notes != 'Forced Web: ' ) {
       row.Cause = row.Cause + '<br/><div class="small text-nowrap text-muted">' + row.Notes + '</div>';
     }


### PR DESCRIPTION
This little fix is to reuse some bootstrap features of modals dialogs to avoid top-scrolling the page when returning from modal linked to objdetect.