### PR TITLE
Typedef C++11 int types to make them easier to use 

### DIFF
--- a/src/zm.h
+++ b/src/zm.h
@@ -21,6 +21,8 @@
 #ifndef ZM_H
 #define ZM_H
 
+#include "zm_define.h"
+
 #include "zm_config.h"
 #include "zm_signal.h"
 #ifdef SOLARIS
@@ -29,10 +31,8 @@
 #endif
 #include "zm_logger.h"
 
-#include <stdint.h>
-
 #include <iostream>
 
-extern const char* self;
+extern const char *self;
 
 #endif // ZM_H

--- a/src/zm_define.h
+++ b/src/zm_define.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the ZoneMinder Project.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef ZONEMINDER_SRC_ZM_DEFINE_H_
+#define ZONEMINDER_SRC_ZM_DEFINE_H_
+
+#include <cinttypes>
+
+typedef std::int64_t int64;
+typedef std::int32_t int32;
+typedef std::int16_t int16;
+typedef std::int8_t int8;
+typedef std::uint64_t uint64;
+typedef std::uint32_t uint32;
+typedef std::uint16_t uint16;
+typedef std::uint8_t uint8;
+
+#endif // ZONEMINDER_SRC_ZM_DEFINE_H_

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -27,7 +27,6 @@
 #include <getopt.h>
 #include <arpa/inet.h>
 #include <glob.h>
-#include <cinttypes>
 
 #include "zm.h"
 #include "zm_db.h"
@@ -692,8 +691,8 @@ void Event::AddFrame(Image *image, struct timeval timestamp, int score, Image *a
     // The idea is to write out 1/sec
     frame_data.push(new Frame(id, frames, frame_type, timestamp, delta_time, score));
     double fps = monitor->get_capture_fps();
-		if ( write_to_db 
-				or 
+		if ( write_to_db
+				or
 				(frame_data.size() >= MAX_DB_FRAMES)
 				or
 				(frame_type == BULK)

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -16,7 +16,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */ 
-#include <cinttypes>
 
 #include "zm_ffmpeg.h"
 #include "zm_image.h"

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -19,8 +19,9 @@
 
 #ifndef ZM_FFMPEG_H
 #define ZM_FFMPEG_H
-#include <stdint.h>
-#include "zm.h"
+
+#include "zm_config.h"
+#include "zm_define.h"
 
 extern "C" {
 

--- a/src/zm_font.h
+++ b/src/zm_font.h
@@ -1,7 +1,8 @@
 #ifndef ZM_FONT_H
 #define ZM_FONT_H
 
-#include <inttypes.h>
+#include "zm_define.h"
+
 #include <string>
 
 #define NUM_FONT_SIZES 4

--- a/src/zm_logger.h
+++ b/src/zm_logger.h
@@ -21,7 +21,9 @@
 #define ZM_LOGGER_H
 
 #include "zm_config.h"
-#include <stdint.h>
+#include "zm_define.h"
+#include "zm_thread.h"
+
 #include <unistd.h>
 #include <string>
 #include <map>
@@ -29,8 +31,6 @@
 #include <sys/syscall.h>
 #endif // HAVE_SYS_SYSCALL_H
 #include <mysql/mysql.h>
-
-#include "zm_thread.h"
 
 class Logger {
 public:

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -21,7 +21,6 @@
 #include <sys/stat.h>
 #include <arpa/inet.h>
 #include <glob.h>
-#include <cinttypes>
 
 #include "zm.h"
 #include "zm_db.h"

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -44,7 +44,6 @@ class Monitor;
 #include "zm_image_analyser.h"
 
 #include <sys/time.h>
-#include <stdint.h>
 
 #define SIGNAL_CAUSE "Signal"
 #define MOTION_CAUSE "Motion"

--- a/src/zm_rtp_data.h
+++ b/src/zm_rtp_data.h
@@ -20,10 +20,9 @@
 #ifndef ZM_RTP_DATA_H
 #define ZM_RTP_DATA_H
 
-#include "zm_thread.h"
 #include "zm_buffer.h"
-
-#include <stdint.h>
+#include "zm_define.h"
+#include "zm_thread.h"
 
 class RtspThread;
 class RtpSource;

--- a/src/zm_rtp_source.h
+++ b/src/zm_rtp_source.h
@@ -21,11 +21,11 @@
 #define ZM_RTP_SOURCE_H
 
 #include "zm_buffer.h"
+#include "zm_define.h"
 #include "zm_ffmpeg.h"
 #include "zm_thread.h"
 
 #include <sys/time.h>
-#include <stdint.h>
 #include <string>
 
 #if HAVE_LIBAVCODEC

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -26,7 +26,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <cinttypes>
 
 extern "C" {
 #include "libavutil/time.h"

--- a/src/zm_zone.cpp
+++ b/src/zm_zone.cpp
@@ -18,7 +18,6 @@
 // 
 
 #define __STDC_FORMAT_MACROS 1
-#include <cinttypes>
 #include "zm.h"
 #include "zm_db.h"
 #include "zm_zone.h"

--- a/src/zms.cpp
+++ b/src/zms.cpp
@@ -19,7 +19,6 @@
 
 #include <sys/ipc.h>
 #include <sys/msg.h>
-#include <cinttypes>
 #include <string>
 
 #include "zm.h"

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -87,7 +87,6 @@ Options for use with monitors:
 */
 
 #include <getopt.h>
-#include <cinttypes>
 
 #include "zm.h"
 #include "zm_db.h"


### PR DESCRIPTION
In order to clearly state the intended length of an integer variable all usages of other integer types (short int, int, long int, ...) should be converted to the appropriate fixed-width integer types.