### PR TITLE
Cleanup zm_utils and add unit tests

### DIFF
--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -273,7 +273,7 @@ int FfmpegCamera::OpenFfmpeg() {
 
   // Set transport method as specified by method field, rtpUni is default
   std::string protocol = mPath.substr(0, 4);
-  string_toupper(protocol);
+  StringToUpper(protocol);
   if ( protocol == "RTSP" ) {
     const std::string method = Method();
     if ( method == "rtpMulti" ) {

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -1738,7 +1738,7 @@ void Image::Blend( const Image &image, int transparency ) {
 
 #ifdef ZM_IMAGE_PROFILING
   clock_gettime(CLOCK_THREAD_CPUTIME_ID,&end);
-  timespec_diff(&start,&end,&diff);
+  TimespecDiff(&start,&end,&diff);
 
   executetime = (1000000000ull * diff.tv_sec) + diff.tv_nsec;
   milpixels = (unsigned long)((long double)size)/((((long double)executetime)/1000));
@@ -1902,7 +1902,7 @@ void Image::Delta(const Image &image, Image* targetimage) const {
 
 #ifdef ZM_IMAGE_PROFILING
   clock_gettime(CLOCK_THREAD_CPUTIME_ID,&end);
-  timespec_diff(&start,&end,&diff);
+  TimespecDiff(&start,&end,&diff);
 
   executetime = (1000000000ull * diff.tv_sec) + diff.tv_nsec;
   milpixels = (unsigned long)((long double)pixels)/((((long double)executetime)/1000));

--- a/src/zm_libvlc_camera.cpp
+++ b/src/zm_libvlc_camera.cpp
@@ -229,7 +229,7 @@ int LibvlcCamera::PrimeCapture() {
     mOptArgV = new char*[opVect.size()];
     Debug(2, "Number of Options: %d",opVect.size());
     for (size_t i=0; i< opVect.size(); i++) {
-      opVect[i] = trimSpaces(opVect[i]);
+      opVect[i] = TrimSpaces(opVect[i]);
       mOptArgV[i] = (char *)opVect[i].c_str();
       Debug(2, "set option %d to '%s'", i,  opVect[i].c_str());
     }

--- a/src/zm_libvlc_camera.cpp
+++ b/src/zm_libvlc_camera.cpp
@@ -213,7 +213,7 @@ void LibvlcCamera::Terminate() {
 int LibvlcCamera::PrimeCapture() {
   Debug(1, "Priming capture from %s, libvlc version %s", mPath.c_str(), (*libvlc_get_version_f)());
 
-  StringVector opVect = split(Options(), ",");
+  StringVector opVect = Split(Options(), ",");
 
   // Set transport method as specified by method field, rtpUni is default
   if ( Method() == "rtpMulti" )

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -166,7 +166,7 @@ void Logger::initialise(const std::string &id, const Options &options) {
     tempSyslogLevel = atoi(envPtr);
 
   if ( config.log_debug ) {
-    StringVector targets = split(config.log_debug_target, "|");
+    StringVector targets = Split(config.log_debug_target, "|");
     for ( unsigned int i = 0; i < targets.size(); i++ ) {
       const std::string &target = targets[i];
       if ( target == mId || target == "_"+mId || target == "_"+mIdRoot || target == "" ) {

--- a/src/zm_remote_camera.cpp
+++ b/src/zm_remote_camera.cpp
@@ -83,7 +83,7 @@ void RemoteCamera::Initialise() {
   if ( authIndex != std::string::npos ) {
     auth = host.substr( 0, authIndex );
     host.erase( 0, authIndex+1 );
-    auth64 = base64Encode( auth );
+    auth64 = Base64Encode(auth);
 
     authIndex = auth.rfind( ':' );
     username = auth.substr(0,authIndex);

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -42,7 +42,7 @@ bool RtspThread::sendCommand(std::string message) {
   message += stringtf("CSeq: %d\r\n\r\n", ++mSeq);
   Debug(2, "Sending RTSP message: %s", message.c_str());
   if ( mMethod == RTP_RTSP_HTTP ) {
-    message = base64Encode(message);
+    message = Base64Encode(message);
     Debug(2, "Sending encoded RTSP message: %s", message.c_str());
     if ( mRtspSocket2.send(message.c_str(), message.size()) != (int)message.length() ) {
       Error("Unable to send message '%s': %s", message.c_str(), strerror(errno));

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -487,28 +487,28 @@ void RtspThread::Run() {
   for ( size_t i = 0; i < parts.size(); i++ ) {
     if ( parts[i] == "unicast" || parts[i] == "multicast" )
       distribution = parts[i];
-    else if ( startsWith( parts[i], "server_port=" ) ) {
+    else if (StartsWith(parts[i], "server_port=") ) {
       method = "RTP/UNICAST";
       StringVector subparts = split( parts[i], "=" );
       StringVector ports = split( subparts[1], "-" );
       remotePorts[0] = strtol( ports[0].c_str(), nullptr, 10 );
       remotePorts[1] = strtol( ports[1].c_str(), nullptr, 10 );
-    } else if ( startsWith( parts[i], "interleaved=" ) ) {
+    } else if (StartsWith(parts[i], "interleaved=") ) {
       method = "RTP/RTSP";
       StringVector subparts = split( parts[i], "=" );
       StringVector channels = split( subparts[1], "-" );
       remoteChannels[0] = strtol( channels[0].c_str(), nullptr, 10 );
       remoteChannels[1] = strtol( channels[1].c_str(), nullptr, 10 );
-    } else if ( startsWith( parts[i], "port=" ) ) {
+    } else if (StartsWith(parts[i], "port=") ) {
       method = "RTP/MULTICAST";
       StringVector subparts = split( parts[i], "=" );
       StringVector ports = split( subparts[1], "-" );
       localPorts[0] = strtol( ports[0].c_str(), nullptr, 10 );
       localPorts[1] = strtol( ports[1].c_str(), nullptr, 10 );
-    } else if ( startsWith( parts[i], "destination=" ) ) {
+    } else if (StartsWith(parts[i], "destination=") ) {
       StringVector subparts = split( parts[i], "=" );
       localHost = subparts[1];
-    } else if ( startsWith( parts[i], "ssrc=" ) ) {
+    } else if (StartsWith(parts[i], "ssrc=") ) {
       StringVector subparts = split( parts[i], "=" );
       ssrc = strtoll( subparts[1].c_str(), nullptr, 16 );
     }
@@ -558,10 +558,10 @@ void RtspThread::Run() {
         // Parse the sequence and rtptime values
         parts = split( streams[i].c_str(), ";" );
         for ( size_t j = 0; j < parts.size(); j++ ) {
-          if ( startsWith( parts[j], "seq=" ) ) {
+          if (StartsWith(parts[j], "seq=") ) {
             StringVector subparts = split( parts[j], "=" );
             seq = strtol( subparts[1].c_str(), nullptr, 10 );
-          } else if ( startsWith( parts[j], "rtptime=" ) ) {
+          } else if (StartsWith(parts[j], "rtptime=") ) {
             StringVector subparts = split( parts[j], "=" );
             rtpTime = strtol( subparts[1].c_str(), nullptr, 10 );
           }

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -356,7 +356,7 @@ void RtspThread::Run() {
     for ( size_t i = 0; i < lines.size(); i++ ) {
       // If the device sends us a url value for Content-Base in the response header, we should use that instead
       if ( ( lines[i].size() > 13 ) && ( lines[i].substr( 0, 13 ) == "Content-Base:" ) ) {
-        mUrl = trimSpaces( lines[i].substr( 13 ) );
+        mUrl = TrimSpaces(lines[i].substr(13));
         Info("Received new Content-Base in DESCRIBE response header. Updated device Url to: '%s'", mUrl.c_str() );
         break;
       }
@@ -461,9 +461,9 @@ void RtspThread::Run() {
   for ( size_t i = 0; i < lines.size(); i++ ) {
     if ( ( lines[i].size() > 8 ) && ( lines[i].substr(0, 8) == "Session:" ) ) {
       StringVector sessionLine = split(lines[i].substr(9), ";");
-      session = trimSpaces(sessionLine[0]);
+      session = TrimSpaces(sessionLine[0]);
       if ( sessionLine.size() == 2 )
-        sscanf(trimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
+        sscanf(TrimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
     }
     sscanf(lines[i].c_str(), "Transport: %s", transport);
   }
@@ -532,12 +532,12 @@ void RtspThread::Run() {
   std::string rtpInfo;
   for ( size_t i = 0; i < lines.size(); i++ ) {
     if ( ( lines[i].size() > 9 ) && ( lines[i].substr(0, 9) == "RTP-Info:" ) )
-      rtpInfo = trimSpaces(lines[i].substr(9));
+      rtpInfo = TrimSpaces(lines[i].substr(9));
     // Check for a timeout again. Some rtsp devices don't send a timeout until after the PLAY command is sent
     if ( ( lines[i].size() > 8 ) && ( lines[i].substr(0, 8) == "Session:" ) && ( timeout == 0 ) ) {
       StringVector sessionLine = split(lines[i].substr(9), ";");
       if ( sessionLine.size() == 2 )
-        sscanf(trimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
+        sscanf(TrimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
       if ( timeout > 0 )
         Debug(2, "Got timeout %d secs from PLAY command response", timeout);
     }

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -34,7 +34,7 @@ RtspThread::PortSet RtspThread::smAssignedPorts;
 
 bool RtspThread::sendCommand(std::string message) {
   if ( mNeedAuth ) {
-    StringVector parts = split(message, " ");
+    StringVector parts = Split(message, " ");
     if ( parts.size() > 1 )
       message += mAuthenticator->getAuthHeader(parts[0], parts[1]);
   }
@@ -172,7 +172,7 @@ RtspThread::RtspThread(
     mHttpSession = stringtf("%d", rand());
   
   mNeedAuth = false;
-  StringVector parts = split(auth, ":");
+  StringVector parts = Split(auth, ":");
   Debug(2, "# of auth parts %d", parts.size());
   if ( parts.size() > 1 ) 
     mAuthenticator = new zm::Authenticator(parts[0], parts[1]);
@@ -320,7 +320,7 @@ void RtspThread::Run() {
   } // end if failed response maybe due to auth
 
   char publicLine[256] = "";
-  StringVector lines = split(response, "\r\n");
+  StringVector lines = Split(response, "\r\n");
   for ( size_t i = 0; i < lines.size(); i++ )
     sscanf(lines[i].c_str(), "Public: %[^\r\n]\r\n", publicLine);
 
@@ -352,7 +352,7 @@ void RtspThread::Run() {
     std::string DescHeader = response.substr(0, sdpStart);
     Debug(1, "Processing DESCRIBE response header '%s'", DescHeader.c_str());
 
-    lines = split(DescHeader, "\r\n");
+    lines = Split(DescHeader, "\r\n");
     for ( size_t i = 0; i < lines.size(); i++ ) {
       // If the device sends us a url value for Content-Base in the response header, we should use that instead
       if ( ( lines[i].size() > 13 ) && ( lines[i].substr( 0, 13 ) == "Content-Base:" ) ) {
@@ -453,14 +453,14 @@ void RtspThread::Run() {
   if ( !recvResponse(response) )
     return;
 
-  lines = split(response, "\r\n");
+  lines = Split(response, "\r\n");
   std::string session;
   int timeout = 0;
   char transport[256] = "";
 
   for ( size_t i = 0; i < lines.size(); i++ ) {
     if ( ( lines[i].size() > 8 ) && ( lines[i].substr(0, 8) == "Session:" ) ) {
-      StringVector sessionLine = split(lines[i].substr(9), ";");
+      StringVector sessionLine = Split(lines[i].substr(9), ";");
       session = TrimSpaces(sessionLine[0]);
       if ( sessionLine.size() == 2 )
         sscanf(TrimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
@@ -483,33 +483,33 @@ void RtspThread::Run() {
   int remoteChannels[2] = { 0, 0 };
   std::string distribution = "";
   unsigned long ssrc = 0;
-  StringVector parts = split( transport, ";" );
+  StringVector parts = Split(transport, ";");
   for ( size_t i = 0; i < parts.size(); i++ ) {
     if ( parts[i] == "unicast" || parts[i] == "multicast" )
       distribution = parts[i];
     else if (StartsWith(parts[i], "server_port=") ) {
       method = "RTP/UNICAST";
-      StringVector subparts = split( parts[i], "=" );
-      StringVector ports = split( subparts[1], "-" );
+      StringVector subparts = Split(parts[i], "=");
+      StringVector ports = Split(subparts[1], "-");
       remotePorts[0] = strtol( ports[0].c_str(), nullptr, 10 );
       remotePorts[1] = strtol( ports[1].c_str(), nullptr, 10 );
     } else if (StartsWith(parts[i], "interleaved=") ) {
       method = "RTP/RTSP";
-      StringVector subparts = split( parts[i], "=" );
-      StringVector channels = split( subparts[1], "-" );
+      StringVector subparts = Split(parts[i], "=");
+      StringVector channels = Split(subparts[1], "-");
       remoteChannels[0] = strtol( channels[0].c_str(), nullptr, 10 );
       remoteChannels[1] = strtol( channels[1].c_str(), nullptr, 10 );
     } else if (StartsWith(parts[i], "port=") ) {
       method = "RTP/MULTICAST";
-      StringVector subparts = split( parts[i], "=" );
-      StringVector ports = split( subparts[1], "-" );
+      StringVector subparts = Split(parts[i], "=");
+      StringVector ports = Split(subparts[1], "-");
       localPorts[0] = strtol( ports[0].c_str(), nullptr, 10 );
       localPorts[1] = strtol( ports[1].c_str(), nullptr, 10 );
     } else if (StartsWith(parts[i], "destination=") ) {
-      StringVector subparts = split( parts[i], "=" );
+      StringVector subparts = Split(parts[i], "=");
       localHost = subparts[1];
     } else if (StartsWith(parts[i], "ssrc=") ) {
-      StringVector subparts = split( parts[i], "=" );
+      StringVector subparts = Split(parts[i], "=");
       ssrc = strtoll( subparts[1].c_str(), nullptr, 16 );
     }
   }
@@ -528,14 +528,14 @@ void RtspThread::Run() {
   if ( !recvResponse(response) )
     return;
 
-  lines = split(response, "\r\n");
+  lines = Split(response, "\r\n");
   std::string rtpInfo;
   for ( size_t i = 0; i < lines.size(); i++ ) {
     if ( ( lines[i].size() > 9 ) && ( lines[i].substr(0, 9) == "RTP-Info:" ) )
       rtpInfo = TrimSpaces(lines[i].substr(9));
     // Check for a timeout again. Some rtsp devices don't send a timeout until after the PLAY command is sent
     if ( ( lines[i].size() > 8 ) && ( lines[i].substr(0, 8) == "Session:" ) && ( timeout == 0 ) ) {
-      StringVector sessionLine = split(lines[i].substr(9), ";");
+      StringVector sessionLine = Split(lines[i].substr(9), ";");
       if ( sessionLine.size() == 2 )
         sscanf(TrimSpaces(sessionLine[1]).c_str(), "timeout=%d", &timeout);
       if ( timeout > 0 )
@@ -551,18 +551,18 @@ void RtspThread::Run() {
   } else {
     Debug( 2, "Got RTP Info %s", rtpInfo.c_str() );
     // More than one stream can be included in the RTP Info
-    streams = split( rtpInfo.c_str(), "," );
+    streams = Split(rtpInfo.c_str(), ",");
     for ( size_t i = 0; i < streams.size(); i++ ) {
       // We want the stream that matches the trackUrl we are using
       if ( streams[i].find(controlUrl.c_str()) != std::string::npos ) {
         // Parse the sequence and rtptime values
-        parts = split( streams[i].c_str(), ";" );
+        parts = Split(streams[i].c_str(), ";");
         for ( size_t j = 0; j < parts.size(); j++ ) {
           if (StartsWith(parts[j], "seq=") ) {
-            StringVector subparts = split( parts[j], "=" );
+            StringVector subparts = Split(parts[j], "=");
             seq = strtol( subparts[1].c_str(), nullptr, 10 );
           } else if (StartsWith(parts[j], "rtptime=") ) {
-            StringVector subparts = split( parts[j], "=" );
+            StringVector subparts = Split(parts[j], "=");
             rtpTime = strtol( subparts[1].c_str(), nullptr, 10 );
           }
         }

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -71,18 +71,18 @@ void Authenticator::authHandleHeader(std::string headerData) {
     StringVector subparts = split(headerData.substr(digest_match_len, headerData.length() - digest_match_len), ",");
     // subparts are key="value"
     for ( size_t i = 0; i < subparts.size(); i++ ) {
-      StringVector kvPair = split(trimSpaces(subparts[i]), "=");
-      std::string key = trimSpaces(kvPair[0]);
+      StringVector kvPair = split(TrimSpaces(subparts[i]), "=");
+      std::string key = TrimSpaces(kvPair[0]);
       if ( key == "realm" ) {
-        fRealm = trimSet(kvPair[1], "\"");
+        fRealm = Trim(kvPair[1], "\"");
         continue;
       }
       if ( key == "nonce" ) {
-        fNonce = trimSet(kvPair[1], "\"");
+        fNonce = Trim(kvPair[1], "\"");
         continue;
       }
       if ( key == "qop" ) {
-        fQop = trimSet(kvPair[1], "\"");
+        fQop = Trim(kvPair[1], "\"");
         continue;
       }
     }
@@ -211,7 +211,7 @@ void Authenticator::checkAuthResponse(std::string &response) {
   }
   if ( !authLine.empty() ) {
     Debug(2, "Analyze auth line %s", authLine.c_str());
-    authHandleHeader(trimSpaces(authLine.substr(authenticate_match_len, authLine.length()-authenticate_match_len)));
+    authHandleHeader(TrimSpaces(authLine.substr(authenticate_match_len, authLine.length() - authenticate_match_len)));
   } else {
     Debug(2, "Didn't find auth line in %s", authLine.c_str());
   }

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -92,7 +92,7 @@ void Authenticator::authHandleHeader(std::string headerData) {
 }  // end void Authenticator::authHandleHeader(std::string headerData)
 
 std::string Authenticator::quote( const std::string &src ) {
-  return replaceAll(replaceAll(src, "\\", "\\\\"), "\"", "\\\"");
+  return ReplaceAll(ReplaceAll(src, "\\", "\\\\"), "\"", "\\\"");
 }
 
 std::string Authenticator::getAuthHeader(std::string method, std::string uri) {

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -68,10 +68,10 @@ void Authenticator::authHandleHeader(std::string headerData) {
   else if ( strncasecmp(headerData.c_str(), digest_match, digest_match_len) == 0) {
     fAuthMethod = AUTH_DIGEST;
     Debug(2, "Set authMethod to Digest");
-    StringVector subparts = split(headerData.substr(digest_match_len, headerData.length() - digest_match_len), ",");
+    StringVector subparts = Split(headerData.substr(digest_match_len, headerData.length() - digest_match_len), ",");
     // subparts are key="value"
     for ( size_t i = 0; i < subparts.size(); i++ ) {
-      StringVector kvPair = split(TrimSpaces(subparts[i]), "=");
+      StringVector kvPair = Split(TrimSpaces(subparts[i]), "=");
       std::string key = TrimSpaces(kvPair[0]);
       if ( key == "realm" ) {
         fRealm = Trim(kvPair[1], "\"");
@@ -194,7 +194,7 @@ std::string Authenticator::computeDigestResponse(std::string &method, std::strin
 
 void Authenticator::checkAuthResponse(std::string &response) {
   std::string authLine;
-  StringVector lines = split(response, "\r\n");
+  StringVector lines = Split(response, "\r\n");
   const char* authenticate_match = "WWW-Authenticate:";
   size_t authenticate_match_len = strlen(authenticate_match);
 

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -98,7 +98,7 @@ std::string Authenticator::quote( const std::string &src ) {
 std::string Authenticator::getAuthHeader(std::string method, std::string uri) {
   std::string result = "Authorization: ";
   if ( fAuthMethod == AUTH_BASIC ) {
-    result += "Basic " + base64Encode(username() + ":" + password());
+    result += "Basic " + Base64Encode(username() + ":" + password());
   } else if ( fAuthMethod == AUTH_DIGEST ) {
     result += std::string("Digest ") + 
           "username=\"" + quote(username()) + "\", realm=\"" + quote(realm()) + "\", " +

--- a/src/zm_rtsp_server.cpp
+++ b/src/zm_rtsp_server.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
     exit(-1);
   }
 
-  hwcaps_detect();
+  HwCapsDetect();
 
   std::string where = "`Function` != 'None' AND `RTSPServer` != false";
   if (staticConfig.SERVER_ID)

--- a/src/zm_sdp.cpp
+++ b/src/zm_sdp.cpp
@@ -107,7 +107,7 @@ SessionDescriptor::ConnInfo::ConnInfo( const std::string &connInfo ) :
   mTtl( 16 ),
   mNoAddresses( 0 )
 {
-  StringVector tokens = split(connInfo, " ");
+  StringVector tokens = Split(connInfo, " ");
   if ( tokens.size() < 3 )
     throw Exception( "Unable to parse SDP connection info from '"+connInfo+"'" );
   mNetworkType = tokens[0];
@@ -116,7 +116,7 @@ SessionDescriptor::ConnInfo::ConnInfo( const std::string &connInfo ) :
   mAddressType = tokens[1];
   if ( mAddressType != "IP4" && mAddressType != "IP6" )
     throw Exception( "Invalid SDP address type '"+mAddressType+"' in connection info '"+connInfo+"'" );
-  StringVector addressTokens = split( tokens[2], "/" );
+  StringVector addressTokens = Split(tokens[2], "/");
   if ( addressTokens.size() < 1 ) 
     throw Exception( "Invalid SDP address '"+tokens[2]+"' in connection info '"+connInfo+"'" );
   mAddress = addressTokens[0];
@@ -129,7 +129,7 @@ SessionDescriptor::ConnInfo::ConnInfo( const std::string &connInfo ) :
 SessionDescriptor::BandInfo::BandInfo( const std::string &bandInfo ) :
   mValue( 0 )
 {
-  StringVector tokens = split( bandInfo, ":" );
+  StringVector tokens = Split(bandInfo, ":");
   if ( tokens.size() < 2 )
     throw Exception( "Unable to parse SDP bandwidth info from '"+bandInfo+"'" );
   mType = tokens[0];
@@ -165,7 +165,7 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
 {
   MediaDescriptor *currMedia = nullptr;
 
-  StringVector lines = split( sdp, "\r\n" );
+  StringVector lines = Split(sdp, "\r\n");
   for ( StringVector::const_iterator iter = lines.begin(); iter != lines.end(); ++iter ) {
     std::string line = *iter;
     if ( line.empty() )
@@ -208,7 +208,7 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
       case 'a' :
       {
         mAttributes.push_back( line );
-        StringVector tokens = split( line, ":", 2 );
+        StringVector tokens = Split(line, ":", 2);
         std::string attrName = tokens[0];
         if ( currMedia ) {
           if ( attrName == "control" ) {
@@ -220,14 +220,14 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
             // a=rtpmap:96 MP4V-ES/90000
             if ( tokens.size() < 2 )
               throw Exception( "Unable to parse SDP rtpmap attribute '"+line+"' for media '"+currMedia->getType()+"'" );
-            StringVector attrTokens = split( tokens[1], " " );
+            StringVector attrTokens = Split(tokens[1], " ");
             int payloadType = atoi(attrTokens[0].c_str());
             if ( payloadType != currMedia->getPayloadType() )
               throw Exception( stringtf( "Payload type mismatch, expected %d, got %d in '%s'", currMedia->getPayloadType(), payloadType, line.c_str() ) );
             std::string payloadDesc = attrTokens[1];
             //currMedia->setPayloadType( payloadType );
             if ( attrTokens.size() > 1 ) {
-              StringVector payloadTokens = split( attrTokens[1], "/" );
+              StringVector payloadTokens = Split(attrTokens[1], "/");
               std::string payloadDesc = payloadTokens[0];
               int payloadClock = atoi(payloadTokens[1].c_str());
               currMedia->setPayloadDesc( payloadDesc );
@@ -237,13 +237,13 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
             // a=framesize:96 320-240
             if ( tokens.size() < 2 )
               throw Exception("Unable to parse SDP framesize attribute '"+line+"' for media '"+currMedia->getType()+"'");
-            StringVector attrTokens = split(tokens[1], " ");
+            StringVector attrTokens = Split(tokens[1], " ");
             int payloadType = atoi(attrTokens[0].c_str());
             if ( payloadType != currMedia->getPayloadType() )
               throw Exception( stringtf("Payload type mismatch, expected %d, got %d in '%s'",
                     currMedia->getPayloadType(), payloadType, line.c_str()));
             //currMedia->setPayloadType( payloadType );
-            StringVector sizeTokens = split(attrTokens[1], "-");
+            StringVector sizeTokens = Split(attrTokens[1], "-");
             int width = atoi(sizeTokens[0].c_str());
             int height = atoi(sizeTokens[1].c_str());
             currMedia->setFrameSize(width, height);
@@ -257,16 +257,16 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
             // a=fmtp:96 profile-level-id=247; config=000001B0F7000001B509000001000000012008D48D8803250F042D14440F
             if ( tokens.size() < 2 )
               throw Exception("Unable to parse SDP fmtp attribute '"+line+"' for media '"+currMedia->getType()+"'");
-            StringVector attrTokens = split(tokens[1], " ", 2);
+            StringVector attrTokens = Split(tokens[1], " ", 2);
             int payloadType = atoi(attrTokens[0].c_str());
             if ( payloadType != currMedia->getPayloadType() )
               throw Exception(stringtf("Payload type mismatch, expected %d, got %d in '%s'",
                     currMedia->getPayloadType(), payloadType, line.c_str()));
             //currMedia->setPayloadType( payloadType );
             if ( attrTokens.size() > 1 ) {
-              StringVector attr2Tokens = split( attrTokens[1], "; " );
+              StringVector attr2Tokens = Split(attrTokens[1], "; ");
               for ( unsigned int i = 0; i < attr2Tokens.size(); i++ ) {
-                StringVector attr3Tokens = split( attr2Tokens[i], "=" );
+                StringVector attr3Tokens = Split(attr2Tokens[i], "=");
                 //Info( "Name = %s, Value = %s", attr3Tokens[0].c_str(), attr3Tokens[1].c_str() );
                 if ( attr3Tokens[0] == "profile-level-id" ) {
                 } else if ( attr3Tokens[0] == "config" ) {
@@ -294,13 +294,13 @@ SessionDescriptor::SessionDescriptor( const std::string &url, const std::string 
       }
       case 'm' :
       {
-        StringVector tokens = split(line, " ");
+        StringVector tokens = Split(line, " ");
         if ( tokens.size() < 4 )
           throw Exception("Can't parse SDP media description '"+line+"'");
         std::string mediaType = tokens[0];
         if ( mediaType != "audio" && mediaType != "video"  && mediaType != "application" )
           throw Exception("Unsupported media type '"+mediaType+"' in SDP media attribute '"+line+"'");
-        StringVector portTokens = split(tokens[1], "/");
+        StringVector portTokens = Split(tokens[1], "/");
         int mediaPort = atoi(portTokens[0].c_str());
         int mediaNumPorts = 1;
         if ( portTokens.size() > 1 )

--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -54,7 +54,7 @@ User::User(const MYSQL_ROW &dbrow) {
   system = (Permission)atoi(dbrow[index++]);
   char *monitor_ids_str = dbrow[index++];
   if ( monitor_ids_str && *monitor_ids_str ) {
-    StringVector ids = split(monitor_ids_str, ",");
+    StringVector ids = Split(monitor_ids_str, ",");
     for ( StringVector::iterator i = ids.begin(); i < ids.end(); ++i ) {
       monitor_ids.push_back(atoi((*i).c_str()));
     }

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -50,13 +50,13 @@ std::string Trim(const std::string &str, const std::string &char_set) {
   return str.substr(start_pos, end_pos - start_pos + 1);
 }
 
-std::string replaceAll(std::string str, std::string from, std::string to) {
-  if ( from.empty() )
+std::string ReplaceAll(std::string str, const std::string &old_value, const std::string &new_value) {
+  if (old_value.empty())
     return str;
   size_t start_pos = 0;
-  while ( (start_pos = str.find(from, start_pos)) != std::string::npos ) {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+  while ((start_pos = str.find(old_value, start_pos)) != std::string::npos) {
+    str.replace(start_pos, old_value.length(), new_value);
+    start_pos += new_value.length(); // In case 'new_value' contains 'old_value', like replacing 'x' with 'yx'
   }
   return str;
 }

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -31,10 +31,6 @@
 #include <sys/auxv.h>
 #endif
 
-#ifdef HAVE_CURL_CURL_H
-#include <curl/curl.h>
-#endif
-
 unsigned int sse_version = 0;
 unsigned int neonversion = 0;
 

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -61,10 +61,6 @@ std::string ReplaceAll(std::string str, const std::string &old_value, const std:
   return str;
 }
 
-bool startsWith(const std::string &haystack, const std::string &needle) {
-  return ( haystack.substr(0, needle.length()) == needle );
-}
-
 std::vector<std::string> split(const std::string &s, char delim) {
   std::vector<std::string> elems;
   std::stringstream ss(s);

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -39,19 +39,15 @@
 unsigned int sse_version = 0;
 unsigned int neonversion = 0;
 
-std::string trimSet(std::string str, std::string trimset) {
-  // Trim Both leading and trailing sets
-  size_t startpos = str.find_first_not_of(trimset); // Find the first character position after excluding leading blank spaces
-  size_t endpos = str.find_last_not_of(trimset); // Find the first character position from reverse af
+// Trim Both leading and trailing sets
+std::string Trim(const std::string &str, const std::string &char_set) {
+  size_t start_pos = str.find_first_not_of(char_set);
+  size_t end_pos = str.find_last_not_of(char_set);
 
   // if all spaces or empty return an empty string
-  if ( ( std::string::npos == startpos ) || ( std::string::npos == endpos ) )
-    return std::string("");
-  return str.substr(startpos, endpos-startpos+1);
-}
-
-std::string trimSpaces(const std::string &str) {
-  return trimSet(str, " \t");
+  if ((start_pos == std::string::npos) || (end_pos == std::string::npos))
+    return "";
+  return str.substr(start_pos, end_pos - start_pos + 1);
 }
 
 std::string replaceAll(std::string str, std::string from, std::string to) {
@@ -74,7 +70,7 @@ std::vector<std::string> split(const std::string &s, char delim) {
   std::stringstream ss(s);
   std::string item;
   while(std::getline(ss, item, delim)) {
-    elems.push_back(trimSpaces(item));
+    elems.push_back(TrimSpaces(item));
   }
   return elems;
 }

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -21,7 +21,6 @@
 
 #include "zm_config.h"
 #include "zm_logger.h"
-#include <algorithm>
 #include <array>
 #include <cstring>
 #include <fcntl.h> /* Definition of AT_* constants */
@@ -121,36 +120,36 @@ std::string Join(const StringVector &values, const std::string &delim) {
   return ss.str();
 }
 
-const std::string base64Encode(const std::string &inString) {
-  static char base64_table[64] = { '\0' };
+std::string Base64Encode(const std::string &str) {
+  static char base64_table[64] = {'\0'};
 
-  if ( !base64_table[0] ) {
+  if (!base64_table[0]) {
     int i = 0;
-    for ( char c = 'A'; c <= 'Z'; c++ )
+    for (char c = 'A'; c <= 'Z'; c++)
       base64_table[i++] = c;
-    for ( char c = 'a'; c <= 'z'; c++ )
+    for (char c = 'a'; c <= 'z'; c++)
       base64_table[i++] = c;
-    for ( char c = '0'; c <= '9'; c++ )
+    for (char c = '0'; c <= '9'; c++)
       base64_table[i++] = c;
     base64_table[i++] = '+';
     base64_table[i++] = '/';
   }
 
   std::string outString;
-  outString.reserve(2 * inString.size());
+  outString.reserve(2 * str.size());
 
-  const char *inPtr = inString.c_str();
-  while ( *inPtr ) {
+  const char *inPtr = str.c_str();
+  while (*inPtr) {
     unsigned char selection = *inPtr >> 2;
     unsigned char remainder = (*inPtr++ & 0x03) << 4;
     outString += base64_table[selection];
 
-    if ( *inPtr ) {
+    if (*inPtr) {
       selection = remainder | (*inPtr >> 4);
       remainder = (*inPtr++ & 0x0f) << 2;
       outString += base64_table[selection];
 
-      if ( *inPtr ) {
+      if (*inPtr) {
         selection = remainder | (*inPtr >> 6);
         outString += base64_table[selection];
         selection = (*inPtr++ & 0x3f);
@@ -331,10 +330,6 @@ std::string UriDecode( const std::string &encoded ) {
     }
   }
   return retbuf;
-}
-
-void string_toupper( std::string& str) {
-  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 }
 
 void touch(const char *pathname) {

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -61,53 +61,62 @@ std::string ReplaceAll(std::string str, const std::string &old_value, const std:
   return str;
 }
 
-std::vector<std::string> split(const std::string &s, char delim) {
-  std::vector<std::string> elems;
-  std::stringstream ss(s);
-  std::string item;
-  while(std::getline(ss, item, delim)) {
-    elems.push_back(TrimSpaces(item));
+StringVector Split(const std::string &str, char delim) {
+  std::vector<std::string> tokens;
+
+  size_t start = 0;
+  for (size_t end = str.find(delim); end != std::string::npos; end = str.find(delim, start)) {
+    tokens.push_back(str.substr(start, end - start));
+    start = end + 1;
   }
-  return elems;
+
+  tokens.push_back(str.substr(start));
+
+  return tokens;
 }
 
-StringVector split(const std::string &string, const std::string &chars, int limit) {
-  StringVector stringVector;
-  std::string tempString = string;
-  std::string::size_type startIndex = 0;
-  std::string::size_type endIndex = 0;
+StringVector Split(const std::string &str, const std::string &delim, size_t limit) {
+  StringVector tokens;
+  size_t start = 0;
 
-  //Info( "Looking for '%s' in '%s', limit %d", chars.c_str(), string.c_str(), limit );
   do {
-    // Find delimiters
-    endIndex = string.find_first_of( chars, startIndex );
-    //Info( "Got endIndex at %d", endIndex );
-    if ( endIndex > 0 ) {
-      //Info( "Adding '%s'", string.substr( startIndex, endIndex-startIndex ).c_str() );
-      stringVector.push_back( string.substr( startIndex, endIndex-startIndex ) );
+    size_t end = str.find_first_of(delim, start);
+    if (end > 0) {
+      tokens.push_back(str.substr(start, end - start));
     }
-    if ( endIndex == std::string::npos )
+    if (end == std::string::npos) {
       break;
+    }
     // Find non-delimiters
-    startIndex = tempString.find_first_not_of( chars, endIndex );
-    if ( limit && (stringVector.size() == (unsigned int)(limit-1)) ) {
-      stringVector.push_back( string.substr( startIndex ) );
+    start = str.find_first_not_of(delim, end);
+    if (limit && (tokens.size() == limit - 1)) {
+      tokens.push_back(str.substr(start));
       break;
     }
-    //Info( "Got new startIndex at %d", startIndex );
-  } while ( startIndex != std::string::npos );
-  //Info( "Finished with %d strings", stringVector.size() );
+  } while (start != std::string::npos);
 
-  return stringVector;
+  return tokens;
 }
 
-const std::string join(const StringVector &v, const char * delim=",") {
+std::pair<std::string, std::string> PairSplit(const std::string &str, char delim) {
+  if (str.empty())
+    return std::make_pair("", "");
+
+  size_t pos = str.find(delim);
+
+  if (pos == std::string::npos)
+    return std::make_pair("", "");
+
+  return std::make_pair(str.substr(0, pos), str.substr(pos + 1, std::string::npos));
+}
+
+std::string Join(const StringVector &values, const std::string &delim) {
   std::stringstream ss;
 
-  for (size_t i = 0; i < v.size(); ++i) {
+  for (size_t i = 0; i < values.size(); ++i) {
     if ( i != 0 )
       ss << delim;
-    ss << v[i];
+    ss << values[i];
   }
   return ss.str();
 }
@@ -157,46 +166,6 @@ const std::string base64Encode(const std::string &inString) {
     }
   }
   return outString;
-}
-
-int split(const char* string, const char delim, std::vector<std::string>& items) {
-  if ( string == nullptr )
-    return -1;
-
-  if ( string[0] == 0 )
-    return -2;
-
-  std::string str(string);
-
-  while ( true ) {
-    size_t pos = str.find(delim);
-    items.push_back(str.substr(0, pos));
-    str.erase(0, pos+1);
-
-    if ( pos == std::string::npos )
-      break;
-  }
-
-  return items.size();
-}
-
-int pairsplit(const char* string, const char delim, std::string& name, std::string& value) {
-  if ( string == nullptr )
-    return -1;
-
-  if ( string[0] == 0 )
-    return -2;
-
-  std::string str(string);
-  size_t pos = str.find(delim);
-
-  if ( pos == std::string::npos || pos == 0 || pos >= str.length() )
-    return -3;
-
-  name = str.substr(0, pos);
-  value = str.substr(pos+1, std::string::npos);
-
-  return 0;
 }
 
 /* Detect special hardware features, such as SIMD instruction sets */

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -31,8 +31,9 @@
 
 typedef std::vector<std::string> StringVector;
 
-std::string trimSpaces(const std::string &str);
-std::string trimSet(std::string str, std::string trimset);
+std::string Trim(const std::string &str, const std::string &char_set);
+inline std::string TrimSpaces(const std::string &str) { return Trim(str, " \t"); }
+
 std::string replaceAll(std::string str, std::string from, std::string to);
 
 template<typename... Args>

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -60,16 +60,15 @@ std::string stringtf(const std::string &format, Args... args) {
 
 std::string Base64Encode(const std::string &str);
 
-void* sse2_aligned_memcpy(void* dest, const void* src, size_t bytes);
-void timespec_diff(struct timespec *start, struct timespec *end, struct timespec *diff);
+void TimespecDiff(timespec *start, timespec *end, timespec *diff);
+std::string TimevalToString(timeval tv);
 
-void hwcaps_detect();
 extern unsigned int sse_version;
 extern unsigned int neonversion;
+void HwCapsDetect();
+void *sse2_aligned_memcpy(void *dest, const void *src, size_t bytes);
 
-std::string TimevalToString(timeval tv);
-std::string UriDecode( const std::string &encoded );
-void touch( const char *pathname );
+void touch(const char *pathname);
 
 namespace ZM {
 //! std::make_unique implementation (TODO: remove this once C++14 is supported)
@@ -99,39 +98,41 @@ typedef std::chrono::hours Hours;
 typedef std::chrono::steady_clock::time_point TimePoint;
 typedef std::chrono::system_clock::time_point SystemTimePoint;
 
+std::string UriDecode(const std::string &encoded);
+
 class QueryParameter {
-  public:
-    const std::string &name() const { return name_; }
-    const std::string &firstValue() const { return values_[0]; }
+ public:
+  explicit QueryParameter(std::string name) : name_(std::move(name)) {}
 
-    const std::vector<std::string> &values() const { return values_; }
-    size_t size() const { return values_.size(); }
+  const std::string &name() const { return name_; }
+  const std::string &firstValue() const { return values_[0]; }
 
-    QueryParameter(std::string name) : name_(std::move(name)) { }
+  const std::vector<std::string> &values() const { return values_; }
+  size_t size() const { return values_.size(); }
 
-    template<class T> void addValue(T&& value) { values_.emplace_back(std::forward<T>(value)); }
-  private:
-    std::string name_;
-    std::vector<std::string> values_;
+  template<class T>
+  void addValue(T &&value) { values_.emplace_back(std::forward<T>(value)); }
+ private:
+  std::string name_;
+  std::vector<std::string> values_;
 };
 
 class QueryString {
-  public:
-    QueryString(std::istream &input);
+ public:
+  explicit QueryString(std::istream &input);
 
-    size_t size() const { return parameters_.size(); }
-    bool has(const char *name) const { return parameters_.find(std::string(name)) != parameters_.end(); }
+  size_t size() const { return parameters_.size(); }
+  bool has(const char *name) const { return parameters_.find(std::string(name)) != parameters_.end(); }
 
-    std::vector<std::string> names() const;
+  std::vector<std::string> names() const;
 
-    const QueryParameter *get(const std::string &name) const;
-    const QueryParameter *get(const char* name) const { return get(std::string(name)); };
+  const QueryParameter *get(const std::string &name) const;
+  const QueryParameter *get(const char *name) const { return get(std::string(name)); };
 
-  private:
+ private:
+  static std::string parseName(std::istream &input);
+  static std::string parseValue(std::istream &input);
 
-    static std::string parseName(std::istream &input);
-    static std::string parseValue(std::istream &input);
-
-    std::map<std::string, std::unique_ptr<QueryParameter>> parameters_;
+  std::map<std::string, std::unique_ptr<QueryParameter>> parameters_;
 };
 #endif // ZM_UTILS_H

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -35,6 +35,10 @@ std::string Trim(const std::string &str, const std::string &char_set);
 inline std::string TrimSpaces(const std::string &str) { return Trim(str, " \t"); }
 std::string ReplaceAll(std::string str, const std::string& old_value, const std::string& new_value);
 
+inline bool StartsWith(const std::string &haystack, const std::string &needle) {
+  return (haystack.substr(0, needle.length()) == needle);
+}
+
 template<typename... Args>
 std::string stringtf(const std::string &format, Args... args) {
   int size = snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
@@ -46,7 +50,6 @@ std::string stringtf(const std::string &format, Args... args) {
   return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
 
-bool startsWith( const std::string &haystack, const std::string &needle );
 StringVector split( const std::string &string, const std::string &chars, int limit=0 );
 const std::string join( const StringVector &, const char * );
 

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -20,6 +20,7 @@
 #ifndef ZM_UTILS_H
 #define ZM_UTILS_H
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <map>
@@ -34,6 +35,7 @@ typedef std::vector<std::string> StringVector;
 std::string Trim(const std::string &str, const std::string &char_set);
 inline std::string TrimSpaces(const std::string &str) { return Trim(str, " \t"); }
 std::string ReplaceAll(std::string str, const std::string& old_value, const std::string& new_value);
+inline void StringToUpper(std::string &str) { std::transform(str.begin(), str.end(), str.begin(), ::toupper); }
 
 StringVector Split(const std::string &str, char delim);
 StringVector Split(const std::string &str, const std::string &delim, size_t limit = 0);
@@ -56,8 +58,7 @@ std::string stringtf(const std::string &format, Args... args) {
   return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
 
-const std::string base64Encode( const std::string &inString );
-void string_toupper(std::string& str);
+std::string Base64Encode(const std::string &str);
 
 void* sse2_aligned_memcpy(void* dest, const void* src, size_t bytes);
 void timespec_diff(struct timespec *start, struct timespec *end, struct timespec *diff);

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -35,6 +35,12 @@ std::string Trim(const std::string &str, const std::string &char_set);
 inline std::string TrimSpaces(const std::string &str) { return Trim(str, " \t"); }
 std::string ReplaceAll(std::string str, const std::string& old_value, const std::string& new_value);
 
+StringVector Split(const std::string &str, char delim);
+StringVector Split(const std::string &str, const std::string &delim, size_t limit = 0);
+std::pair<std::string, std::string> PairSplit(const std::string &str, char delim);
+
+std::string Join(const StringVector &values, const std::string &delim = ",");
+
 inline bool StartsWith(const std::string &haystack, const std::string &needle) {
   return (haystack.substr(0, needle.length()) == needle);
 }
@@ -50,14 +56,8 @@ std::string stringtf(const std::string &format, Args... args) {
   return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
 
-StringVector split( const std::string &string, const std::string &chars, int limit=0 );
-const std::string join( const StringVector &, const char * );
-
 const std::string base64Encode( const std::string &inString );
 void string_toupper(std::string& str);
-
-int split(const char* string, const char delim, std::vector<std::string>& items);
-int pairsplit(const char* string, const char delim, std::string& name, std::string& value);
 
 void* sse2_aligned_memcpy(void* dest, const void* src, size_t bytes);
 void timespec_diff(struct timespec *start, struct timespec *end, struct timespec *diff);

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -33,8 +33,7 @@ typedef std::vector<std::string> StringVector;
 
 std::string Trim(const std::string &str, const std::string &char_set);
 inline std::string TrimSpaces(const std::string &str) { return Trim(str, " \t"); }
-
-std::string replaceAll(std::string str, std::string from, std::string to);
+std::string ReplaceAll(std::string str, const std::string& old_value, const std::string& new_value);
 
 template<typename... Args>
 std::string stringtf(const std::string &format, Args... args) {

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
   zmLoadDBConfig();
   logInit(log_id_string);
 
-  hwcaps_detect();
+  HwCapsDetect();
 
   std::vector<std::shared_ptr<Monitor>> monitors;
 #if ZM_HAS_V4L

--- a/src/zms.cpp
+++ b/src/zms.cpp
@@ -229,7 +229,7 @@ int main(int argc, const char *argv[], char **envp) {
     user = nullptr;
   }  // end if config.opt_use_auth
 
-  hwcaps_detect();
+  HwCapsDetect();
   zmSetDefaultTermHandler();
   zmSetDefaultDieHandler();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 include(Catch)
 
 set(TEST_SOURCES
-  zm_crypt.cpp)
+  zm_crypt.cpp
+  zm_utils.cpp)
 
 add_executable(tests main.cpp ${TEST_SOURCES})
 

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -71,3 +71,20 @@ TEST_CASE("startsWith") {
   REQUIRE(startsWith("test=abc", "test") == true);
   REQUIRE(startsWith(" test=abc", "test") == false);
 }
+
+TEST_CASE("split (char delimiter)") {
+  std::vector<std::string> items;
+  int res;
+
+  res = split(nullptr, ' ', items);
+  REQUIRE(res == -1);
+  REQUIRE(items.size() == 0);
+
+  res = split("", ' ', items);
+  REQUIRE(res == -2);
+  REQUIRE(items.size() == 0);
+
+  res = split("abc def ghi", ' ', items);
+  REQUIRE(res == 3);
+  REQUIRE(items == std::vector<std::string>{"abc", "def", "ghi"});
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -88,3 +88,49 @@ TEST_CASE("split (char delimiter)") {
   REQUIRE(res == 3);
   REQUIRE(items == std::vector<std::string>{"abc", "def", "ghi"});
 }
+
+TEST_CASE("split (string delimiter)") {
+  std::vector<std::string> items;
+
+  items = split("", "");
+  REQUIRE(items == std::vector<std::string>{""});
+
+  items = split("", " ");
+  REQUIRE(items == std::vector<std::string>{""});
+
+  items = split("", " \t");
+  REQUIRE(items == std::vector<std::string>{""});
+
+  items = split("", " \t");
+  REQUIRE(items == std::vector<std::string>{""});
+
+  items = split(" ", " ");
+  REQUIRE(items.size() == 0);
+
+  items = split("  ", " ");
+  REQUIRE(items.size() == 0);
+
+  items = split(" ", " \t");
+  REQUIRE(items.size() == 0);
+
+  items = split("a b", "");
+  REQUIRE(items == std::vector<std::string>{"a b"});
+
+  items = split("a b", " ");
+  REQUIRE(items == std::vector<std::string>{"a", "b"});
+
+  items = split("a \tb", " \t");
+  REQUIRE(items == std::vector<std::string>{"a", "b"});
+
+  items = split(" a \tb ", " \t");
+  REQUIRE(items == std::vector<std::string>{"a", "b"});
+
+  items = split(" a=b ", "=");
+  REQUIRE(items == std::vector<std::string>{" a", "b "});
+
+  items = split(" a=b ", " =");
+  REQUIRE(items == std::vector<std::string>{"a", "b"});
+
+  items = split("a b c", " ", 2);
+  REQUIRE(items == std::vector<std::string>{"a", "b c"});
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "catch2/catch.hpp"
+
+#include "zm_utils.h"
+
+TEST_CASE("trimSet") {
+  REQUIRE(trimSet("", "") == "");
+  REQUIRE(trimSet("test", "") == "test");
+  REQUIRE(trimSet(" ", "") == " ");
+
+  REQUIRE(trimSet("\"test", "\"") == "test");
+  REQUIRE(trimSet("test\"", "\"") == "test");
+  REQUIRE(trimSet("\"test\"", "\"") == "test");
+
+  REQUIRE(trimSet("te\"st", "\"") == "te\"st");
+  REQUIRE(trimSet("\"te\"st\"", "\"") == "te\"st");
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -154,3 +154,8 @@ TEST_CASE("base64Encode") {
   REQUIRE(base64Encode("fooba") == "Zm9vYmE=");
   REQUIRE(base64Encode("foobar") == "Zm9vYmFy");
 }
+
+TEST_CASE("UriDecode") {
+  REQUIRE(UriDecode("abcABC123-_.~%21%28%29%26%3d%20") == "abcABC123-_.~!()&= ");
+  REQUIRE(UriDecode("abcABC123-_.~%21%28%29%26%3d+") == "abcABC123-_.~!()&= ");
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -49,3 +49,17 @@ TEST_CASE("trimSpaces") {
 
   REQUIRE(trimSpaces("\t te st \t") == "te st");
 }
+
+TEST_CASE("replaceAll") {
+  REQUIRE(replaceAll("", "", "") == "");
+
+  REQUIRE(replaceAll("a", "", "b") == "a");
+  REQUIRE(replaceAll("a", "a", "b") == "b");
+  REQUIRE(replaceAll("a", "b", "c") == "a");
+
+  REQUIRE(replaceAll("aa", "a", "b") == "bb");
+  REQUIRE(replaceAll("aba", "a", "c") == "cbc");
+
+  REQUIRE(replaceAll("aTOKENa", "TOKEN", "VAL") == "aVALa");
+  REQUIRE(replaceAll("aTOKENaTOKEN", "TOKEN", "VAL") == "aVALaVAL");
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -73,77 +73,71 @@ TEST_CASE("StartsWith") {
   REQUIRE(StartsWith(" test=abc", "test") == false);
 }
 
-TEST_CASE("split (char delimiter)") {
-  std::vector<std::string> items;
-  int res;
+TEST_CASE("Split (char delimiter)") {
+  std::vector<std::string> items = Split("", ' ');
+  REQUIRE(items == std::vector<std::string>{""});
 
-  res = split(nullptr, ' ', items);
-  REQUIRE(res == -1);
-  REQUIRE(items.size() == 0);
-
-  res = split("", ' ', items);
-  REQUIRE(res == -2);
-  REQUIRE(items.size() == 0);
-
-  res = split("abc def ghi", ' ', items);
-  REQUIRE(res == 3);
+  items = Split("abc def ghi", ' ');
   REQUIRE(items == std::vector<std::string>{"abc", "def", "ghi"});
+
+  items = Split("abc,def,,ghi", ',');
+  REQUIRE(items == std::vector<std::string>{"abc", "def", "", "ghi"});
 }
 
-TEST_CASE("split (string delimiter)") {
+TEST_CASE("Split (string delimiter)") {
   std::vector<std::string> items;
 
-  items = split("", "");
+  items = Split("", "");
   REQUIRE(items == std::vector<std::string>{""});
 
-  items = split("", " ");
+  items = Split("", " ");
   REQUIRE(items == std::vector<std::string>{""});
 
-  items = split("", " \t");
+  items = Split("", " \t");
   REQUIRE(items == std::vector<std::string>{""});
 
-  items = split("", " \t");
+  items = Split("", " \t");
   REQUIRE(items == std::vector<std::string>{""});
 
-  items = split(" ", " ");
+  items = Split(" ", " ");
   REQUIRE(items.size() == 0);
 
-  items = split("  ", " ");
+  items = Split("  ", " ");
   REQUIRE(items.size() == 0);
 
-  items = split(" ", " \t");
+  items = Split(" ", " \t");
   REQUIRE(items.size() == 0);
 
-  items = split("a b", "");
+  items = Split("a b", "");
   REQUIRE(items == std::vector<std::string>{"a b"});
 
-  items = split("a b", " ");
+  items = Split("a b", " ");
   REQUIRE(items == std::vector<std::string>{"a", "b"});
 
-  items = split("a \tb", " \t");
+  items = Split("a \tb", " \t");
   REQUIRE(items == std::vector<std::string>{"a", "b"});
 
-  items = split(" a \tb ", " \t");
+  items = Split(" a \tb ", " \t");
   REQUIRE(items == std::vector<std::string>{"a", "b"});
 
-  items = split(" a=b ", "=");
+  items = Split(" a=b ", "=");
   REQUIRE(items == std::vector<std::string>{" a", "b "});
 
-  items = split(" a=b ", " =");
+  items = Split(" a=b ", " =");
   REQUIRE(items == std::vector<std::string>{"a", "b"});
 
-  items = split("a b c", " ", 2);
+  items = Split("a b c", " ", 2);
   REQUIRE(items == std::vector<std::string>{"a", "b c"});
 }
 
-TEST_CASE("join") {
-  REQUIRE(join({}, "") == "");
-  REQUIRE(join({}, " ") == "");
-  REQUIRE(join({""}, "") == "");
-  REQUIRE(join({"a"}, "") == "a");
-  REQUIRE(join({"a"}, ",") == "a");
-  REQUIRE(join({"a", "b"}, ",") == "a,b");
-  REQUIRE(join({"a", "b"}, "") == "ab");
+TEST_CASE("Join") {
+  REQUIRE(Join({}, "") == "");
+  REQUIRE(Join({}, " ") == "");
+  REQUIRE(Join({""}, "") == "");
+  REQUIRE(Join({"a"}, "") == "a");
+  REQUIRE(Join({"a"}, ",") == "a");
+  REQUIRE(Join({"a", "b"}, ",") == "a,b");
+  REQUIRE(Join({"a", "b"}, "") == "ab");
 }
 
 TEST_CASE("base64Encode") {

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -144,3 +144,13 @@ TEST_CASE("join") {
   REQUIRE(join({"a", "b"}, ",") == "a,b");
   REQUIRE(join({"a", "b"}, "") == "ab");
 }
+
+TEST_CASE("base64Encode") {
+  REQUIRE(base64Encode("") == "");
+  REQUIRE(base64Encode("f") == "Zg==");
+  REQUIRE(base64Encode("fo") == "Zm8=");
+  REQUIRE(base64Encode("foo") == "Zm9v");
+  REQUIRE(base64Encode("foob") == "Zm9vYg==");
+  REQUIRE(base64Encode("fooba") == "Zm9vYmE=");
+  REQUIRE(base64Encode("foobar") == "Zm9vYmFy");
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -140,14 +140,14 @@ TEST_CASE("Join") {
   REQUIRE(Join({"a", "b"}, "") == "ab");
 }
 
-TEST_CASE("base64Encode") {
-  REQUIRE(base64Encode("") == "");
-  REQUIRE(base64Encode("f") == "Zg==");
-  REQUIRE(base64Encode("fo") == "Zm8=");
-  REQUIRE(base64Encode("foo") == "Zm9v");
-  REQUIRE(base64Encode("foob") == "Zm9vYg==");
-  REQUIRE(base64Encode("fooba") == "Zm9vYmE=");
-  REQUIRE(base64Encode("foobar") == "Zm9vYmFy");
+TEST_CASE("Base64Encode") {
+  REQUIRE(Base64Encode("") == "");
+  REQUIRE(Base64Encode("f") == "Zg==");
+  REQUIRE(Base64Encode("fo") == "Zm8=");
+  REQUIRE(Base64Encode("foo") == "Zm9v");
+  REQUIRE(Base64Encode("foob") == "Zm9vYg==");
+  REQUIRE(Base64Encode("fooba") == "Zm9vYmE=");
+  REQUIRE(Base64Encode("foobar") == "Zm9vYmFy");
 }
 
 TEST_CASE("UriDecode") {

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -51,18 +51,18 @@ TEST_CASE("TrimSpaces") {
   REQUIRE(TrimSpaces("\t te st \t") == "te st");
 }
 
-TEST_CASE("replaceAll") {
-  REQUIRE(replaceAll("", "", "") == "");
+TEST_CASE("ReplaceAll") {
+  REQUIRE(ReplaceAll("", "", "") == "");
 
-  REQUIRE(replaceAll("a", "", "b") == "a");
-  REQUIRE(replaceAll("a", "a", "b") == "b");
-  REQUIRE(replaceAll("a", "b", "c") == "a");
+  REQUIRE(ReplaceAll("a", "", "b") == "a");
+  REQUIRE(ReplaceAll("a", "a", "b") == "b");
+  REQUIRE(ReplaceAll("a", "b", "c") == "a");
 
-  REQUIRE(replaceAll("aa", "a", "b") == "bb");
-  REQUIRE(replaceAll("aba", "a", "c") == "cbc");
+  REQUIRE(ReplaceAll("aa", "a", "b") == "bb");
+  REQUIRE(ReplaceAll("aba", "a", "c") == "cbc");
 
-  REQUIRE(replaceAll("aTOKENa", "TOKEN", "VAL") == "aVALa");
-  REQUIRE(replaceAll("aTOKENaTOKEN", "TOKEN", "VAL") == "aVALaVAL");
+  REQUIRE(ReplaceAll("aTOKENa", "TOKEN", "VAL") == "aVALa");
+  REQUIRE(ReplaceAll("aTOKENaTOKEN", "TOKEN", "VAL") == "aVALaVAL");
 }
 
 TEST_CASE("startsWith") {

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -134,3 +134,13 @@ TEST_CASE("split (string delimiter)") {
   items = split("a b c", " ", 2);
   REQUIRE(items == std::vector<std::string>{"a", "b c"});
 }
+
+TEST_CASE("join") {
+  REQUIRE(join({}, "") == "");
+  REQUIRE(join({}, " ") == "");
+  REQUIRE(join({""}, "") == "");
+  REQUIRE(join({"a"}, "") == "a");
+  REQUIRE(join({"a"}, ",") == "a");
+  REQUIRE(join({"a", "b"}, ",") == "a,b");
+  REQUIRE(join({"a", "b"}, "") == "ab");
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -65,12 +65,12 @@ TEST_CASE("ReplaceAll") {
   REQUIRE(ReplaceAll("aTOKENaTOKEN", "TOKEN", "VAL") == "aVALaVAL");
 }
 
-TEST_CASE("startsWith") {
-  REQUIRE(startsWith("", "") == true);
+TEST_CASE("StartsWith") {
+  REQUIRE(StartsWith("", "") == true);
 
-  REQUIRE(startsWith("test", "test") == true);
-  REQUIRE(startsWith("test=abc", "test") == true);
-  REQUIRE(startsWith(" test=abc", "test") == false);
+  REQUIRE(StartsWith("test", "test") == true);
+  REQUIRE(StartsWith("test=abc", "test") == true);
+  REQUIRE(StartsWith(" test=abc", "test") == false);
 }
 
 TEST_CASE("split (char delimiter)") {

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -20,35 +20,35 @@
 #include "zm_utils.h"
 #include <sstream>
 
-TEST_CASE("trimSet") {
-  REQUIRE(trimSet("", "") == "");
-  REQUIRE(trimSet("test", "") == "test");
-  REQUIRE(trimSet(" ", "") == " ");
+TEST_CASE("Trim") {
+  REQUIRE(Trim("", "") == "");
+  REQUIRE(Trim("test", "") == "test");
+  REQUIRE(Trim(" ", "") == " ");
 
-  REQUIRE(trimSet("\"test", "\"") == "test");
-  REQUIRE(trimSet("test\"", "\"") == "test");
-  REQUIRE(trimSet("\"test\"", "\"") == "test");
+  REQUIRE(Trim("\"test", "\"") == "test");
+  REQUIRE(Trim("test\"", "\"") == "test");
+  REQUIRE(Trim("\"test\"", "\"") == "test");
 
-  REQUIRE(trimSet("te\"st", "\"") == "te\"st");
-  REQUIRE(trimSet("\"te\"st\"", "\"") == "te\"st");
+  REQUIRE(Trim("te\"st", "\"") == "te\"st");
+  REQUIRE(Trim("\"te\"st\"", "\"") == "te\"st");
 }
 
-TEST_CASE("trimSpaces") {
-  REQUIRE(trimSpaces(" ") == "");
+TEST_CASE("TrimSpaces") {
+  REQUIRE(TrimSpaces(" ") == "");
 
-  REQUIRE(trimSpaces("test") == "test");
-  REQUIRE(trimSpaces(" test ") == "test");
-  REQUIRE(trimSpaces("  test ") == "test");
-  REQUIRE(trimSpaces("  test  ") == "test");
-  REQUIRE(trimSpaces(" test") == "test");
-  REQUIRE(trimSpaces("\ttest") == "test");
-  REQUIRE(trimSpaces("test\t") == "test");
-  REQUIRE(trimSpaces("\ttest\t") == "test");
-  REQUIRE(trimSpaces(" test\t") == "test");
-  REQUIRE(trimSpaces("\ttest ") == "test");
-  REQUIRE(trimSpaces("\t test \t") == "test");
+  REQUIRE(TrimSpaces("test") == "test");
+  REQUIRE(TrimSpaces(" test ") == "test");
+  REQUIRE(TrimSpaces("  test ") == "test");
+  REQUIRE(TrimSpaces("  test  ") == "test");
+  REQUIRE(TrimSpaces(" test") == "test");
+  REQUIRE(TrimSpaces("\ttest") == "test");
+  REQUIRE(TrimSpaces("test\t") == "test");
+  REQUIRE(TrimSpaces("\ttest\t") == "test");
+  REQUIRE(TrimSpaces(" test\t") == "test");
+  REQUIRE(TrimSpaces("\ttest ") == "test");
+  REQUIRE(TrimSpaces("\t test \t") == "test");
 
-  REQUIRE(trimSpaces("\t te st \t") == "te st");
+  REQUIRE(TrimSpaces("\t te st \t") == "te st");
 }
 
 TEST_CASE("replaceAll") {

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -63,3 +63,11 @@ TEST_CASE("replaceAll") {
   REQUIRE(replaceAll("aTOKENa", "TOKEN", "VAL") == "aVALa");
   REQUIRE(replaceAll("aTOKENaTOKEN", "TOKEN", "VAL") == "aVALaVAL");
 }
+
+TEST_CASE("startsWith") {
+  REQUIRE(startsWith("", "") == true);
+
+  REQUIRE(startsWith("test", "test") == true);
+  REQUIRE(startsWith("test=abc", "test") == true);
+  REQUIRE(startsWith(" test=abc", "test") == false);
+}

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -18,6 +18,7 @@
 #include "catch2/catch.hpp"
 
 #include "zm_utils.h"
+#include <sstream>
 
 TEST_CASE("trimSet") {
   REQUIRE(trimSet("", "") == "");
@@ -158,4 +159,82 @@ TEST_CASE("base64Encode") {
 TEST_CASE("UriDecode") {
   REQUIRE(UriDecode("abcABC123-_.~%21%28%29%26%3d%20") == "abcABC123-_.~!()&= ");
   REQUIRE(UriDecode("abcABC123-_.~%21%28%29%26%3d+") == "abcABC123-_.~!()&= ");
+}
+
+TEST_CASE("QueryString") {
+  SECTION("no value") {
+    std::stringstream str("name1=");
+    QueryString qs(str);
+
+    REQUIRE(qs.size() == 1);
+    REQUIRE(qs.has("name1") == true);
+
+    const QueryParameter *p = qs.get("name1");
+    REQUIRE(p != nullptr);
+    REQUIRE(p->name() == "name1");
+    REQUIRE(p->size() == 0);
+  }
+
+  SECTION("no value and ampersand") {
+    std::stringstream str("name1=&");
+    QueryString qs(str);
+
+    REQUIRE(qs.size() == 1);
+    REQUIRE(qs.has("name1") == true);
+
+    const QueryParameter *p = qs.get("name1");
+    REQUIRE(p != nullptr);
+    REQUIRE(p->name() == "name1");
+    REQUIRE(p->size() == 0);
+  }
+
+  SECTION("one parameter, one value") {
+    std::stringstream str("name1=value1");
+    QueryString qs(str);
+
+    REQUIRE(qs.size() == 1);
+    REQUIRE(qs.has("name1") == true);
+
+    const QueryParameter *p = qs.get("name1");
+    REQUIRE(p != nullptr);
+    REQUIRE(p->name() == "name1");
+    REQUIRE(p->size() == 1);
+    REQUIRE(p->values()[0] == "value1");
+  }
+
+  SECTION("one parameter, multiple values") {
+    std::stringstream str("name1=value1&name1=value2");
+    QueryString qs(str);
+
+    REQUIRE(qs.size() == 1);
+    REQUIRE(qs.has("name1") == true);
+
+    const QueryParameter *p = qs.get("name1");
+    REQUIRE(p != nullptr);
+    REQUIRE(p->name() == "name1");
+    REQUIRE(p->size() == 2);
+    REQUIRE(p->values()[0] == "value1");
+    REQUIRE(p->values()[1] == "value2");
+  }
+
+  SECTION("multiple parameters, multiple values") {
+    std::stringstream str("name1=value1&name2=value2");
+    QueryString qs(str);
+
+    REQUIRE(qs.size() == 2);
+    REQUIRE(qs.has("name1") == true);
+    REQUIRE(qs.has("name2") == true);
+
+    const QueryParameter *p1 = qs.get("name1");
+    REQUIRE(p1 != nullptr);
+    REQUIRE(p1->name() == "name1");
+    REQUIRE(p1->size() == 1);
+    REQUIRE(p1->values()[0] == "value1");
+
+    const QueryParameter *p2 = qs.get("name2");
+    REQUIRE(p2 != nullptr);
+    REQUIRE(p2->name() == "name2");
+    REQUIRE(p2->size() == 1);
+    REQUIRE(p2->values()[0] == "value2");
+  }
 }

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -31,3 +31,21 @@ TEST_CASE("trimSet") {
   REQUIRE(trimSet("te\"st", "\"") == "te\"st");
   REQUIRE(trimSet("\"te\"st\"", "\"") == "te\"st");
 }
+
+TEST_CASE("trimSpaces") {
+  REQUIRE(trimSpaces(" ") == "");
+
+  REQUIRE(trimSpaces("test") == "test");
+  REQUIRE(trimSpaces(" test ") == "test");
+  REQUIRE(trimSpaces("  test ") == "test");
+  REQUIRE(trimSpaces("  test  ") == "test");
+  REQUIRE(trimSpaces(" test") == "test");
+  REQUIRE(trimSpaces("\ttest") == "test");
+  REQUIRE(trimSpaces("test\t") == "test");
+  REQUIRE(trimSpaces("\ttest\t") == "test");
+  REQUIRE(trimSpaces(" test\t") == "test");
+  REQUIRE(trimSpaces("\ttest ") == "test");
+  REQUIRE(trimSpaces("\t test \t") == "test");
+
+  REQUIRE(trimSpaces("\t te st \t") == "te st");
+}


### PR DESCRIPTION
Unit tests were added before the cleanup to ensure no semantic changes were introduced (except for the rework of one `Split` overload, which is unused).