### PR TITLE
Fixed issue where mysql_free_result can get called twice

### DIFF
--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -132,12 +132,12 @@ User *zmLoadUser(const char *username, const char *password) {
   if ( mysql_num_rows(result) == 1 ) {
     MYSQL_ROW dbrow = mysql_fetch_row(result);
     User *user = new User(dbrow);
-    mysql_free_result(result);
 
     if ( 
         (! password )  // relay type must be none
         ||
         verifyPassword(username, password, user->getPassword()) ) {
+      mysql_free_result(result);
       Info("Authenticated user '%s'", user->getUsername());
       return user;
     } 


### PR DESCRIPTION
When a valid username with an incorrect password is used mysql_free_result() gets called twice to free the same resource.
Moving the first mysql_free_result() to after the password check corrects this.
