### PR TITLE
rgb: Convert some constant defines to constexpr

### DIFF
--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -2001,7 +2001,7 @@ void Image::Annotate(
   const uint8_t bg_b_col = BLUE_VAL_RGBA(bg_colour);
   const uint8_t bg_bw_col = bg_colour & 0xff;
   const Rgb bg_rgb_col = rgb_convert(bg_colour, subpixelorder);
-  const bool bg_trans = (bg_colour == RGB_TRANSPARENT);
+  const bool bg_trans = (bg_colour == kRGBTransparent);
 
   font.SetFontSize(size-1);
   const uint16_t char_width = font.GetCharWidth();

--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -276,13 +276,13 @@ public:
 	void Blend(const Image &image, int transparency=12);
 	static Image *Merge( unsigned int n_images, Image *images[] );
 	static Image *Merge( unsigned int n_images, Image *images[], double weight );
-	static Image *Highlight( unsigned int n_images, Image *images[], const Rgb threshold=RGB_BLACK, const Rgb ref_colour=RGB_RED );
+  static Image *Highlight(unsigned int n_images, Image *images[], Rgb threshold = kRGBBlack, Rgb ref_colour = kRGBRed);
 	//Image *Delta( const Image &image ) const;
 	void Delta( const Image &image, Image* targetimage) const;
 
 	const Coord centreCoord(const char *text, const int size) const;
   void MaskPrivacy( const unsigned char *p_bitmask, const Rgb pixel_colour=0x00222222 );
-	void Annotate( const char *p_text, const Coord &coord, const unsigned int size=1, const Rgb fg_colour=RGB_WHITE, const Rgb bg_colour=RGB_BLACK );
+  void Annotate(const char *p_text, const Coord &coord, unsigned int size = 1, Rgb fg_colour = kRGBWhite, Rgb bg_colour = kRGBBlack);
 	Image *HighlightEdges( Rgb colour, unsigned int p_colours, unsigned int p_subpixelorder, const Box *limits=0 );
 	//Image *HighlightEdges( Rgb colour, const Polygon &polygon );
 	void Timestamp( const char *label, const time_t when, const Coord &coord, const int size );

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -1511,15 +1511,15 @@ void Monitor::DumpZoneImage(const char *zone_string) {
       colour = extra_colour;
     } else {
       if ( zones[i]->IsActive() ) {
-        colour = RGB_RED;
+        colour = kRGBRed;
       } else if ( zones[i]->IsInclusive() ) {
-        colour = RGB_ORANGE;
+        colour = kRGBOrange;
       } else if ( zones[i]->IsExclusive() ) {
-        colour = RGB_PURPLE;
+        colour = kRGBPurple;
       } else if ( zones[i]->IsPreclusive() ) {
-        colour = RGB_BLUE;
+        colour = kRGBBlue;
       } else {
-        colour = RGB_WHITE;
+        colour = kRGBWhite;
       }
     }
     zone_image->Fill(colour, 2, zones[i]->GetPolygon());
@@ -2698,7 +2698,7 @@ unsigned int Monitor::DetectMotion(const Image &comp_image, Event::StringSet &zo
       continue;
     }
     Debug(3, "Blanking inactive zone %s", zone->Label());
-    delta_image.Fill(RGB_BLACK, zone->GetPolygon());
+    delta_image.Fill(kRGBBlack, zone->GetPolygon());
   } // end foreach zone
 
   // Check preclusive zones first

--- a/src/zm_rgb.h
+++ b/src/zm_rgb.h
@@ -24,24 +24,24 @@
 
 typedef uint32 Rgb;  // RGB colour type
 
-#define WHITE     0xff
-#define WHITE_R   0xff
-#define WHITE_G   0xff
-#define WHITE_B   0xff
+constexpr uint8 kWhite = 0xff;
+constexpr uint8 kWhiteR = 0xff;
+constexpr uint8 kWhiteG = 0xff;
+constexpr uint8 kWhiteB = 0xff;
 
-#define BLACK     0x00
-#define BLACK_R   0x00
-#define BLACK_G   0x00
-#define BLACK_B   0x00
+constexpr uint8 kBlack = 0x00;
+constexpr uint8 kBlackR = 0x00;
+constexpr uint8 kBlackG = 0x00;
+constexpr uint8 kBlackB = 0x00;
 
-#define RGB_WHITE     (0x00ffffff)
-#define RGB_BLACK     (0x00000000)
-#define RGB_RED     (0x000000ff)
-#define RGB_GREEN     (0x0000ff00)
-#define RGB_BLUE    (0x00ff0000)
-#define RGB_ORANGE    (0x0000a5ff)
-#define RGB_PURPLE    (0x00800080)
-#define RGB_TRANSPARENT  (0x01000000)
+constexpr Rgb kRGBWhite = 0x00ffffff;
+constexpr Rgb kRGBBlack = 0x00000000;
+constexpr Rgb kRGBRed = 0x000000ff;
+constexpr Rgb kRGBGreen = 0x0000ff00;
+constexpr Rgb kRGBBlue = 0x00ff0000;
+constexpr Rgb kRGBOrange = 0x0000a5ff;
+constexpr Rgb kRGBPurple = 0x00800080;
+constexpr Rgb kRGBTransparent = 0x01000000;
 
 #define RGB_VAL(v,c)    (((v)>>(16-((c)*8)))&0xff)
 

--- a/src/zm_zone.cpp
+++ b/src/zm_zone.cpp
@@ -287,7 +287,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
         pdiff = (uint8_t*)diff_image->Buffer(lo_x, y);
 
         for ( int x = lo_x; x <= hi_x; x++, pdiff++ ) {
-          if ( *pdiff == WHITE ) {
+          if ( *pdiff == kWhite ) {
             // Check participation in an X block
             ldx = (x>=(lo_x+bx1))?-bx1:lo_x-x;
             hdx = (x<=(hi_x-bx1))?0:((hi_x-x)-bx1);
@@ -308,7 +308,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
               }
             }
             if ( !block ) {
-              *pdiff = BLACK;
+              *pdiff = kBlack;
               continue;
             }
             alarm_filter_pixels++;
@@ -365,7 +365,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
 
         pdiff = (uint8_t*)diff_image->Buffer(lo_x, y);
         for ( int x = lo_x; x <= hi_x; x++, pdiff++ ) {
-          if ( *pdiff == WHITE ) {
+          if ( *pdiff == kWhite ) {
             Debug(9, "Got white pixel at %d,%d (%p)", x, y, pdiff);
 
             last_x = ((x > 0) && ( (x-1) >= lo_x )) ? *(pdiff-1) : 0;
@@ -483,7 +483,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
               } else {
                 // Create a new blob
                 int i;
-                for ( i = (WHITE-1); i > 0; i-- ) {
+                for ( i = (kWhite-1); i > 0; i-- ) {
                   BlobStats *bs = &blob_stats[i];
                   // See if we can recycle one first, only if it's at least two rows up
                   if ( bs->count && bs->hi_y < (int)(y-1) ) {
@@ -497,7 +497,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
                           spdiff = diff_buff + ((diff_width * sy) + bs->lo_x);
                           for ( int sx = bs->lo_x; sx <= bs->hi_x; sx++, spdiff++ ) {
                             if ( *spdiff == bs->tag ) {
-                              *spdiff = BLACK;
+                              *spdiff = kBlack;
                             }
                           }
                         }
@@ -557,7 +557,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
       }
 
       // Now eliminate blobs under the threshold
-      for ( int i = 1; i < WHITE; i++ ) {
+      for ( uint32 i = 1; i < kWhite; i++ ) {
         BlobStats *bs = &blob_stats[i];
         if ( bs->count ) {
           if ( (min_blob_pixels && bs->count < min_blob_pixels) || (max_blob_pixels && bs->count > max_blob_pixels) ) {
@@ -566,7 +566,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
                 spdiff = diff_buff + ((diff_width * sy) + bs->lo_x);
                 for ( int sx = bs->lo_x; sx <= bs->hi_x; sx++, spdiff++ ) {
                   if ( *spdiff == bs->tag ) {
-                    *spdiff = BLACK;
+                    *spdiff = kBlack;
                   }
                 }
               }
@@ -631,7 +631,7 @@ bool Zone::CheckAlarms(const Image *delta_image) {
       alarm_lo_y = polygon.HiY()+1;
       alarm_hi_y = polygon.LoY()-1;
 
-      for ( int i = 1; i < WHITE; i++ ) {
+      for ( uint32 i = 1; i < kWhite; i++ ) {
         BlobStats *bs = &blob_stats[i];
         if ( bs->count ) {
           if ( bs->count == max_blob_size ) {
@@ -701,9 +701,9 @@ bool Zone::CheckAlarms(const Image *delta_image) {
         int lo_gap = lo_x2-lo_x;
         if ( lo_gap > 0 ) {
           if ( lo_gap == 1 ) {
-            *pdiff++ = BLACK;
+            *pdiff++ = kBlack;
           } else {
-            memset(pdiff, BLACK, lo_gap);
+            memset(pdiff, kBlack, lo_gap);
             pdiff += lo_gap;
           }
         }
@@ -711,16 +711,16 @@ bool Zone::CheckAlarms(const Image *delta_image) {
         const uint8_t* ppoly = pg_image->Buffer(lo_x2, y);
         for ( int x = lo_x2; x <= hi_x2; x++, pdiff++, ppoly++ ) {
           if ( !*ppoly ) {
-            *pdiff = BLACK;
+            *pdiff = kBlack;
           }
         }
 
         int hi_gap = hi_x-hi_x2;
         if ( hi_gap > 0 ) {
           if ( hi_gap == 1 ) {
-            *pdiff = BLACK;
+            *pdiff = kBlack;
           } else {
-            memset(pdiff, BLACK, hi_gap);
+            memset(pdiff, kBlack, hi_gap);
           }
         }
       } // end for y
@@ -982,9 +982,9 @@ void Zone::std_alarmedpixels(
       if ( *ppoly && (*pdiff > min_pixel_threshold) && (*pdiff <= calc_max_pixel_threshold) ) {
         pixelsalarmed++;
         pixelsdifference += *pdiff;
-        *pdiff = WHITE;
+        *pdiff = kWhite;
       } else {
-        *pdiff = BLACK;
+        *pdiff = kBlack;
       }
     }
   }  // end for y = lo_y to hi_y

--- a/src/zm_zone.h
+++ b/src/zm_zone.h
@@ -114,11 +114,11 @@ public:
   }
   Zone( Monitor *p_monitor, int p_id, const char *p_label, const Polygon &p_polygon )
   {
-    Setup( p_monitor, p_id, p_label, Zone::INACTIVE, p_polygon, RGB_BLACK, (Zone::CheckMethod)0, 0, 0, 0, 0, Coord( 0, 0 ), 0, 0, 0, 0, 0, 0, 0, 0 );
+    Setup( p_monitor, p_id, p_label, Zone::INACTIVE, p_polygon, kRGBBlack, (Zone::CheckMethod)0, 0, 0, 0, 0, Coord( 0, 0 ), 0, 0, 0, 0, 0, 0, 0, 0 );
   }
   Zone( Monitor *p_monitor, int p_id, const char *p_label, ZoneType p_type, const Polygon &p_polygon )
   {
-    Setup( p_monitor, p_id, p_label, p_type, p_polygon, RGB_BLACK, (Zone::CheckMethod)0, 0, 0, 0, 0, Coord( 0, 0 ), 0, 0, 0, 0, 0, 0, 0, 0 );
+    Setup( p_monitor, p_id, p_label, p_type, p_polygon, kRGBBlack, (Zone::CheckMethod)0, 0, 0, 0, 0, Coord( 0, 0 ), 0, 0, 0, 0, 0, 0, 0, 0 );
   }
 
 public:


### PR DESCRIPTION
Using defines interferes with fmt.
Also rename them according to the Google styleguide.