### PR TITLE
Fix SQL queries with missing lock

### DIFF
--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -2,6 +2,7 @@ target_compile_options(zm-warning-interface
   INTERFACE
     -Wall
     -Wextra
+    -Wformat-security
     -Wno-cast-function-type
     -Wno-type-limits
     -Wno-unused-parameter)

--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -340,16 +340,11 @@ Config::~Config() {
 }
 
 void Config::Load() {
-  if ( mysql_query(&dbconn, "SELECT `Name`, `Value`, `Type` FROM `Config` ORDER BY `Id`") ) {
-    Error("Can't run query: %s", mysql_error(&dbconn));
-    exit(mysql_errno(&dbconn));
+  MYSQL_RES *result = zmDbFetch("SELECT `Name`, `Value`, `Type` FROM `Config` ORDER BY `Id`");
+  if (!result) {
+    exit(-1);
   }
 
-  MYSQL_RES *result = mysql_store_result(&dbconn);
-  if ( !result ) {
-    Error("Can't use query result: %s", mysql_error(&dbconn));
-    exit(mysql_errno(&dbconn));
-  }
   n_items = mysql_num_rows(result);
 
   if ( n_items <= ZM_MAX_CFG_ID ) {
@@ -362,7 +357,6 @@ void Config::Load() {
     items[i] = new ConfigItem(dbrow[0], dbrow[1], dbrow[2]);
   }
   mysql_free_result(result);
-  result = nullptr;
 }
 
 void Config::Assign() {

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -105,7 +105,7 @@ void RemoteCameraHttp::Initialise() {
     request += stringtf( "User-Agent: %s/%s\r\n", config.http_ua, ZM_VERSION );
     request += stringtf( "Host: %s\r\n", host.c_str());
     if ( strcmp( config.http_version, "1.0" ) == 0 )
-      request += stringtf( "Connection: Keep-Alive\r\n" );
+      request += "Connection: Keep-Alive\r\n";
     if ( !auth.empty() )
       request += stringtf( "Authorization: Basic %s\r\n", auth64.c_str() );
     request += "\r\n";
@@ -362,7 +362,7 @@ int RemoteCameraHttp::GetResponse() {
                   request += stringtf( "User-Agent: %s/%s\r\n", config.http_ua, ZM_VERSION );
                   request += stringtf( "Host: %s\r\n", host.c_str());
                   if ( strcmp( config.http_version, "1.0" ) == 0 )
-                    request += stringtf( "Connection: Keep-Alive\r\n" );
+                    request += "Connection: Keep-Alive\r\n";
                   request += mAuthenticator->getAuthHeader( "GET", path.c_str() );
                   request += "\r\n";
 
@@ -738,7 +738,7 @@ int RemoteCameraHttp::GetResponse() {
                   request += stringtf("User-Agent: %s/%s\r\n", config.http_ua, ZM_VERSION);
                   request += stringtf("Host: %s\r\n", host.c_str());
                   if ( strcmp(config.http_version, "1.0") == 0 )
-                    request += stringtf("Connection: Keep-Alive\r\n");
+                    request += "Connection: Keep-Alive\r\n";
                   request += mAuthenticator->getAuthHeader("GET", path.c_str());
                   request += "\r\n";
 

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -65,34 +65,6 @@ std::string replaceAll(std::string str, std::string from, std::string to) {
   return str;
 }
 
-const std::string stringtf( const char *format, ... ) {
-  va_list ap;
-  char tempBuffer[8192];
-  std::string tempString;
-
-  va_start(ap, format);
-  vsnprintf(tempBuffer, sizeof(tempBuffer), format , ap);
-  va_end(ap);
-
-  tempString = tempBuffer;
-
-  return tempString;
-}
-
-const std::string stringtf(const std::string format, ...) {
-  va_list ap;
-  char tempBuffer[8192];
-  std::string tempString;
-
-  va_start(ap, format);
-  vsnprintf(tempBuffer, sizeof(tempBuffer), format.c_str(), ap);
-  va_end(ap);
-
-  tempString = tempBuffer;
-
-  return tempString;
-}
-
 bool startsWith(const std::string &haystack, const std::string &needle) {
   return ( haystack.substr(0, needle.length()) == needle );
 }

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -23,8 +23,9 @@
 #include <chrono>
 #include <ctime>
 #include <memory>
-#include <sys/time.h>
+#include <stdexcept>
 #include <string>
+#include <sys/time.h>
 #include <vector>
 
 typedef std::vector<std::string> StringVector;
@@ -33,8 +34,16 @@ std::string trimSpaces(const std::string &str);
 std::string trimSet(std::string str, std::string trimset);
 std::string replaceAll(std::string str, std::string from, std::string to);
 
-const std::string stringtf( const char *format, ... );
-const std::string stringtf( const std::string &format, ... );
+template<typename... Args>
+std::string stringtf(const std::string &format, Args... args) {
+  int size = snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
+  if (size <= 0) {
+    throw std::runtime_error("Error during formatting.");
+  }
+  std::unique_ptr<char[]> buf(new char[size]);
+  snprintf(buf.get(), size, format.c_str(), args...);
+  return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
+}
 
 bool startsWith( const std::string &haystack, const std::string &needle );
 StringVector split( const std::string &string, const std::string &chars, int limit=0 );

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -721,20 +721,14 @@ int main(int argc, char *argv[]) {
 
     if ( function & ZMU_LIST ) {
       std::string sql = "SELECT `Id`, `Function`+0 FROM `Monitors`";
-      if ( !verbose ) {
+      if (!verbose) {
         sql += "WHERE `Function` != 'None'";
       }
       sql += " ORDER BY Id ASC";
 
-      if ( mysql_query(&dbconn, sql.c_str()) ) {
-        Error("Can't run query: %s", mysql_error(&dbconn));
-        exit_zmu(mysql_errno(&dbconn));
-      }
-
-      MYSQL_RES *result = mysql_store_result(&dbconn);
-      if ( !result ) {
-        Error("Can't use query result: %s", mysql_error(&dbconn));
-        exit_zmu(mysql_errno(&dbconn));
+      MYSQL_RES *result = zmDbFetch(sql.c_str());
+      if (!result) {
+        exit_zmu(-1);
       }
       Debug(1, "Got %d monitors", mysql_num_rows(result));
 


### PR DESCRIPTION
Replace raw `mysql_query` calls with the `zmDb*` functions.
With this we can make sure we have proper locking of our DB connection at all times.

Also replace `stringtf` with a type-safe version that can't overflow.