### PR TITLE
Fix a possible deadlock on zmc shutdown and reconnect

### DIFF
--- a/src/zm_analysis_thread.cpp
+++ b/src/zm_analysis_thread.cpp
@@ -9,7 +9,7 @@ AnalysisThread::AnalysisThread(std::shared_ptr<Monitor> monitor) :
 }
 
 AnalysisThread::~AnalysisThread() {
-  terminate_ = true;
+  Stop();
   if (thread_.joinable())
     thread_.join();
 }

--- a/src/zm_analysis_thread.h
+++ b/src/zm_analysis_thread.h
@@ -13,6 +13,8 @@ class AnalysisThread {
   AnalysisThread(AnalysisThread &rhs) = delete;
   AnalysisThread(AnalysisThread &&rhs) = delete;
 
+  void Stop() { terminate_ = true; }
+
  private:
   void Run();
 

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -384,8 +384,8 @@ int main(int argc, char *argv[]) {
       }  // end if zm_reload
     }  // end while ! zm_terminate and connected
 
-    // Killoff the analysis threads. Don't need them spinning while we try to reconnect
-    analysis_threads.clear();
+    for (std::unique_ptr<AnalysisThread> &analysis_thread: analysis_threads)
+      analysis_thread->Stop();
 
     for (size_t i = 0; i < monitors.size(); i++) {
 #if HAVE_RTSP_SERVER
@@ -407,6 +407,9 @@ int main(int argc, char *argv[]) {
       Debug(1, "Closing camera");
       camera->Close();
     }
+
+    // Killoff the analysis threads. Don't need them spinning while we try to reconnect
+    analysis_threads.clear();
 
 #if HAVE_RTSP_SERVER
     if (rtsp_server_threads) {


### PR DESCRIPTION
Close the monitor and thus drain the packet queue before trying to stop/join the analysis threads since they might hang while waiting for the next packet to arrive.

Tested with various combinations of signal loss / reconnection / shutdown.