### PR TITLE
Image: Replace qsort with std::sort

### DIFF
--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -22,6 +22,7 @@
 #include "zm_font.h"
 #include "zm_poly.h"
 #include "zm_utils.h"
+#include <algorithm>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -2488,7 +2489,7 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
     global_edges[n_global_edges]._1_m = dx/dy;
     n_global_edges++;
   }
-  qsort( global_edges, n_global_edges, sizeof(*global_edges), Edge::CompareYX );
+  std::sort(global_edges, global_edges + n_global_edges, Edge::CompareYX);
 
 #ifndef ZM_DBG_OFF
   if ( logLevel() >= Logger::DEBUG9 ) {
@@ -2517,7 +2518,7 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
         break;
       }
     }
-    qsort(active_edges, n_active_edges, sizeof(*active_edges), Edge::CompareX);
+    std::sort(active_edges, active_edges + n_active_edges, Edge::CompareX);
 #ifndef ZM_DBG_OFF
     if ( logLevel() >= Logger::DEBUG9 ) {
       for ( int i = 0; i < n_active_edges; i++ ) {

--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -94,27 +94,25 @@ class Image {
     blend_fptr_t blend;
 
     void update_function_pointers();
+
 protected:
+    struct Edge {
+      int min_y;
+      int max_y;
+      double min_x;
+      double _1_m;
 
-	struct Edge {
-		int min_y;
-		int max_y;
-		double min_x;
-		double _1_m;
+      static bool CompareYX(const Edge &e1, const Edge &e2) {
+        if ( e1.min_y == e2.min_y )
+          return e1.min_x < e2.min_x;
+        else
+          return e1.min_y < e2.min_y;
+      }
 
-		static int CompareYX( const void *p1, const void *p2 ) {
-      // This is because these functions are passed to qsort
-			const Edge *e1 = reinterpret_cast<const Edge *>(p1), *e2 = reinterpret_cast<const Edge *>(p2);
-			if ( e1->min_y == e2->min_y )
-				return( int(e1->min_x - e2->min_x) );
-			else
-				return( int(e1->min_y - e2->min_y) );
-		}
-		static int CompareX( const void *p1, const void *p2 ) {
-			const Edge *e1 = reinterpret_cast<const Edge *>(p1), *e2 = reinterpret_cast<const Edge *>(p2);
-			return( int(e1->min_x - e2->min_x) );
-		}
-	};
+      static bool CompareX(const Edge &e1, const Edge &e2) {
+        return e1.min_x < e2.min_x;
+      }
+    };
 	
 	inline void DumpImgBuffer() {
 		DumpBuffer(buffer, buffertype);


### PR DESCRIPTION
std::sort has stricter complexity requirements than qsort and can be better optimized by the compiler due to templating.