### PR TITLE
DB: Make connection initialization more predictable and finalize mysql library correctly

### DIFF
--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -36,21 +36,21 @@ void zmLoadStaticConfig() {
 
   // Search for user created config files. If one or more are found then
   // update the Config hash with those values
-  DIR* configSubFolder = opendir(ZM_CONFIG_SUBDIR);
-  if ( configSubFolder ) { // subfolder exists and is readable
+  DIR *configSubFolder = opendir(ZM_CONFIG_SUBDIR);
+  if (configSubFolder) { // subfolder exists and is readable
     char glob_pattern[PATH_MAX] = "";
     snprintf(glob_pattern, sizeof(glob_pattern), "%s/*.conf", ZM_CONFIG_SUBDIR);
 
     glob_t pglob;
-    int glob_status = glob(glob_pattern, 0, 0, &pglob);
-    if ( glob_status != 0 ) {
-      if ( glob_status < 0 ) {
+    int glob_status = glob(glob_pattern, 0, nullptr, &pglob);
+    if (glob_status != 0) {
+      if (glob_status < 0) {
         Error("Can't glob '%s': %s", glob_pattern, strerror(errno));
       } else {
         Debug(1, "Can't glob '%s': %d", glob_pattern, glob_status);
       }
     } else {
-      for ( unsigned int i = 0; i < pglob.gl_pathc; i++ ) {
+      for (unsigned int i = 0; i < pglob.gl_pathc; i++) {
         process_configfile(pglob.gl_pathv[i]);
       }
     }
@@ -60,48 +60,51 @@ void zmLoadStaticConfig() {
 }
 
 void zmLoadDBConfig() {
-  if ( !zmDbConnected ) {
+  if (!zmDbConnected) {
     Fatal("Not connected to the database. Can't continue.");
   }
   config.Load();
   config.Assign();
 
   // Populate the server config entries
-  if ( !staticConfig.SERVER_ID ) {
-    if ( !staticConfig.SERVER_NAME.empty() ) {
+  if (!staticConfig.SERVER_ID) {
+    if (!staticConfig.SERVER_NAME.empty()) {
 
       Debug(1, "Fetching ZM_SERVER_ID For Name = %s", staticConfig.SERVER_NAME.c_str());
       std::string sql = stringtf("SELECT `Id` FROM `Servers` WHERE `Name`='%s'",
-          staticConfig.SERVER_NAME.c_str());
+                                 staticConfig.SERVER_NAME.c_str());
       zmDbRow dbrow;
-      if ( dbrow.fetch(sql.c_str()) ) {
+      if (dbrow.fetch(sql.c_str())) {
         staticConfig.SERVER_ID = atoi(dbrow[0]);
       } else {
         Fatal("Can't get ServerId for Server %s", staticConfig.SERVER_NAME.c_str());
       }
 
     } // end if has SERVER_NAME
-  } else if ( staticConfig.SERVER_NAME.empty() ) {
+  } else if (staticConfig.SERVER_NAME.empty()) {
     Debug(1, "Fetching ZM_SERVER_NAME For Id = %d", staticConfig.SERVER_ID);
     std::string sql = stringtf("SELECT `Name` FROM `Servers` WHERE `Id`='%d'", staticConfig.SERVER_ID);
-    
+
     zmDbRow dbrow;
-    if ( dbrow.fetch(sql.c_str()) ) {
+    if (dbrow.fetch(sql.c_str())) {
       staticConfig.SERVER_NAME = std::string(dbrow[0]);
     } else {
       Fatal("Can't get ServerName for Server ID %d", staticConfig.SERVER_ID);
     }
 
-    if ( staticConfig.SERVER_ID ) {
-			Debug(3, "Multi-server configuration detected. Server is %d.", staticConfig.SERVER_ID);
-		} else {
-			Debug(3, "Single server configuration assumed because no Server ID or Name was specified.");
-		}
+    if (staticConfig.SERVER_ID) {
+      Debug(3, "Multi-server configuration detected. Server is %d.", staticConfig.SERVER_ID);
+    } else {
+      Debug(3, "Single server configuration assumed because no Server ID or Name was specified.");
+    }
   }
 
-  snprintf(staticConfig.capture_file_format, sizeof(staticConfig.capture_file_format), "%%s/%%0%dd-capture.jpg", config.event_image_digits);
-  snprintf(staticConfig.analyse_file_format, sizeof(staticConfig.analyse_file_format), "%%s/%%0%dd-analyse.jpg", config.event_image_digits);
-  snprintf(staticConfig.general_file_format, sizeof(staticConfig.general_file_format), "%%s/%%0%dd-%%s", config.event_image_digits);
+  snprintf(staticConfig.capture_file_format, sizeof(staticConfig.capture_file_format), "%%s/%%0%dd-capture.jpg",
+           config.event_image_digits);
+  snprintf(staticConfig.analyse_file_format, sizeof(staticConfig.analyse_file_format), "%%s/%%0%dd-analyse.jpg",
+           config.event_image_digits);
+  snprintf(staticConfig.general_file_format, sizeof(staticConfig.general_file_format), "%%s/%%0%dd-%%s",
+           config.event_image_digits);
   snprintf(staticConfig.video_file_format, sizeof(staticConfig.video_file_format), "%%s/%%s");
 }
 

--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -30,8 +30,7 @@
 // set the relevant ENV vars because the logger gets it's setting from the 
 // config.
 
-void zmLoadConfig() {
-
+void zmLoadStaticConfig() {
   // Process name, value pairs from the main config file first
   process_configfile(ZM_CONFIG);
 
@@ -58,9 +57,11 @@ void zmLoadConfig() {
     globfree(&pglob);
     closedir(configSubFolder);
   }
+}
 
-  if ( !zmDbConnect() ) {
-    Fatal("Can't connect to db. Can't continue.");
+void zmLoadDBConfig() {
+  if ( !zmDbConnected ) {
+    Fatal("Not connected to the database. Can't continue.");
   }
   config.Load();
   config.Assign();

--- a/src/zm_config.h
+++ b/src/zm_config.h
@@ -53,7 +53,8 @@
 #define ZM_SAMPLE_RATE      int(1000000/ZM_MAX_FPS) // A general nyquist sample frequency for delays etc
 #define ZM_SUSPENDED_RATE     int(1000000/4) // A slower rate for when disabled etc
 
-extern void zmLoadConfig();
+void zmLoadStaticConfig();
+void zmLoadDBConfig();
 
 extern void process_configfile(char const *configFile);
 

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -106,8 +106,7 @@ void zmDbClose() {
     mysql_close(&dbconn);
     // mysql_init() call implicitly mysql_library_init() but
     // mysql_close() does not call mysql_library_end()
-    // We get segfaults and a hang when we call this.  So just don't.
-    //mysql_library_end();
+    mysql_library_end();
     zmDbConnected = false;
     db_mutex.unlock();
   }

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -60,6 +60,7 @@ bool zmDbConnect() {
           staticConfig.DB_PASS.c_str(),
           nullptr, 0, nullptr, 0) ) {
       Error("Can't connect to server: %s", mysql_error(&dbconn));
+      mysql_close(&dbconn);
       return false;
     }
   } else {
@@ -73,6 +74,7 @@ bool zmDbConnect() {
             staticConfig.DB_PASS.c_str(),
             nullptr, 0, dbPortOrSocket.c_str(), 0) ) {
         Error("Can't connect to server: %s", mysql_error(&dbconn));
+        mysql_close(&dbconn);
         return false;
       }
     } else {
@@ -85,12 +87,14 @@ bool zmDbConnect() {
             atoi(dbPortOrSocket.c_str()),
             nullptr, 0) ) {
         Error("Can't connect to server: %s", mysql_error(&dbconn));
+        mysql_close(&dbconn);
         return false;
       }
     }
   }
   if ( mysql_select_db(&dbconn, staticConfig.DB_NAME.c_str()) ) {
     Error("Can't select database: %s", mysql_error(&dbconn));
+    mysql_close(&dbconn);
     return false;
   }
   if ( mysql_query(&dbconn, "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED") ) {

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -101,7 +101,7 @@ bool zmDbConnect() {
 }
 
 void zmDbClose() {
-  if ( zmDbConnected ) {
+  if (zmDbConnected) {
     db_mutex.lock();
     mysql_close(&dbconn);
     // mysql_init() call implicitly mysql_library_init() but

--- a/src/zm_db.h
+++ b/src/zm_db.h
@@ -43,6 +43,8 @@ class zmDbRow {
 extern MYSQL dbconn;
 extern RecursiveMutex db_mutex;
 
+extern bool zmDbConnected;
+
 bool zmDbConnect();
 void zmDbClose();
 

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -342,7 +342,7 @@ Logger::Level Logger::databaseLevel(Logger::Level databaseLevel) {
     databaseLevel = limit(databaseLevel);
     if ( mDatabaseLevel != databaseLevel ) {
       if ( (databaseLevel > NOLOG) && (mDatabaseLevel <= NOLOG) ) { // <= NOLOG would be NOOPT
-        if ( !zmDbConnect() ) {
+        if ( !zmDbConnected ) {
           databaseLevel = NOLOG;
         }
       }  // end if ( databaseLevel > NOLOG && mDatabaseLevel <= NOLOG )

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -338,17 +338,17 @@ Logger::Level Logger::terminalLevel(Logger::Level terminalLevel) {
 }
 
 Logger::Level Logger::databaseLevel(Logger::Level databaseLevel) {
-  if ( databaseLevel > NOOPT ) {
+  if (databaseLevel > NOOPT) {
     databaseLevel = limit(databaseLevel);
-    if ( mDatabaseLevel != databaseLevel ) {
-      if ( (databaseLevel > NOLOG) && (mDatabaseLevel <= NOLOG) ) { // <= NOLOG would be NOOPT
-        if ( !zmDbConnected ) {
+    if (mDatabaseLevel != databaseLevel) {
+      if ((databaseLevel > NOLOG) && (mDatabaseLevel <= NOLOG)) { // <= NOLOG would be NOOPT
+        if (!zmDbConnected) {
           databaseLevel = NOLOG;
         }
-      }  // end if ( databaseLevel > NOLOG && mDatabaseLevel <= NOLOG )
+      }
       mDatabaseLevel = databaseLevel;
-    }  // end if ( mDatabaseLevel != databaseLevel )
-  }  // end if ( databaseLevel > NOOPT )
+    }
+  }
 
   return mDatabaseLevel;
 }

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -181,7 +181,9 @@ int main(int argc, char *argv[]) {
   }
 
   logInit(log_id_string);
-  zmLoadConfig();
+  zmLoadStaticConfig();
+  zmDbConnect();
+  zmLoadDBConfig();
   logInit(log_id_string);
 
   hwcaps_detect();

--- a/src/zms.cpp
+++ b/src/zms.cpp
@@ -81,9 +81,12 @@ int main(int argc, const char *argv[], char **envp) {
     nph = true;
   }
 
-  zmLoadConfig();
   char log_id_string[32] = "zms";
   logInit(log_id_string);
+  zmLoadStaticConfig();
+  zmDbConnect();
+  zmLoadDBConfig();
+
   for (char **env = envp; *env != 0; env++) {
     char *thisEnv = *env;
     Debug(1, "env: %s", thisEnv);

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -417,8 +417,10 @@ int main(int argc, char *argv[]) {
   }
   //printf( "Monitor %d, Function %d\n", mon_id, function );
 
-  zmLoadConfig();
-
+  logInit("zmu");
+  zmLoadStaticConfig();
+  zmDbConnect();
+  zmLoadDBConfig();
   logInit("zmu");
 
   zmSetDefaultTermHandler();


### PR DESCRIPTION
Remove calls to `zmDBConnect` from various places to avoid possible side-effects/double initialization.
The function should be called once from the main thread of the daemon.

Also split config loading into 2 steps: static and DB config loading. Load the static config before `zmDBConnect` is called so it has a chance to succeed.

The call to `mysql_library_end` is re-introduced. No more leaks from mysql on shutdown.