### PR TITLE
build: Enable -Wextra with some exceptions and fix related warnings

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -1,6 +1,8 @@
 target_compile_options(zm-warning-interface
   INTERFACE
-    -Wall)
+    -Wall
+    -Wextra
+    -Wno-unused-parameter)
 
 if(ASAN)
   target_compile_options(zm-compile-option-interface

--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -1,6 +1,10 @@
 target_compile_options(zm-warning-interface
   INTERFACE
-    -Wall)
+    -Wall
+    -Wextra
+    -Wno-cast-function-type
+    -Wno-type-limits
+    -Wno-unused-parameter)
 
 if(ASAN)
   target_compile_options(zm-compile-option-interface

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -37,7 +37,7 @@ char frame_insert_sql[ZM_SQL_LGE_BUFSIZ] = "INSERT INTO `Frames` (`EventId`, `Fr
 
 int Event::pre_alarm_count = 0;
 
-Event::PreAlarmData Event::pre_alarm_data[MAX_PRE_ALARM_FRAMES] = { { 0 } };
+Event::PreAlarmData Event::pre_alarm_data[MAX_PRE_ALARM_FRAMES] = {};
 
 Event::Event(
     Monitor *p_monitor,

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -998,7 +998,7 @@ bool Monitor::connect() {
     trigger_data->trigger_text[0] = 0;
     trigger_data->trigger_showtext[0] = 0;
     shared_data->valid = true;
-    video_store_data->recording = (struct timeval){0};
+    video_store_data->recording = {};
     // Uh, why nothing?  Why not nullptr?
     snprintf(video_store_data->event_file, sizeof(video_store_data->event_file), "nothing");
     video_store_data->size = sizeof(VideoStoreData);
@@ -2671,7 +2671,7 @@ bool Monitor::closeEvent() {
   delete event;
   event = nullptr;
   if ( shared_data )
-    video_store_data->recording = (struct timeval){0};
+    video_store_data->recording = {};
   return true;
 } // end bool Monitor::closeEvent()
 

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -992,7 +992,7 @@ bool Monitor::connect() {
     shared_data->alarm_cause[0] = 0;
     shared_data->last_frame_score = 0;
     trigger_data->size = sizeof(TriggerData);
-    trigger_data->trigger_state = TRIGGER_CANCEL;
+    trigger_data->trigger_state = TriggerState::TRIGGER_CANCEL;
     trigger_data->trigger_score = 0;
     trigger_data->trigger_cause[0] = 0;
     trigger_data->trigger_text[0] = 0;
@@ -1295,18 +1295,18 @@ void Monitor::UpdateAdaptiveSkip() {
 }
 
 void Monitor::ForceAlarmOn( int force_score, const char *force_cause, const char *force_text ) {
-  trigger_data->trigger_state = TRIGGER_ON;
+  trigger_data->trigger_state = TriggerState::TRIGGER_ON;
   trigger_data->trigger_score = force_score;
   strncpy(trigger_data->trigger_cause, force_cause, sizeof(trigger_data->trigger_cause)-1);
   strncpy(trigger_data->trigger_text, force_text, sizeof(trigger_data->trigger_text)-1);
 }
 
 void Monitor::ForceAlarmOff() {
-  trigger_data->trigger_state = TRIGGER_OFF;
+  trigger_data->trigger_state = TriggerState::TRIGGER_OFF;
 }
 
 void Monitor::CancelForced() {
-  trigger_data->trigger_state = TRIGGER_CANCEL;
+  trigger_data->trigger_state = TriggerState::TRIGGER_CANCEL;
 }
 
 void Monitor::actionReload() {
@@ -1795,14 +1795,14 @@ bool Monitor::Analyse() {
   bool signal_change = (signal != last_signal);
 
   Debug(3, "Motion detection is enabled signal(%d) signal_change(%d) trigger state(%d) image index %d",
-      signal, signal_change, trigger_data->trigger_state, snap->image_index);
+      signal, signal_change, int(trigger_data->trigger_state), snap->image_index);
 
   // Need to guard around event creation/deletion from Reload()
   std::lock_guard<std::mutex> lck(event_mutex);
 
   // if we have been told to be OFF, then we are off and don't do any processing.
-  if ( trigger_data->trigger_state != TRIGGER_OFF ) {
-    Debug(4, "Trigger not OFF state is (%d)", trigger_data->trigger_state);
+  if ( trigger_data->trigger_state != TriggerState::TRIGGER_OFF ) {
+    Debug(4, "Trigger not OFF state is (%d)", int(trigger_data->trigger_state));
     int score = 0;
     // Ready means that we have captured the warmup # of frames
     if ( !Ready() ) {
@@ -1816,7 +1816,7 @@ bool Monitor::Analyse() {
     Event::StringSetMap noteSetMap;
 
     // Specifically told to be on.  Setting the score here will trigger the alarm.
-    if ( trigger_data->trigger_state == TRIGGER_ON ) {
+    if ( trigger_data->trigger_state == TriggerState::TRIGGER_ON ) {
       score += trigger_data->trigger_score;
       Debug(1, "Triggered on score += %d => %d", trigger_data->trigger_score, score);
       if ( !event ) {
@@ -2200,7 +2200,7 @@ bool Monitor::Analyse() {
       closeEvent();
     }
     shared_data->state = state = IDLE;
-    trigger_data->trigger_state = TRIGGER_CANCEL;
+    trigger_data->trigger_state = TriggerState::TRIGGER_CANCEL;
   } // end if ( trigger_data->trigger_state != TRIGGER_OFF )
 
   if ( event ) event->AddPacket(snap);

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -459,7 +459,7 @@ public:
   VideoWriter GetOptVideoWriter() const { return videowriter; }
   //const std::vector<EncoderParameter_t>* GetEncoderParams() const { return &encoderparamsvec; }
   const std::string &GetEncoderOptions() const { return encoderparams; }
-  const int OutputCodec() const { return output_codec; }
+  int OutputCodec() const { return output_codec; }
   const std::string &Encoder() const { return encoder; }
   const std::string &OutputContainer() const { return output_container; }
 

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -157,12 +157,16 @@ protected:
 
   } SharedData;
 
-  typedef enum { TRIGGER_CANCEL, TRIGGER_ON, TRIGGER_OFF } TriggerState;
+  enum TriggerState : uint32 {
+    TRIGGER_CANCEL,
+    TRIGGER_ON,
+    TRIGGER_OFF
+  };
 
   /* sizeof(TriggerData) expected to be 560 on 32bit & and 64bit */
   typedef struct {
     uint32_t size;
-    uint32_t trigger_state;
+    TriggerState trigger_state;
     uint32_t trigger_score;
     uint32_t padding;
     char trigger_cause[32];
@@ -496,7 +500,7 @@ public:
   void ForceAlarmOn( int force_score, const char *force_case, const char *force_text="" );
   void ForceAlarmOff();
   void CancelForced();
-  TriggerState GetTriggerState() const { return (TriggerState)(trigger_data?trigger_data->trigger_state:TRIGGER_CANCEL); }
+  TriggerState GetTriggerState() const { return trigger_data ? trigger_data->trigger_state : TRIGGER_CANCEL; }
 	inline time_t getStartupTime() const { return shared_data->startup_time; }
 	inline void setStartupTime( time_t p_time ) { shared_data->startup_time = p_time; }
   void get_ref_image();

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -270,8 +270,8 @@ void MonitorStream::processCommand(const CmdMsg *msg) {
     status_data.analysis_fps = monitor->get_analysis_fps();
     status_data.state = monitor->shared_data->state;
     //status_data.enabled = monitor->shared_data->active;
-    status_data.enabled = monitor->trigger_data->trigger_state!=Monitor::TRIGGER_OFF;
-    status_data.forced = monitor->trigger_data->trigger_state==Monitor::TRIGGER_ON;
+    status_data.enabled = monitor->trigger_data->trigger_state != Monitor::TriggerState::TRIGGER_OFF;
+    status_data.forced = monitor->trigger_data->trigger_state == Monitor::TriggerState::TRIGGER_ON;
     if ( playback_buffer > 0 )
       status_data.buffer_level = (MOD_ADD( (temp_write_index-temp_read_index), 0, temp_image_buffer_count )*100)/temp_image_buffer_count;
     else

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -617,6 +617,7 @@ int RemoteCameraHttp::GetResponse() {
             content_type[0] = '\0';
             content_boundary[0] = '\0';
             content_boundary_len = 0;
+            [[gnu::fallthrough]];
           }
         case HEADERCONT :
           {
@@ -833,6 +834,7 @@ int RemoteCameraHttp::GetResponse() {
             subcontent_type_header[0] = '\0';
             content_length = 0;
             content_type[0] = '\0';
+            [[gnu::fallthrough]];
           }
         case SUBHEADERCONT :
           {

--- a/src/zm_sdp.h
+++ b/src/zm_sdp.h
@@ -114,7 +114,7 @@ public:
     {
       return( mTransport );
     }
-    const int getPayloadType() const
+    int getPayloadType() const
     {
       return( mPayloadType );
     }
@@ -136,7 +136,7 @@ public:
       mControlUrl = controlUrl;
     }
 
-    const int getClock() const {
+    int getClock() const {
       return( mClock );
     }
     void setClock( int clock ) {
@@ -157,10 +157,10 @@ public:
     void setSprops(const std::string &props) {
       mSprops = props;
     }
-    const std::string getSprops() const {
+    std::string getSprops() const {
       return ( mSprops );
     }
-    const double getFrameRate() const {
+    double getFrameRate() const {
       return( mFrameRate );
     }
     void setFrameRate( double frameRate ) {

--- a/src/zm_storage.h
+++ b/src/zm_storage.h
@@ -48,8 +48,8 @@ public:
 	unsigned int	Id() const { return id; }
 	const char *Name() const { return name; }
 	const char *Path() const { return path; }
-  const Schemes  Scheme() const { return scheme; }
-  const std::string  SchemeString() const { return scheme_str; }
+  Schemes  Scheme() const { return scheme; }
+  std::string  SchemeString() const { return scheme_str; }
 };
 
 #endif // ZM_STORAGE_H

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -182,7 +182,7 @@ public:
     vid_stream = 0;
 #endif // HAVE_LIBAVCODEC   
     last_frame_sent = 0.0;
-    last_frame_timestamp = (struct timeval){0};
+    last_frame_timestamp = {};
     msg = { 0, { 0 } };
   }
   virtual ~StreamBase();

--- a/src/zm_user.h
+++ b/src/zm_user.h
@@ -52,7 +52,7 @@ class User {
     Copy(u); return *this;
   }
 
-  const int  Id() const { return id; }
+  int  Id() const { return id; }
   const char *getUsername() const { return username; }
   const char *getPassword() const { return password; }
   bool isEnabled() const { return enabled; }


### PR DESCRIPTION
`-Wno-cast-function-type`:
Signal handler code relies on this.

`-Wno-type-limits`:
Some of the color space conversion code in zm_image throws this warning. To not break anything let's ignore this warning for the time being.

Note that clang enables `-Woverloaded-virtual` with `-Wextra`. To not flood the GCC build log with warnings let's not enable this at the moment.
This will be done in a second step, when the currently throwing code will be cleaned up.