### PR TITLE
db: Make sure to bind only rvalues when pushing to zmDbQueue

### DIFF
--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -212,10 +212,11 @@ zmDbQueue::~zmDbQueue() {
   mCondition.notify_all();
   mThread.join();
 }
+
 void zmDbQueue::process() {
   std::unique_lock<std::mutex> lock(mMutex);
 
-  while (!mTerminate and !zm_terminate) { 
+  while (!mTerminate and !zm_terminate) {
     if (mQueue.empty()) {
       mCondition.wait(lock);
     }
@@ -229,8 +230,8 @@ void zmDbQueue::process() {
   }
 }  // end void zmDbQueue::process()
 
-void zmDbQueue::push(std::string sql) {
+void zmDbQueue::push(std::string &&sql) {
   std::unique_lock<std::mutex> lock(mMutex);
-  mQueue.push(sql);
+  mQueue.push(std::move(sql));
   mCondition.notify_all();
 }

--- a/src/zm_db.h
+++ b/src/zm_db.h
@@ -21,13 +21,13 @@
 #define ZM_DB_H
 
 #include "zm_thread.h"
-#include <mysql/mysql.h>
-#include <mysql/mysqld_error.h>
-#include <string>
-#include <thread>
-#include <queue>
 #include <condition_variable>
 #include <mutex>
+#include <mysql/mysql.h>
+#include <mysql/mysqld_error.h>
+#include <queue>
+#include <string>
+#include <thread>
 
 class zmDbQueue {
   private:
@@ -40,7 +40,7 @@ class zmDbQueue {
   zmDbQueue();
   ~zmDbQueue();
   void push(const char *sql) { return push(std::string(sql)); };
-  void push(std::string);
+  void push(std::string &&sql);
   void process();
 };
 

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -536,7 +536,7 @@ void Logger::logPrint(bool hex, const char * const filepath, const int line, con
           "( %ld.%06ld, '%s', %d, %d, %d, '%s', '%s', '%s', %d )",
           timeVal.tv_sec, timeVal.tv_usec, mId.c_str(), staticConfig.SERVER_ID, tid, level, classString, escapedString, file, line
           );
-      dbQueue.push(sql_string);
+      dbQueue.push(std::move(sql_string));
     } else {
       puts("Db is closed");
     }


### PR DESCRIPTION
With this we can ensure that no copy-construction of the SQL string takes place.
Regarding calling semantics: The pushed SQL string will be moved and cannot be reused.