### PR TITLE
 Logger: Try harder to obtain the DB lock

### DIFF
--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -534,7 +534,7 @@ void Logger::logPrint(bool hex, const char * const filepath, const int line, con
   }  // end if level <= mFileLevel
 
   if ( level <= mDatabaseLevel ) {
-    if ( !db_mutex.trylock() ) {
+    if (db_mutex.try_lock_for(1)) {
       char escapedString[(strlen(syslogStart)*2)+1];
       mysql_real_escape_string(&dbconn, escapedString, syslogStart, strlen(syslogStart));
 
@@ -556,7 +556,7 @@ void Logger::logPrint(bool hex, const char * const filepath, const int line, con
     } else {
       Level tempDatabaseLevel = mDatabaseLevel;
       databaseLevel(NOLOG);
-      Error("Can't insert log entry: sql(%s) error(%s)", syslogStart, mysql_error(&dbconn));
+      Error("Can't insert log entry since the DB lock could not be obtained. Message: %s", syslogStart);
       databaseLevel(tempDatabaseLevel);
     }
   }  // end if level <= mDatabaseLevel

--- a/src/zm_thread.cpp
+++ b/src/zm_thread.cpp
@@ -59,7 +59,7 @@ Mutex::~Mutex() {
     Error("Unable to destroy pthread mutex: %s", strerror(errno));
 }
 
-int Mutex::trylock() {
+int Mutex::try_lock() {
   return pthread_mutex_trylock(&mMutex);
 }
 void Mutex::lock() {
@@ -68,16 +68,14 @@ void Mutex::lock() {
   //Debug(3, "Lock");
 }
 
-void Mutex::lock( int secs ) {
+bool Mutex::try_lock_for(int secs) {
   struct timespec timeout = getTimeout(secs);
-  if ( pthread_mutex_timedlock(&mMutex, &timeout) < 0 )
-    throw ThreadException(stringtf("Unable to timedlock pthread mutex: %s", strerror(errno)));
+  return pthread_mutex_timedlock(&mMutex, &timeout) == 0;
 }
 
-void Mutex::lock( double secs ) {
+bool Mutex::try_lock_for(double secs) {
   struct timespec timeout = getTimeout(secs);
-  if ( pthread_mutex_timedlock(&mMutex, &timeout) < 0 )
-    throw ThreadException(stringtf("Unable to timedlock pthread mutex: %s", strerror(errno)));
+  return pthread_mutex_timedlock(&mMutex, &timeout) == 0;
 }
 
 void Mutex::unlock() {

--- a/src/zm_thread.h
+++ b/src/zm_thread.h
@@ -78,10 +78,10 @@ class Mutex {
     }
 
   public:
-    int trylock();
+    int try_lock();
     void lock();
-    void lock( int secs );
-    void lock( double secs );
+    bool try_lock_for(int secs);
+    bool try_lock_for(double secs);
     void unlock();
     bool locked();
 };


### PR DESCRIPTION
Since we are now multi-threaded it can happen quite easily that a log message should be written to the DB on one thread while the other thread executes another query. Don't bail out immediately in the logging code, instead try to obtain the lock within 1s.