### PR TITLE
Make capturing/analysing log lines follow same pattern

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -1725,7 +1725,7 @@ void Monitor::UpdateCaptureFPS() {
           now_double, last_analysis_fps_time,
           elapsed, new_capture_fps
           );
-      Info("%s: images:%d - Capturing at %.2lf fps, capturing bandwidth %ubytes/sec",
+      Info("%s: %d - Capturing at %.2lf fps, capturing bandwidth %ubytes/sec",
           name, image_count, new_capture_fps, new_capture_bandwidth);
       shared_data->capture_fps = new_capture_fps;
       last_fps_time = now_double;


### PR DESCRIPTION
Only a cosmetic change to follow same pattern and have them aligned:

CAMARA01-LOW: 50500 - Analysing at 25.02 fps from 50500 - 50000=500 / ...
CAMARA01-LOW: 50500 - Capturing at 24.98 fps, capturing bandwidth 104283bytes/sec
