### PR TITLE
Let Monitor own its Camera

### DIFF
--- a/src/zm_camera.h
+++ b/src/zm_camera.h
@@ -21,10 +21,10 @@
 #define ZM_CAMERA_H
 
 #include "zm_image.h"
-#include "zm_monitor.h"
 #include <sys/ioctl.h>
 #include <sys/types.h>
 
+class Monitor;
 class ZMPacket;
 
 //
@@ -76,7 +76,6 @@ public:
       );
   virtual ~Camera();
 
-  unsigned int getId() const { return monitor->Id(); }
   SourceType Type() const { return type; }
   bool IsLocal() const { return type == LOCAL_SRC; }
   bool IsRemote() const { return type == REMOTE_SRC; }

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -220,14 +220,13 @@ Event::Event(
     db_mutex.unlock();
     video_file = path + "/" + video_name;
     Debug(1, "Writing video file to %s", video_file.c_str());
-    Camera * camera = monitor->getCamera();
     videoStore = new VideoStore(
         video_file.c_str(),
         container.c_str(),
-        camera->get_VideoStream(),
-        camera->get_VideoCodecContext(),
-        ( monitor->RecordAudio() ? camera->get_AudioStream() : nullptr ),
-        ( monitor->RecordAudio() ? camera->get_AudioCodecContext() : nullptr ),
+        monitor->GetVideoStream(),
+        monitor->GetVideoCodecContext(),
+        ( monitor->RecordAudio() ? monitor->GetAudioStream() : nullptr ),
+        ( monitor->RecordAudio() ? monitor->GetAudioCodecContext() : nullptr ),
         monitor );
 
     if ( !videoStore->open() ) {

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -2941,6 +2941,8 @@ int Monitor::PrimeCapture() {
 int Monitor::PreCapture() const { return camera->PreCapture(); }
 int Monitor::PostCapture() const { return camera->PostCapture(); }
 int Monitor::Close() {
+  if (camera)
+    camera->Close();
   packetqueue.clear();
 #if 0
   if ( packetqueue ) {

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -1073,6 +1073,8 @@ bool Monitor::disconnect() {
 }  // end bool Monitor::disconnect()
 
 Monitor::~Monitor() {
+  Close();
+
   if ( mem_ptr ) {
     if ( event ) {
       Info( "%s: image_count:%d - Closing event %" PRIu64 ", shutting down", name, image_count, event->Id() );

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -21,6 +21,7 @@
 #define ZM_MONITOR_H
 
 #include "zm_define.h"
+#include "zm_camera.h"
 #include "zm_event.h"
 #include "zm_image.h"
 #include "zm_packet.h"
@@ -30,7 +31,6 @@
 #include <sys/time.h>
 #include <vector>
 
-class Camera;
 class Group;
 
 #define SIGNAL_CAUSE "Signal"
@@ -470,6 +470,11 @@ public:
   unsigned int GetPreEventCount() const { return pre_event_count; };
   int GetImageBufferCount() const { return image_buffer_count; };
   State GetState() const { return (State)shared_data->state; }
+
+  AVStream *GetAudioStream() const { return camera ? camera->get_AudioStream() : nullptr; };
+  AVCodecContext *GetAudioCodecContext() const { return camera ?  camera->get_AudioCodecContext() : nullptr; };
+  AVStream *GetVideoStream() const { return camera ? camera->get_VideoStream() : nullptr; };
+  AVCodecContext *GetVideoCodecContext() const { return camera ?  camera->get_VideoCodecContext() : nullptr; };
 
   int GetImage( int index=-1, int scale=100 );
   ZMPacket *getSnapshot( int index=-1 ) const;

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -358,7 +358,7 @@ protected:
   int video_stream_id; // will be filled in PrimeCapture
   int audio_stream_id; // will be filled in PrimeCapture
 
-  Camera      *camera;
+  std::unique_ptr<Camera> camera;
   Event       *event;
   Storage     *storage;
 
@@ -393,13 +393,14 @@ public:
   void AddZones( int p_n_zones, Zone *p_zones[] );
   void AddPrivacyBitmask( Zone *p_zones[] );
 
+  void LoadCamera();
   bool connect();
   bool disconnect();
 
   inline int ShmValid() const {
     return shared_data && shared_data->valid;
   }
-  Camera *getCamera();
+
 
   inline unsigned int Id() const { return id; }
   inline const char *Name() const { return name; }

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -19,6 +19,7 @@
 
 #include "zm_remote_camera_http.h"
 
+#include "zm_monitor.h"
 #include "zm_packet.h"
 #include "zm_signal.h"
 #include "zm_regexp.h"

--- a/src/zm_remote_camera_nvsocket.cpp
+++ b/src/zm_remote_camera_nvsocket.cpp
@@ -19,6 +19,7 @@
 
 #include "zm_remote_camera_nvsocket.h"
 
+#include "zm_monitor.h"
 #include "zm_packet.h"
 #include <netdb.h>
 #include <sys/socket.h>

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -20,6 +20,7 @@
 #include "zm_remote_camera_rtsp.h"
 
 #include "zm_config.h"
+#include "zm_monitor.h"
 #include "zm_packet.h"
 
 #if HAVE_LIBAVFORMAT

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -403,9 +403,6 @@ int main(int argc, char *argv[]) {
         rtsp_server_threads[i] = nullptr;
       }
 #endif
-      Camera *camera = monitors[i]->getCamera();
-      Debug(1, "Closing camera");
-      camera->Close();
     }
 
     // Killoff the analysis threads. Don't need them spinning while we try to reconnect

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -309,8 +309,7 @@ int main(int argc, char *argv[]) {
 #if HAVE_RTSP_SERVER
       if ( rtsp_server_threads ) {
         rtsp_server_threads[i] = new RTSPServerThread(monitors[i]);
-        Camera *camera = monitors[i]->getCamera();
-        rtsp_server_threads[i]->addStream(camera->get_VideoStream(), camera->get_AudioStream());
+        rtsp_server_threads[i]->addStream(monitors[i]->GetVideoStream(), monitors[i]->GetAudioStream());
         rtsp_server_threads[i]->start();
       }
 #endif

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -237,8 +237,8 @@ int main(int argc, char *argv[]) {
     result = 0;
     static char sql[ZM_SQL_SML_BUFSIZ];
     for (const std::shared_ptr<Monitor> &monitor : monitors) {
-      if (!monitor->getCamera()) {
-      }
+      monitor->LoadCamera();
+
       if (!monitor->connect()) {
         Warning("Couldn't connect to monitor %d", monitor->Id());
       }

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -435,7 +435,6 @@ int main(int argc, char *argv[]) {
     if (mysql_query(&dbconn, sql)) {
       Error("Can't run query: %s", mysql_error(&dbconn));
     }
-    monitor->disconnect();
   }
 
   Image::Deinitialise();


### PR DESCRIPTION
Use `unique_ptr` to signal ownership of the camera by its monitor. Additionally, this allows us to simplify `Monitor`'s shutdown/destruction procedure due to RAII.