### PR TITLE
RecursiveMutex: Use the pthread_mutex_t of the base class

### DIFF
--- a/src/zm_thread.h
+++ b/src/zm_thread.h
@@ -65,7 +65,7 @@ public:
 class Mutex {
   friend class Condition;
 
-  private:
+  protected:
     pthread_mutex_t mMutex;
 
   public:
@@ -87,8 +87,6 @@ class Mutex {
 };
 
 class RecursiveMutex : public Mutex {
-  private:
-    pthread_mutex_t mMutex;
   public:
     RecursiveMutex();
 };


### PR DESCRIPTION
Not doing so initializes a pthread_mutex_t with PTHREAD_MUTEX_RECURSIVE in the derived class but the lock/unlock
methods still use the pthread_mutex_t instance of the base class, which is not a recursive mutex.

This fixes a possible deadlock in `Logger::logPrint`.