### PR TITLE
monitor: Move system includes back to their original location

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -17,10 +17,6 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
 
-#include <algorithm>
-#include <sys/types.h>
-#include <sys/stat.h>
-
 #include "zm_monitor.h"
 
 #include "zm_group.h"
@@ -59,6 +55,9 @@
 #include "zm_libvnc_camera.h"
 #endif // HAVE_LIBVNC
 
+#include <algorithm>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #if ZM_MEM_MAPPED
 #include <sys/mman.h>


### PR DESCRIPTION
41dc0212e0d4792f04b3cbace46a50bffe1020d4 moved the system includes to work around some compilation problems.
The underlying cause has been fixed in cf9406a1e836ecc194ac5f13bddd8d71c1bd6aaa.
Thus we can move the includes back so the follow the project-wide order.