### PR TITLE
AnalysisThread: Make the class un-movable 

### DIFF
--- a/src/zm_analysis_thread.cpp
+++ b/src/zm_analysis_thread.cpp
@@ -14,9 +14,6 @@ AnalysisThread::~AnalysisThread() {
     thread_.join();
 }
 
-AnalysisThread::AnalysisThread(AnalysisThread &&rhs) noexcept
-    : monitor_(std::move(rhs.monitor_)), terminate_(rhs.terminate_.load()), thread_(std::move(rhs.thread_)) {}
-
 void AnalysisThread::Run() {
   Debug(2, "AnalysisThread::Run()");
 

--- a/src/zm_analysis_thread.h
+++ b/src/zm_analysis_thread.h
@@ -10,7 +10,8 @@ class AnalysisThread {
  public:
   explicit AnalysisThread(std::shared_ptr<Monitor> monitor);
   ~AnalysisThread();
-  AnalysisThread(AnalysisThread &&rhs) noexcept;
+  AnalysisThread(AnalysisThread &rhs) = delete;
+  AnalysisThread(AnalysisThread &&rhs) = delete;
 
  private:
   void Run();

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <ctime>
+#include <memory>
 #include <sys/time.h>
 #include <string>
 #include <vector>
@@ -55,6 +56,25 @@ extern unsigned int neonversion;
 char *timeval_to_string( struct timeval tv );
 std::string UriDecode( const std::string &encoded );
 void touch( const char *pathname );
+
+namespace ZM {
+//! std::make_unique implementation (TODO: remove this once C++14 is supported)
+template<typename T, typename ...Args>
+inline auto make_unique(Args &&...args) ->
+typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<typename T>
+inline auto make_unique(std::size_t size) ->
+typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0, std::unique_ptr<T>>::type {
+  return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
+}
+
+template<typename T, typename... Args>
+inline auto make_unique(Args &&...) ->
+typename std::enable_if<std::extent<T>::value != 0, void>::type = delete;
+}
 
 typedef std::chrono::microseconds Microseconds;
 typedef std::chrono::milliseconds Milliseconds;

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -62,6 +62,7 @@ possible, this should run at more or less constant speed.
 #include "zm_rtsp_server_thread.h"
 #include "zm_signal.h"
 #include "zm_time.h"
+#include "zm_utils.h"
 #include <getopt.h>
 #include <iostream>
 
@@ -287,7 +288,7 @@ int main(int argc, char *argv[]) {
     }
 #endif
 
-    std::vector<AnalysisThread> analysis_threads = std::vector<AnalysisThread>();
+    std::vector<std::unique_ptr<AnalysisThread>> analysis_threads = std::vector<std::unique_ptr<AnalysisThread>>();
 
     int *capture_delays = new int[monitors.size()];
     int *alarm_capture_delays = new int[monitors.size()];
@@ -303,7 +304,7 @@ int main(int argc, char *argv[]) {
       Monitor::Function function = monitors[0]->GetFunction();
       if ( function != Monitor::MONITOR ) {
         Debug(1, "Starting an analysis thread for monitor (%d)", monitors[i]->Id());
-        analysis_threads.emplace_back(monitors[i]);
+        analysis_threads.emplace_back(ZM::make_unique<AnalysisThread>(monitors[i]));
       }
 #if HAVE_RTSP_SERVER
       if ( rtsp_server_threads ) {


### PR DESCRIPTION
We depend on an unchanged value of "this" after the creation of the thread otherwise undefined values would be accessed within the std::thread.

