### PR TITLE
comms: Fix Woverloaded-virtual warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,5 +18,5 @@ task:
     - make install
 
   test_script:
-    - cd build
-    - CTEST_OUTPUT_ON_FAILURE=1 make test
+    - cd build/tests
+    - ./tests "~[notCI]"

--- a/.gitignore
+++ b/.gitignore
@@ -120,8 +120,6 @@ src/CMakeFiles/
 src/cmake_install.cmake
 src/libzm.a
 src/nph-zms
-src/zm_config_data.h
-src/zm_config_defines.h
 src/zmc
 src/zmf
 src/zms
@@ -154,4 +152,6 @@ web/undef.log
 zm.conf
 zmconfgen.pl
 zmlinkcontent.sh
+zm_config_data.h
+zm_config_defines.h
 **/.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,6 @@ endif()
 
 # Required for certain checks to work
 set(CMAKE_EXTRA_INCLUDE_FILES ${CMAKE_EXTRA_INCLUDE_FILES} stdio.h stdlib.h math.h signal.h)
-# Required for including headers from the this folder
-include_directories("${CMAKE_BINARY_DIR}")
 # This is required to enable searching in lib64 (if exists), do not change
 set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
 

--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -6,7 +6,8 @@ target_compile_options(zm-warning-interface
     -Wformat-security
     -Wno-cast-function-type
     -Wno-type-limits
-    -Wno-unused-parameter)
+    -Wno-unused-parameter
+    -Woverloaded-virtual)
 
 if(ASAN)
   target_compile_options(zm-compile-option-interface

--- a/distros/ubuntu1504_cmake_split_packages/rules
+++ b/distros/ubuntu1504_cmake_split_packages/rules
@@ -72,7 +72,7 @@ override_dh_auto_test:
 override_dh_clean:
 	# Add here commands to clean up after the build process.
 	[ ! -f Makefile ] || $(MAKE) distclean
-	dh_clean src/zm_config_defines.h
+	dh_clean zm_config_defines.h
 	#
 	# Delete remaining auto-generated Makefile if Makefile.in exists
 	find $(CURDIR)/ -type f -name "Makefile" | while read file; do \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt for the ZoneMinder binaries
 
 # Create files from the .in files
-configure_file(zm_config_data.h.in "${CMAKE_CURRENT_BINARY_DIR}/zm_config_data.h" @ONLY)
+configure_file(zm_config_data.h.in "${CMAKE_BINARY_DIR}/zm_config_data.h" @ONLY)
 
 # Group together all the source files that are used by all the binaries (zmc, zmu, zms etc)
 set(ZM_BIN_SRC_FILES
@@ -74,6 +74,7 @@ add_library(zm STATIC ${ZM_BIN_SRC_FILES})
 
 target_include_directories(zm
   PUBLIC
+    ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(zm

--- a/src/zm_comms.cpp
+++ b/src/zm_comms.cpp
@@ -36,40 +36,42 @@
 
 int ZM::CommsBase::readV(int iovcnt, /* const void *, int, */ ...) {
   va_list arg_ptr;
-  struct iovec iov[iovcnt];
+  iovec iov[iovcnt];
 
   va_start(arg_ptr, iovcnt);
-  for ( int i = 0; i < iovcnt; i++ ) {
+  for (int i = 0; i < iovcnt; i++) {
     iov[i].iov_base = va_arg(arg_ptr, void *);
     iov[i].iov_len = va_arg(arg_ptr, int);
   }
   va_end(arg_ptr);
 
   int nBytes = ::readv(mRd, iov, iovcnt);
-  if ( nBytes < 0 )
+  if (nBytes < 0) {
     Debug(1, "Readv of %d buffers max on rd %d failed: %s", iovcnt, mRd, strerror(errno));
+  }
   return nBytes;
 }
 
 int ZM::CommsBase::writeV(int iovcnt, /* const void *, int, */ ...) {
   va_list arg_ptr;
-  struct iovec iov[iovcnt];
+  iovec iov[iovcnt];
 
   va_start(arg_ptr, iovcnt);
-  for ( int i = 0; i < iovcnt; i++ ) {
+  for (int i = 0; i < iovcnt; i++) {
     iov[i].iov_base = va_arg(arg_ptr, void *);
     iov[i].iov_len = va_arg(arg_ptr, int);
   }
   va_end(arg_ptr);
 
   ssize_t nBytes = ::writev(mWd, iov, iovcnt);
-  if ( nBytes < 0 )
+  if (nBytes < 0) {
     Debug(1, "Writev of %d buffers on wd %d failed: %s", iovcnt, mWd, strerror(errno));
+  }
   return nBytes;
 }
 
 bool ZM::Pipe::open() {
-  if ( ::pipe(mFd) < 0 ) {
+  if (::pipe(mFd) < 0) {
     Error("pipe(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -78,9 +80,13 @@ bool ZM::Pipe::open() {
 }
 
 bool ZM::Pipe::close() {
-  if ( mFd[0] > -1 ) ::close( mFd[0] );
+  if (mFd[0] > -1) {
+    ::close(mFd[0]);
+  }
   mFd[0] = -1;
-  if ( mFd[1] > -1 ) ::close( mFd[1] );
+  if (mFd[1] > -1) {
+    ::close(mFd[1]);
+  }
   mFd[1] = -1;
   return true;
 }
@@ -89,16 +95,16 @@ bool ZM::Pipe::setBlocking(bool blocking) {
   int flags;
 
   /* Now set it for non-blocking I/O */
-  if ( (flags = fcntl(mFd[1], F_GETFL)) < 0 ) {
+  if ((flags = fcntl(mFd[1], F_GETFL)) < 0) {
     Error("fcntl(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
-  if ( blocking ) {
+  if (blocking) {
     flags &= ~O_NONBLOCK;
   } else {
     flags |= O_NONBLOCK;
   }
-  if ( fcntl(mFd[1], F_SETFL, flags) < 0 ) {
+  if (fcntl(mFd[1], F_SETFL, flags) < 0) {
     Error("fcntl(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -106,53 +112,50 @@ bool ZM::Pipe::setBlocking(bool blocking) {
   return true;
 }
 
-ZM::SockAddr::SockAddr(const struct sockaddr *addr) : mAddr(addr) {
-}
-
-ZM::SockAddr *ZM::SockAddr::newSockAddr(const struct sockaddr &addr, socklen_t len) {
-  if ( (addr.sa_family == AF_INET) && (len == SockAddrInet::addrSize()) ) {
-    return new SockAddrInet((const struct sockaddr_in *)&addr);
-  } else if ( (addr.sa_family == AF_UNIX) && (len == SockAddrUnix::addrSize()) ) {
-    return new SockAddrUnix((const struct sockaddr_un *)&addr);
+ZM::SockAddr *ZM::SockAddr::newSockAddr(const sockaddr &addr, socklen_t len) {
+  if ((addr.sa_family == AF_INET) && (len == SockAddrInet::addrSize())) {
+    return new SockAddrInet((const sockaddr_in *) &addr);
+  } else if ((addr.sa_family == AF_UNIX) && (len == SockAddrUnix::addrSize())) {
+    return new SockAddrUnix((const sockaddr_un *) &addr);
   }
+
   Error("Unable to create new SockAddr from addr family %d with size %d", addr.sa_family, len);
   return nullptr;
 }
 
 ZM::SockAddr *ZM::SockAddr::newSockAddr(const SockAddr *addr) {
-  if ( !addr )
+  if (!addr) {
     return nullptr;
-
-  if ( addr->getDomain() == AF_INET ) {
-    return new SockAddrInet(*(SockAddrInet *)addr);
-  } else if ( addr->getDomain() == AF_UNIX ) {
-    return new SockAddrUnix(*(SockAddrUnix *)addr);
   }
+
+  if (addr->getDomain() == AF_INET) {
+    return new SockAddrInet(*(SockAddrInet *) addr);
+  } else if (addr->getDomain() == AF_UNIX) {
+    return new SockAddrUnix(*(SockAddrUnix *) addr);
+  }
+
   Error("Unable to create new SockAddr from addr family %d", addr->getDomain());
   return nullptr;
-}
-
-ZM::SockAddrInet::SockAddrInet() : SockAddr( (struct sockaddr *)&mAddrIn ) {
 }
 
 bool ZM::SockAddrInet::resolve(const char *host, const char *serv, const char *proto) {
   memset(&mAddrIn, 0, sizeof(mAddrIn));
 
-  struct hostent *hostent = nullptr;
-  if ( !(hostent = ::gethostbyname(host) ) ) {
+  hostent *hostent = nullptr;
+  if (!(hostent = ::gethostbyname(host))) {
     Error("gethostbyname(%s), h_errno = %d", host, h_errno);
     return false;
   }
 
-  struct servent *servent = nullptr;
-  if ( !(servent = ::getservbyname(serv, proto) ) ) {
+  servent *servent = nullptr;
+  if (!(servent = ::getservbyname(serv, proto))) {
     Error("getservbyname( %s ), errno = %d, error = %s", serv, errno, strerror(errno));
     return false;
   }
 
   mAddrIn.sin_port = servent->s_port;
   mAddrIn.sin_family = AF_INET;
-  mAddrIn.sin_addr.s_addr = ((struct in_addr *)(hostent->h_addr))->s_addr;
+  mAddrIn.sin_addr.s_addr = ((in_addr *) (hostent->h_addr))->s_addr;
 
   return true;
 }
@@ -160,23 +163,23 @@ bool ZM::SockAddrInet::resolve(const char *host, const char *serv, const char *p
 bool ZM::SockAddrInet::resolve(const char *host, int port, const char *proto) {
   memset(&mAddrIn, 0, sizeof(mAddrIn));
 
-  struct hostent *hostent = nullptr;
-  if ( !(hostent = ::gethostbyname(host)) ) {
+  hostent *hostent = nullptr;
+  if (!(hostent = ::gethostbyname(host))) {
     Error("gethostbyname(%s), h_errno = %d", host, h_errno);
     return false;
   }
 
   mAddrIn.sin_port = htons(port);
   mAddrIn.sin_family = AF_INET;
-  mAddrIn.sin_addr.s_addr = ((struct in_addr *)(hostent->h_addr))->s_addr;
+  mAddrIn.sin_addr.s_addr = ((in_addr *) (hostent->h_addr))->s_addr;
   return true;
 }
 
 bool ZM::SockAddrInet::resolve(const char *serv, const char *proto) {
   memset(&mAddrIn, 0, sizeof(mAddrIn));
 
-  struct servent *servent = nullptr;
-  if ( !(servent = ::getservbyname(serv, proto)) ) {
+  servent *servent = nullptr;
+  if (!(servent = ::getservbyname(serv, proto))) {
     Error("getservbyname(%s), errno = %d, error = %s", serv, errno, strerror(errno));
     return false;
   }
@@ -198,9 +201,6 @@ bool ZM::SockAddrInet::resolve(int port, const char *proto) {
   return true;
 }
 
-ZM::SockAddrUnix::SockAddrUnix() : SockAddr((struct sockaddr *)&mAddrUn ) {
-}
-
 bool ZM::SockAddrUnix::resolve(const char *path, const char *proto) {
   memset(&mAddrUn, 0, sizeof(mAddrUn));
 
@@ -211,44 +211,45 @@ bool ZM::SockAddrUnix::resolve(const char *path, const char *proto) {
 }
 
 bool ZM::Socket::socket() {
-  if ( mSd >= 0 )
+  if (mSd >= 0) {
     return true;
+  }
 
-  if ( (mSd = ::socket(getDomain(), getType(), 0) ) < 0 ) {
+  if ((mSd = ::socket(getDomain(), getType(), 0)) < 0) {
     Error("socket(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
 
   int val = 1;
 
-  (void)::setsockopt(mSd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
-  (void)::setsockopt(mSd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+  ::setsockopt(mSd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+  ::setsockopt(mSd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
 
   mState = DISCONNECTED;
-
   return true;
 }
 
 bool ZM::Socket::connect() {
-  if ( !socket() )
+  if (!socket()) {
     return false;
+  }
 
-  if ( ::connect(mSd, mRemoteAddr->getAddr(), getAddrSize()) == -1 ) {
+  if (::connect(mSd, mRemoteAddr->getAddr(), getAddrSize()) == -1) {
     Error("connect(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
   }
 
   mState = CONNECTED;
-
   return true;
 }
 
 bool ZM::Socket::bind() {
-  if ( !socket() )
+  if (!socket()) {
     return false;
+  }
 
-  if ( ::bind(mSd, mLocalAddr->getAddr(), getAddrSize()) == -1 ) {
+  if (::bind(mSd, mLocalAddr->getAddr(), getAddrSize()) == -1) {
     Error("bind(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
@@ -257,7 +258,7 @@ bool ZM::Socket::bind() {
 }
 
 bool ZM::Socket::listen() {
-  if ( ::listen(mSd, SOMAXCONN) == -1 ) {
+  if (::listen(mSd, SOMAXCONN) == -1) {
     Error("listen(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
@@ -268,11 +269,11 @@ bool ZM::Socket::listen() {
 }
 
 bool ZM::Socket::accept() {
-  struct sockaddr *rem_addr = mLocalAddr->getTempAddr();
+  sockaddr *rem_addr = mLocalAddr->getTempAddr();
   socklen_t rem_addr_size = getAddrSize();
 
   int newSd = -1;
-  if ( (newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1 ) {
+  if ((newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1) {
     Error("accept(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
@@ -282,16 +283,15 @@ bool ZM::Socket::accept() {
   mSd = newSd;
 
   mState = CONNECTED;
-
   return true;
 }
 
 bool ZM::Socket::accept(int &newSd) {
-  struct sockaddr *rem_addr = mLocalAddr->getTempAddr();
+  sockaddr *rem_addr = mLocalAddr->getTempAddr();
   socklen_t rem_addr_size = getAddrSize();
 
   newSd = -1;
-  if ( (newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1 ) {
+  if ((newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1) {
     Error("accept(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
@@ -301,7 +301,10 @@ bool ZM::Socket::accept(int &newSd) {
 }
 
 bool ZM::Socket::close() {
-  if ( mSd > -1 ) ::close(mSd);
+  if (mSd > -1) {
+    ::close(mSd);
+  }
+
   mSd = -1;
   mState = CLOSED;
   return true;
@@ -310,7 +313,7 @@ bool ZM::Socket::close() {
 int ZM::Socket::bytesToRead() const {
   int bytes_to_read = 0;
 
-  if ( ioctl(mSd, FIONREAD, &bytes_to_read) < 0 ) {
+  if (ioctl(mSd, FIONREAD, &bytes_to_read) < 0) {
     Error("ioctl(), errno = %d, error = %s", errno, strerror(errno));
     return -1;
   }
@@ -320,7 +323,7 @@ int ZM::Socket::bytesToRead() const {
 bool ZM::Socket::getBlocking(bool &blocking) {
   int flags;
 
-  if ( (flags = fcntl(mSd, F_GETFL)) < 0 ) {
+  if ((flags = fcntl(mSd, F_GETFL)) < 0) {
     Error("fcntl(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -332,16 +335,16 @@ bool ZM::Socket::setBlocking(bool blocking) {
   int flags;
 
   /* Now set it for non-blocking I/O */
-  if ( (flags = fcntl(mSd, F_GETFL)) < 0 ) {
+  if ((flags = fcntl(mSd, F_GETFL)) < 0) {
     Error("fcntl(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
-  if ( blocking ) {
+  if (blocking) {
     flags &= ~O_NONBLOCK;
   } else {
     flags |= O_NONBLOCK;
   }
-  if ( fcntl(mSd, F_SETFL, flags) < 0 ) {
+  if (fcntl(mSd, F_SETFL, flags) < 0) {
     Error("fcntl(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -351,7 +354,7 @@ bool ZM::Socket::setBlocking(bool blocking) {
 
 bool ZM::Socket::getSendBufferSize(int &buffersize) const {
   socklen_t optlen = sizeof(buffersize);
-  if ( getsockopt(mSd, SOL_SOCKET, SO_SNDBUF, &buffersize, &optlen) < 0 ) {
+  if (getsockopt(mSd, SOL_SOCKET, SO_SNDBUF, &buffersize, &optlen) < 0) {
     Error("getsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return -1;
   }
@@ -360,7 +363,7 @@ bool ZM::Socket::getSendBufferSize(int &buffersize) const {
 
 bool ZM::Socket::getRecvBufferSize(int &buffersize) const {
   socklen_t optlen = sizeof(buffersize);
-  if ( getsockopt(mSd, SOL_SOCKET, SO_RCVBUF, &buffersize, &optlen) < 0 ) {
+  if (getsockopt(mSd, SOL_SOCKET, SO_RCVBUF, &buffersize, &optlen) < 0) {
     Error("getsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return -1;
   }
@@ -368,7 +371,7 @@ bool ZM::Socket::getRecvBufferSize(int &buffersize) const {
 }
 
 bool ZM::Socket::setSendBufferSize(int buffersize) {
-  if ( setsockopt(mSd, SOL_SOCKET, SO_SNDBUF, (char *)&buffersize, sizeof(buffersize)) < 0 ) {
+  if (setsockopt(mSd, SOL_SOCKET, SO_SNDBUF, (char *) &buffersize, sizeof(buffersize)) < 0) {
     Error("setsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -376,7 +379,7 @@ bool ZM::Socket::setSendBufferSize(int buffersize) {
 }
 
 bool ZM::Socket::setRecvBufferSize(int buffersize) {
-  if ( setsockopt( mSd, SOL_SOCKET, SO_RCVBUF, (char *)&buffersize, sizeof(buffersize)) < 0 ) {
+  if (setsockopt(mSd, SOL_SOCKET, SO_RCVBUF, (char *) &buffersize, sizeof(buffersize)) < 0) {
     Error("setsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -386,7 +389,7 @@ bool ZM::Socket::setRecvBufferSize(int buffersize) {
 bool ZM::Socket::getRouting(bool &route) const {
   int dontRoute;
   socklen_t optlen = sizeof(dontRoute);
-  if ( getsockopt(mSd, SOL_SOCKET, SO_DONTROUTE, &dontRoute, &optlen) < 0 ) {
+  if (getsockopt(mSd, SOL_SOCKET, SO_DONTROUTE, &dontRoute, &optlen) < 0) {
     Error("getsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -396,7 +399,7 @@ bool ZM::Socket::getRouting(bool &route) const {
 
 bool ZM::Socket::setRouting(bool route) {
   int dontRoute = !route;
-  if ( setsockopt(mSd, SOL_SOCKET, SO_DONTROUTE, (char *)&dontRoute, sizeof(dontRoute)) < 0 ) {
+  if (setsockopt(mSd, SOL_SOCKET, SO_DONTROUTE, (char *) &dontRoute, sizeof(dontRoute)) < 0) {
     Error("setsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -406,7 +409,7 @@ bool ZM::Socket::setRouting(bool route) {
 bool ZM::Socket::getNoDelay(bool &nodelay) const {
   int int_nodelay;
   socklen_t optlen = sizeof(int_nodelay);
-  if ( getsockopt(mSd, IPPROTO_TCP, TCP_NODELAY, &int_nodelay, &optlen) < 0 ) {
+  if (getsockopt(mSd, IPPROTO_TCP, TCP_NODELAY, &int_nodelay, &optlen) < 0) {
     Error("getsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -417,7 +420,7 @@ bool ZM::Socket::getNoDelay(bool &nodelay) const {
 bool ZM::Socket::setNoDelay(bool nodelay) {
   int int_nodelay = nodelay;
 
-  if ( setsockopt(mSd, IPPROTO_TCP, TCP_NODELAY, (char *)&int_nodelay, sizeof(int_nodelay)) < 0 ) {
+  if (setsockopt(mSd, IPPROTO_TCP, TCP_NODELAY, (char *) &int_nodelay, sizeof(int_nodelay)) < 0) {
     Error("setsockopt(), errno = %d, error = %s", errno, strerror(errno));
     return false;
   }
@@ -425,20 +428,20 @@ bool ZM::Socket::setNoDelay(bool nodelay) {
 }
 
 bool ZM::InetSocket::connect(const char *host, const char *serv) {
-  struct addrinfo hints;
-  struct addrinfo *result, *rp;
+  addrinfo hints;
+  addrinfo *result, *rp;
   int s;
   char buf[255];
 
   mAddressFamily = AF_UNSPEC;
-  memset(&hints, 0, sizeof(struct addrinfo));
+  memset(&hints, 0, sizeof(addrinfo));
   hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
   hints.ai_socktype = getType();
   hints.ai_flags = 0;
   hints.ai_protocol = 0;          /* Any protocol */
 
   s = getaddrinfo(host, serv, &hints, &result);
-  if ( s != 0 ) {
+  if (s != 0) {
     Error("connect(): getaddrinfo: %s", gai_strerror(s));
     return false;
   }
@@ -448,47 +451,51 @@ bool ZM::InetSocket::connect(const char *host, const char *serv) {
    * If socket(2) (or connect(2)) fails, we (close the socket
    * and) try the next address. */
 
-  for ( rp = result; rp != nullptr; rp = rp->ai_next ) {
-    if ( mSd != -1 ) {
-      if ( ::connect(mSd, rp->ai_addr, rp->ai_addrlen) != -1 )
+  for (rp = result; rp != nullptr; rp = rp->ai_next) {
+    if (mSd != -1) {
+      if (::connect(mSd, rp->ai_addr, rp->ai_addrlen) != -1) {
         break;                  /* Success */
+      }
       continue;
     }
+
     memset(&buf, 0, sizeof(buf));
-    if ( rp->ai_family == AF_INET ) {
-      inet_ntop(AF_INET, &((struct sockaddr_in *)rp->ai_addr)->sin_addr, buf, sizeof(buf)-1);
+    if (rp->ai_family == AF_INET) {
+      inet_ntop(AF_INET, &((sockaddr_in *) rp->ai_addr)->sin_addr, buf, sizeof(buf) - 1);
     } else if (rp->ai_family == AF_INET6) {
-      inet_ntop(AF_INET6, &((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr, buf, sizeof(buf)-1);
+      inet_ntop(AF_INET6, &((sockaddr_in6 *) rp->ai_addr)->sin6_addr, buf, sizeof(buf) - 1);
     } else {
-      strncpy(buf, "n/a", sizeof(buf)-1);
+      strncpy(buf, "n/a", sizeof(buf) - 1);
     }
+
     Debug(1, "connect(): Trying '%s', family '%d', proto '%d'", buf, rp->ai_family, rp->ai_protocol);
     mSd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-    if ( mSd == -1 )
+    if (mSd == -1) {
       continue;
+    }
 
     int val = 1;
 
-    (void)::setsockopt(mSd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
-    (void)::setsockopt(mSd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
+    ::setsockopt(mSd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
+    ::setsockopt(mSd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val));
     mAddressFamily = rp->ai_family;         /* save AF_ for ctrl and data connections */
 
-    if ( ::connect(mSd, rp->ai_addr, rp->ai_addrlen) != -1 )
+    if (::connect(mSd, rp->ai_addr, rp->ai_addrlen) != -1) {
       break;                  /* Success */
+    }
 
     ::close(mSd);
-  }  // end for
+  }
 
   freeaddrinfo(result);   /* No longer needed */
 
-  if ( rp == nullptr ) {               /* No address succeeded */
+  if (rp == nullptr) {               /* No address succeeded */
     Error("connect(), Could not connect");
     mAddressFamily = AF_UNSPEC;
     return false;
   }
 
   mState = CONNECTED;
-
   return true;
 }
 
@@ -499,10 +506,10 @@ bool ZM::InetSocket::connect(const char *host, int port) {
   return connect(host, serv);
 }
 
-bool ZM::InetSocket::bind(const char * host, const char * serv) {
-  struct addrinfo hints;
+bool ZM::InetSocket::bind(const char *host, const char *serv) {
+  addrinfo hints;
 
-  memset(&hints, 0, sizeof(struct addrinfo));
+  memset(&hints, 0, sizeof(addrinfo));
   hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
   hints.ai_socktype = getType();
   hints.ai_flags = AI_PASSIVE;    /* For wildcard IP address */
@@ -511,9 +518,9 @@ bool ZM::InetSocket::bind(const char * host, const char * serv) {
   hints.ai_addr = nullptr;
   hints.ai_next = nullptr;
 
-  struct addrinfo *result, *rp;
+  addrinfo *result, *rp;
   int s = getaddrinfo(host, serv, &hints, &result);
-  if ( s != 0 ) {
+  if (s != 0) {
     Error("bind(): getaddrinfo: %s", gai_strerror(s));
     return false;
   }
@@ -523,29 +530,32 @@ bool ZM::InetSocket::bind(const char * host, const char * serv) {
    * Try each address until we successfully bind(2).
    * If socket(2) (or bind(2)) fails, we (close the socket
    * and) try the next address. */
-  for ( rp = result; rp != nullptr; rp = rp->ai_next ) {
+  for (rp = result; rp != nullptr; rp = rp->ai_next) {
     memset(&buf, 0, sizeof(buf));
-    if ( rp->ai_family == AF_INET ) {
-      inet_ntop(AF_INET, &((struct sockaddr_in *)rp->ai_addr)->sin_addr, buf, sizeof(buf)-1);
-    } else if ( rp->ai_family == AF_INET6 ) {
-      inet_ntop(AF_INET6, &((struct sockaddr_in6 *)rp->ai_addr)->sin6_addr, buf, sizeof(buf)-1);
+    if (rp->ai_family == AF_INET) {
+      inet_ntop(AF_INET, &((sockaddr_in *) rp->ai_addr)->sin_addr, buf, sizeof(buf) - 1);
+    } else if (rp->ai_family == AF_INET6) {
+      inet_ntop(AF_INET6, &((sockaddr_in6 *) rp->ai_addr)->sin6_addr, buf, sizeof(buf) - 1);
     } else {
-      strncpy(buf, "n/a", sizeof(buf)-1);
+      strncpy(buf, "n/a", sizeof(buf) - 1);
     }
+
     Debug(1, "bind(): Trying '%s', family '%d', proto '%d'", buf, rp->ai_family, rp->ai_protocol);
     mSd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-    if ( mSd == -1 )
+    if (mSd == -1) {
       continue;
+    }
 
     mState = DISCONNECTED;
-    if ( ::bind(mSd, rp->ai_addr, rp->ai_addrlen) == 0 )
+    if (::bind(mSd, rp->ai_addr, rp->ai_addrlen) == 0) {
       break;                  /* Success */
+    }
 
     ::close(mSd);
     mSd = -1;
-  }  // end foreach result
+  }
 
-  if ( rp == nullptr ) {               /* No address succeeded */
+  if (rp == nullptr) {               /* No address succeeded */
     Error("bind(), Could not bind");
     return false;
   }
@@ -554,11 +564,11 @@ bool ZM::InetSocket::bind(const char * host, const char * serv) {
   return true;
 }
 
-bool ZM::InetSocket::bind(const char * serv) {
+bool ZM::InetSocket::bind(const char *serv) {
   return bind(nullptr, serv);
 }
 
-bool ZM::InetSocket::bind(const char * host, int port) {
+bool ZM::InetSocket::bind(const char *host, int port) {
   char serv[8];
   snprintf(serv, sizeof(serv), "%d", port);
 
@@ -584,11 +594,11 @@ bool ZM::TcpInetServer::accept(TcpInetSocket *&newSocket) {
   int newSd = -1;
   newSocket = nullptr;
 
-  if ( !Socket::accept(newSd) )
+  if (!Socket::accept(newSd)) {
     return false;
+  }
 
   newSocket = new TcpInetSocket(*this, newSd);
-
   return true;
 }
 
@@ -596,27 +606,12 @@ bool ZM::TcpUnixServer::accept(TcpUnixSocket *&newSocket) {
   int newSd = -1;
   newSocket = nullptr;
 
-  if ( !Socket::accept(newSd) )
+  if (!Socket::accept(newSd)) {
     return false;
+  }
 
   newSocket = new TcpUnixSocket(*this, newSd);
-
   return true;
-}
-
-ZM::Select::Select() : mHasTimeout(false), mMaxFd(-1) {
-}
-
-ZM::Select::Select(struct timeval timeout) : mMaxFd(-1) {
-  setTimeout(timeout);
-}
-
-ZM::Select::Select(int timeout) : mMaxFd(-1) {
-  setTimeout(timeout);
-}
-
-ZM::Select::Select(double timeout) : mMaxFd(-1) {
-  setTimeout(timeout);
 }
 
 void ZM::Select::setTimeout(int timeout) {
@@ -627,11 +622,11 @@ void ZM::Select::setTimeout(int timeout) {
 
 void ZM::Select::setTimeout(double timeout) {
   mTimeout.tv_sec = int(timeout);
-  mTimeout.tv_usec = suseconds_t((timeout-mTimeout.tv_sec)*1000000.0);
+  mTimeout.tv_usec = suseconds_t((timeout - mTimeout.tv_sec) * 1000000.0);
   mHasTimeout = true;
 }
 
-void ZM::Select::setTimeout(struct timeval timeout) {
+void ZM::Select::setTimeout(timeval timeout) {
   mTimeout = timeout;
   mHasTimeout = true;
 }
@@ -642,35 +637,36 @@ void ZM::Select::clearTimeout() {
 
 void ZM::Select::calcMaxFd() {
   mMaxFd = -1;
-  for ( CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter ) {
-    if ( (*iter)->getMaxDesc() > mMaxFd )
+  for (CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter) {
+    if ((*iter)->getMaxDesc() > mMaxFd)
       mMaxFd = (*iter)->getMaxDesc();
   }
-  for ( CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter ) {
-    if ( (*iter)->getMaxDesc() > mMaxFd )
+  for (CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter) {
+    if ((*iter)->getMaxDesc() > mMaxFd)
       mMaxFd = (*iter)->getMaxDesc();
   }
 }
 
 bool ZM::Select::addReader(CommsBase *comms) {
-  if ( !comms->isOpen() ) {
+  if (!comms->isOpen()) {
     Error("Unable to add closed reader");
     return false;
   }
   std::pair<CommsSet::iterator, bool> result = mReaders.insert(comms);
-  if ( result.second ) {
-    if ( comms->getMaxDesc() > mMaxFd )
+  if (result.second) {
+    if (comms->getMaxDesc() > mMaxFd) {
       mMaxFd = comms->getMaxDesc();
+    }
   }
   return result.second;
 }
 
 bool ZM::Select::deleteReader(CommsBase *comms) {
-  if ( !comms->isOpen() ) {
+  if (!comms->isOpen()) {
     Error("Unable to add closed reader");
     return false;
   }
-  if ( mReaders.erase(comms) ) {
+  if (mReaders.erase(comms)) {
     calcMaxFd();
     return true;
   }
@@ -684,15 +680,16 @@ void ZM::Select::clearReaders() {
 
 bool ZM::Select::addWriter(CommsBase *comms) {
   std::pair<CommsSet::iterator, bool> result = mWriters.insert(comms);
-  if ( result.second ) {
-    if ( comms->getMaxDesc() > mMaxFd )
+  if (result.second) {
+    if (comms->getMaxDesc() > mMaxFd) {
       mMaxFd = comms->getMaxDesc();
+    }
   }
   return result.second;
 }
 
 bool ZM::Select::deleteWriter(CommsBase *comms) {
-  if ( mWriters.erase(comms) ) {
+  if (mWriters.erase(comms)) {
     calcMaxFd();
     return true;
   }
@@ -705,42 +702,40 @@ void ZM::Select::clearWriters() {
 }
 
 int ZM::Select::wait() {
-  struct timeval tempTimeout = mTimeout;
-  struct timeval *selectTimeout = mHasTimeout?&tempTimeout:nullptr;
+  timeval tempTimeout = mTimeout;
+  timeval *selectTimeout = mHasTimeout ? &tempTimeout : nullptr;
 
   fd_set rfds;
   fd_set wfds;
 
   mReadable.clear();
   FD_ZERO(&rfds);
-  for ( CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter )
+  for (CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter) {
     FD_SET((*iter)->getReadDesc(), &rfds);
+  }
 
   mWriteable.clear();
   FD_ZERO(&wfds);
-  for ( CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter )
+  for (CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter) {
     FD_SET((*iter)->getWriteDesc(), &wfds);
+  }
 
-  int nFound = select(mMaxFd+1, &rfds, &wfds, nullptr, selectTimeout);
-  if ( nFound == 0 ) {
+  int nFound = select(mMaxFd + 1, &rfds, &wfds, nullptr, selectTimeout);
+  if (nFound == 0) {
     Debug(1, "Select timed out");
-  } else if ( nFound < 0 ) {
+  } else if (nFound < 0) {
     Error("Select error: %s", strerror(errno));
   } else {
-    for ( CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter )
-      if ( FD_ISSET((*iter)->getReadDesc(), &rfds) )
+    for (CommsSet::iterator iter = mReaders.begin(); iter != mReaders.end(); ++iter) {
+      if (FD_ISSET((*iter)->getReadDesc(), &rfds)) {
         mReadable.push_back(*iter);
-    for ( CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter )
-      if ( FD_ISSET((*iter)->getWriteDesc(), &rfds) )
+      }
+    }
+    for (CommsSet::iterator iter = mWriters.begin(); iter != mWriters.end(); ++iter) {
+      if (FD_ISSET((*iter)->getWriteDesc(), &rfds)) {
         mWriteable.push_back(*iter);
+      }
+    }
   }
   return nFound;
-}
-
-const ZM::Select::CommsList &ZM::Select::getReadable() const {
-  return mReadable;
-}
-
-const ZM::Select::CommsList &ZM::Select::getWriteable() const {
-  return mWriteable;
 }

--- a/src/zm_comms.cpp
+++ b/src/zm_comms.cpp
@@ -269,11 +269,11 @@ bool ZM::Socket::listen() {
 }
 
 bool ZM::Socket::accept() {
-  sockaddr *rem_addr = mLocalAddr->getTempAddr();
+  sockaddr rem_addr = {};
   socklen_t rem_addr_size = getAddrSize();
 
   int newSd = -1;
-  if ((newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1) {
+  if ((newSd = ::accept(mSd, &rem_addr, &rem_addr_size)) == -1) {
     Error("accept(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;
@@ -287,11 +287,11 @@ bool ZM::Socket::accept() {
 }
 
 bool ZM::Socket::accept(int &newSd) {
-  sockaddr *rem_addr = mLocalAddr->getTempAddr();
+  sockaddr rem_addr = {};
   socklen_t rem_addr_size = getAddrSize();
 
   newSd = -1;
-  if ((newSd = ::accept(mSd, rem_addr, &rem_addr_size)) == -1) {
+  if ((newSd = ::accept(mSd, &rem_addr, &rem_addr_size)) == -1) {
     Error("accept(), errno = %d, error = %s", errno, strerror(errno));
     close();
     return false;

--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -301,13 +301,13 @@ class Socket : public CommsBase {
  protected:
   virtual bool isListening() const { return mState == LISTENING; }
 
-  virtual bool socket();
-  virtual bool bind();
+  bool socket();
+  bool bind();
 
-  virtual bool connect();
+  bool connect();
   virtual bool listen();
   virtual bool accept();
-  virtual bool accept(int &);
+  bool accept(int &);
 
   int mSd;
   State mState;

--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -111,6 +111,7 @@ class Pipe : public CommsBase {
   bool close();
 
   bool isOpen() const { return mFd[0] != -1 && mFd[1] != -1; }
+  bool isClosed() const { return !isOpen(); }
   int getReadDesc() const { return mFd[0]; }
   int getWriteDesc() const { return mFd[1]; }
 

--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -38,613 +38,559 @@
 namespace ZM {
 
 class CommsException : public Exception {
-public:
-  explicit CommsException( const std::string &message ) : Exception( message ) { }
+ public:
+  explicit CommsException(const std::string &message) : Exception(message) {}
 };
 
 class CommsBase {
-protected:
-  const int  &mRd;
-  const int  &mWd;
+ protected:
+  CommsBase(const int &rd, const int &wd) : mRd(rd), mWd(wd) {}
+  virtual ~CommsBase() = default;
 
-protected:
-  CommsBase(const int &rd, const int &wd) : mRd(rd), mWd(wd) {
-  }
-  virtual ~CommsBase() {
-  }
+ public:
+  virtual bool close() = 0;
+  virtual bool isOpen() const = 0;
+  virtual bool isClosed() const = 0;
+  virtual bool setBlocking(bool blocking) = 0;
 
-public:
-  virtual bool close()=0;
-  virtual bool isOpen() const=0;
-  virtual bool isClosed() const=0;
-  virtual bool setBlocking( bool blocking )=0;
+ public:
+  int getReadDesc() const { return mRd; }
+  int getWriteDesc() const { return mWd; }
+  int getMaxDesc() const { return mRd > mWd ? mRd : mWd; }
 
-public:
-  int getReadDesc() const {
-    return mRd;
-  }
-  int getWriteDesc() const {
-    return mWd;
-  }
-  int getMaxDesc() const {
-    return( mRd>mWd?mRd:mWd );
+  virtual int read(void *msg, int len) {
+    ssize_t nBytes = ::read(mRd, msg, len);
+    if (nBytes < 0) {
+      Debug(1, "Read of %d bytes max on rd %d failed: %s", len, mRd, strerror(errno));
+    }
+    return nBytes;
   }
 
-  virtual int read( void *msg, int len ) {
-    ssize_t nBytes = ::read( mRd, msg, len );
-    if ( nBytes < 0 )
-      Debug( 1, "Read of %d bytes max on rd %d failed: %s", len, mRd, strerror(errno) );
-    return( nBytes );
+  virtual int write(const void *msg, int len) {
+    ssize_t nBytes = ::write(mWd, msg, len);
+    if (nBytes < 0) {
+      Debug(1, "Write of %d bytes on wd %d failed: %s", len, mWd, strerror(errno));
+    }
+    return nBytes;
   }
-  virtual int write( const void *msg, int len ) {
-    ssize_t nBytes = ::write( mWd, msg, len );
-    if ( nBytes < 0 )
-      Debug( 1, "Write of %d bytes on wd %d failed: %s", len, mWd, strerror(errno) );
-    return( nBytes );
+
+  virtual int readV(const iovec *iov, int iovcnt) {
+    int nBytes = ::readv(mRd, iov, iovcnt);
+    if (nBytes < 0) {
+      Debug(1, "Readv of %d buffers max on rd %d failed: %s", iovcnt, mRd, strerror(errno));
+    }
+    return nBytes;
   }
-  virtual int readV( const struct iovec *iov, int iovcnt ) {
-    int nBytes = ::readv( mRd, iov, iovcnt );
-    if ( nBytes < 0 )
-      Debug( 1, "Readv of %d buffers max on rd %d failed: %s", iovcnt, mRd, strerror(errno) );
-    return( nBytes );
+
+  virtual int writeV(const iovec *iov, int iovcnt) {
+    ssize_t nBytes = ::writev(mWd, iov, iovcnt);
+    if (nBytes < 0) {
+      Debug(1, "Writev of %d buffers on wd %d failed: %s", iovcnt, mWd, strerror(errno));
+    }
+    return nBytes;
   }
-  virtual int writeV( const struct iovec *iov, int iovcnt ) {
-    ssize_t nBytes = ::writev( mWd, iov, iovcnt );
-    if ( nBytes < 0 )
-      Debug( 1, "Writev of %d buffers on wd %d failed: %s", iovcnt, mWd, strerror(errno) );
-    return( nBytes );
-  }
-  virtual int readV( int iovcnt, /* const void *msg1, int len1, */ ... );
-  virtual int writeV( int iovcnt, /* const void *msg1, int len1, */ ... );
+
+  virtual int readV(int iovcnt, /* const void *msg1, int len1, */ ...);
+  virtual int writeV(int iovcnt, /* const void *msg1, int len1, */ ...);
+
+ protected:
+  const int &mRd;
+  const int &mWd;
 };
 
 class Pipe : public CommsBase {
-protected:
-  int mFd[2];
-
-public:
-  Pipe() : CommsBase( mFd[0], mFd[1] ) {
+ public:
+  Pipe() : CommsBase(mFd[0], mFd[1]) {
     mFd[0] = -1;
     mFd[1] = -1;
   }
-  ~Pipe() {
-    close();
-  }
 
-public:
+  ~Pipe() { close(); }
+
   bool open();
   bool close();
 
-  bool isOpen() const
-  {
-    return( mFd[0] != -1 && mFd[1] != -1 );
-  }
-  int getReadDesc() const
-  {
-    return( mFd[0] );
-  }
-  int getWriteDesc() const
-  {
-    return( mFd[1] );
-  }
+  bool isOpen() const { return mFd[0] != -1 && mFd[1] != -1; }
+  int getReadDesc() const { return mFd[0]; }
+  int getWriteDesc() const { return mFd[1]; }
 
-  bool setBlocking( bool blocking );
+  bool setBlocking(bool blocking);
+
+ protected:
+  int mFd[2];
 };
 
 class SockAddr {
-private:
-  const struct sockaddr *mAddr;
+ public:
+  explicit SockAddr(const sockaddr *addr) : mAddr(addr) {}
+  virtual ~SockAddr() = default;
 
-public:
-  explicit SockAddr( const struct sockaddr *addr );
-  virtual ~SockAddr() {
-  }
+  static SockAddr *newSockAddr(const sockaddr &addr, socklen_t len);
+  static SockAddr *newSockAddr(const SockAddr *addr);
 
-  static SockAddr *newSockAddr( const struct sockaddr &addr, socklen_t len );
-  static SockAddr *newSockAddr( const SockAddr *addr );
+  int getDomain() const { return mAddr ? mAddr->sa_family : AF_UNSPEC; }
+  const sockaddr *getAddr() const { return mAddr; }
 
-  int getDomain() const {
-    return( mAddr?mAddr->sa_family:AF_UNSPEC );
-  }
+  virtual socklen_t getAddrSize() const = 0;
+  virtual sockaddr *getTempAddr() const = 0;
 
-  const struct sockaddr *getAddr() const {
-    return( mAddr );
-  }
-  virtual socklen_t getAddrSize() const=0;
-  virtual struct sockaddr *getTempAddr() const=0;
+ private:
+  const sockaddr *mAddr;
 };
 
 class SockAddrInet : public SockAddr {
-private:
-  struct sockaddr_in  mAddrIn;
-  struct sockaddr_in  mTempAddrIn;
+ public:
+  SockAddrInet() : SockAddr((sockaddr *) &mAddrIn) {}
+  explicit SockAddrInet(const SockAddrInet &addr)
+      : SockAddr((const sockaddr *) &mAddrIn), mAddrIn(addr.mAddrIn) {}
+  explicit SockAddrInet(const sockaddr_in *addr)
+      : SockAddr((const sockaddr *) &mAddrIn), mAddrIn(*addr) {}
 
-public:
-  SockAddrInet();
-  explicit SockAddrInet( const SockAddrInet &addr ) : SockAddr( (const struct sockaddr *)&mAddrIn ), mAddrIn( addr.mAddrIn ) {
-  }
-  explicit SockAddrInet( const struct sockaddr_in *addr ) : SockAddr( (const struct sockaddr *)&mAddrIn ), mAddrIn( *addr ) {
-  }
+  bool resolve(const char *host, const char *serv, const char *proto);
+  bool resolve(const char *host, int port, const char *proto);
+  bool resolve(const char *serv, const char *proto);
+  bool resolve(int port, const char *proto);
 
+  socklen_t getAddrSize() const { return sizeof(mAddrIn); }
+  sockaddr *getTempAddr() const { return (sockaddr *) &mTempAddrIn; }
 
-  bool resolve( const char *host, const char *serv, const char *proto );
-  bool resolve( const char *host, int port, const char *proto );
-  bool resolve( const char *serv, const char *proto );
-  bool resolve( int port, const char *proto );
+  static socklen_t addrSize() { return sizeof(sockaddr_in); }
 
-  socklen_t getAddrSize() const {
-    return( sizeof(mAddrIn) );
-  }
-  struct sockaddr *getTempAddr() const {
-    return( (sockaddr *)&mTempAddrIn );
-  }
-
-public:
-  static socklen_t addrSize() {
-    return( sizeof(sockaddr_in) );
-  }
+ private:
+  sockaddr_in mAddrIn;
+  sockaddr_in mTempAddrIn;
 };
 
 class SockAddrUnix : public SockAddr {
-private:
-  struct sockaddr_un  mAddrUn;
-  struct sockaddr_un  mTempAddrUn;
+ public:
+  SockAddrUnix() : SockAddr((sockaddr *) &mAddrUn) {}
+  SockAddrUnix(const SockAddrUnix &addr)
+      : SockAddr((const sockaddr *) &mAddrUn), mAddrUn(addr.mAddrUn) {}
+  explicit SockAddrUnix(const sockaddr_un *addr)
+      : SockAddr((const sockaddr *) &mAddrUn), mAddrUn(*addr) {}
 
-public:
-  SockAddrUnix();
-  SockAddrUnix( const SockAddrUnix &addr ) : SockAddr( (const struct sockaddr *)&mAddrUn ), mAddrUn( addr.mAddrUn ) {
-  }
-  explicit SockAddrUnix( const struct sockaddr_un *addr ) : SockAddr( (const struct sockaddr *)&mAddrUn ), mAddrUn( *addr ) {
-  }
+  bool resolve(const char *path, const char *proto);
 
-  bool resolve( const char *path, const char *proto );
+  socklen_t getAddrSize() const { return sizeof(mAddrUn); }
+  sockaddr *getTempAddr() const { return (sockaddr *) &mTempAddrUn; }
 
-  socklen_t getAddrSize() const {
-    return( sizeof(mAddrUn) );
-  }
-  struct sockaddr *getTempAddr() const {
-    return( (sockaddr *)&mTempAddrUn );
-  }
+  static socklen_t addrSize() { return sizeof(sockaddr_un); }
 
-public:
-  static socklen_t addrSize() {
-    return( sizeof(sockaddr_un) );
-  }
+ private:
+  sockaddr_un mAddrUn;
+  sockaddr_un mTempAddrUn;
 };
 
 class Socket : public CommsBase {
-protected:
-  typedef enum { CLOSED, DISCONNECTED, LISTENING, CONNECTED } State;
+ protected:
+  enum State { CLOSED, DISCONNECTED, LISTENING, CONNECTED };
 
-protected:
-  int  mSd;
-  State mState;
-  SockAddr *mLocalAddr;
-  SockAddr *mRemoteAddr;
+  Socket() : CommsBase(mSd, mSd),
+             mSd(-1),
+             mState(CLOSED),
+             mLocalAddr(nullptr),
+             mRemoteAddr(nullptr) {}
+  Socket(const Socket &socket, int newSd) : CommsBase(mSd, mSd),
+                                            mSd(newSd),
+                                            mState(CONNECTED),
+                                            mLocalAddr(nullptr),
+                                            mRemoteAddr(nullptr) {
+    if (socket.mLocalAddr)
+      mLocalAddr = SockAddr::newSockAddr(mLocalAddr);
+    if (socket.mRemoteAddr)
+      mRemoteAddr = SockAddr::newSockAddr(mRemoteAddr);
+  }
 
-protected:
-  Socket() : CommsBase( mSd, mSd ), mSd( -1 ), mState( CLOSED ), mLocalAddr( 0 ), mRemoteAddr( 0 ) {
-  }
-  Socket( const Socket &socket, int newSd ) : CommsBase( mSd, mSd ), mSd( newSd ), mState( CONNECTED ), mLocalAddr( 0 ), mRemoteAddr( 0 ) {
-    if ( socket.mLocalAddr )
-      mLocalAddr = SockAddr::newSockAddr( mLocalAddr );
-    if ( socket.mRemoteAddr )
-      mRemoteAddr = SockAddr::newSockAddr( mRemoteAddr );
-  }
   virtual ~Socket() {
     close();
     delete mLocalAddr;
     delete mRemoteAddr;
   }
 
-public:
-  bool isOpen() const {
-    return( !isClosed() );
-  }
-  bool isClosed() const {
-    return( mState == CLOSED );
-  }
-  bool isDisconnected() const {
-    return( mState == DISCONNECTED );
-  }
-  bool isConnected() const {
-    return( mState == CONNECTED );
-  }
+ public:
+  bool isOpen() const { return !isClosed(); }
+  bool isClosed() const { return mState == CLOSED; }
+  bool isDisconnected() const { return mState == DISCONNECTED; }
+  bool isConnected() const { return mState == CONNECTED; }
   virtual bool close();
 
-protected:
-  bool isListening() const {
-    return( mState == LISTENING );
+  virtual int send(const void *msg, int len) const {
+    ssize_t nBytes = ::send(mSd, msg, len, 0);
+    if (nBytes < 0) {
+      Debug(1, "Send of %d bytes on sd %d failed: %s", len, mSd, strerror(errno));
+    }
+    return nBytes;
   }
 
-protected:
+  virtual int recv(void *msg, int len) const {
+    ssize_t nBytes = ::recv(mSd, msg, len, 0);
+    if (nBytes < 0) {
+      Debug(1, "Recv of %d bytes max on sd %d failed: %s", len, mSd, strerror(errno));
+    }
+    return nBytes;
+  }
+
+  virtual int send(const std::string &msg) const {
+    ssize_t nBytes = ::send(mSd, msg.data(), msg.size(), 0);
+    if (nBytes < 0) {
+      Debug(1, "Send of string '%s' (%zd bytes) on sd %d failed: %s",
+            msg.c_str(),
+            msg.size(),
+            mSd,
+            strerror(errno));
+    }
+    return nBytes;
+  }
+
+  virtual int recv(std::string &msg) const {
+    char buffer[msg.capacity()];
+    int nBytes = 0;
+    if ((nBytes = ::recv(mSd, buffer, sizeof(buffer), 0)) < 0) {
+      Debug(1, "Recv of %zd bytes max to string on sd %d failed: %s", sizeof(buffer), mSd, strerror(errno));
+      return nBytes;
+    }
+    buffer[nBytes] = '\0';
+    msg = buffer;
+    return nBytes;
+  }
+
+  virtual int recv(std::string &msg, size_t maxLen) const {
+    char buffer[maxLen];
+    int nBytes = 0;
+    if ((nBytes = ::recv(mSd, buffer, sizeof(buffer), 0)) < 0) {
+      Debug(1, "Recv of %zd bytes max to string on sd %d failed: %s", maxLen, mSd, strerror(errno));
+      return nBytes;
+    }
+    buffer[nBytes] = '\0';
+    msg = buffer;
+    return nBytes;
+  }
+
+  virtual int bytesToRead() const;
+
+  int getDesc() const { return mSd; }
+  //virtual bool isOpen() const
+  //{
+  //return( mSd != -1 );
+  //}
+
+  virtual int getDomain() const = 0;
+  virtual int getType() const = 0;
+  virtual const char *getProtocol() const = 0;
+
+  const SockAddr *getLocalAddr() const { return mLocalAddr; }
+  const SockAddr *getRemoteAddr() const { return mRemoteAddr; }
+  virtual socklen_t getAddrSize() const = 0;
+
+  bool getBlocking(bool &blocking);
+  bool setBlocking(bool blocking);
+
+  bool getSendBufferSize(int &) const;
+  bool getRecvBufferSize(int &) const;
+
+  bool setSendBufferSize(int);
+  bool setRecvBufferSize(int);
+
+  bool getRouting(bool &) const;
+  bool setRouting(bool);
+
+  bool getNoDelay(bool &) const;
+  bool setNoDelay(bool);
+
+ protected:
+  bool isListening() const { return mState == LISTENING; }
+
   virtual bool socket();
   virtual bool bind();
 
-protected:
   virtual bool connect();
   virtual bool listen();
   virtual bool accept();
-  virtual bool accept( int & );
+  virtual bool accept(int &);
 
-public:
-  virtual int send( const void *msg, int len ) const {
-    ssize_t nBytes = ::send( mSd, msg, len, 0 );
-    if ( nBytes < 0 )
-      Debug( 1, "Send of %d bytes on sd %d failed: %s", len, mSd, strerror(errno) );
-    return( nBytes );
-  }
-  virtual int recv( void *msg, int len ) const {
-    ssize_t nBytes = ::recv( mSd, msg, len, 0 );
-    if ( nBytes < 0 )
-      Debug( 1, "Recv of %d bytes max on sd %d failed: %s", len, mSd, strerror(errno) );
-    return( nBytes );
-  }
-  virtual int send( const std::string &msg ) const {
-    ssize_t nBytes = ::send( mSd, msg.data(), msg.size(), 0 );
-    if ( nBytes < 0 )
-      Debug( 1, "Send of string '%s' (%zd bytes) on sd %d failed: %s", msg.c_str(), msg.size(), mSd, strerror(errno) );
-    return( nBytes );
-  }
-  virtual int recv( std::string &msg ) const {
-    char buffer[msg.capacity()];
-    int nBytes = 0;
-    if ( (nBytes = ::recv( mSd, buffer, sizeof(buffer), 0 )) < 0 ) {
-      Debug( 1, "Recv of %zd bytes max to string on sd %d failed: %s", sizeof(buffer), mSd, strerror(errno) );
-      return( nBytes );
-    }
-    buffer[nBytes] = '\0';
-    msg = buffer;
-    return( nBytes );
-  }
-  virtual int recv( std::string &msg, size_t maxLen ) const {
-    char buffer[maxLen];
-    int nBytes = 0;
-    if ( (nBytes = ::recv( mSd, buffer, sizeof(buffer), 0 )) < 0 ) {
-      Debug( 1, "Recv of %zd bytes max to string on sd %d failed: %s", maxLen, mSd, strerror(errno) );
-      return( nBytes );
-    }
-    buffer[nBytes] = '\0';
-    msg = buffer;
-    return( nBytes );
-  }
-  virtual int bytesToRead() const;
-
-  int getDesc() const {
-    return( mSd );
-  }
-  //virtual bool isOpen() const
-  //{
-    //return( mSd != -1 );
-  //}
-
-  virtual int getDomain() const=0;
-  virtual int getType() const=0;
-  virtual const char *getProtocol() const=0;
-
-  const SockAddr *getLocalAddr() const {
-    return( mLocalAddr );
-  }
-  const SockAddr *getRemoteAddr() const {
-    return( mRemoteAddr );
-  }
-  virtual socklen_t getAddrSize() const=0;
-
-  bool getBlocking( bool &blocking );
-  bool setBlocking( bool blocking );
-
-  bool getSendBufferSize( int & ) const;
-  bool getRecvBufferSize( int & ) const;
-
-  bool setSendBufferSize( int );
-  bool setRecvBufferSize( int );
-
-  bool getRouting( bool & ) const;
-  bool setRouting( bool );
-
-  bool getNoDelay( bool & ) const;
-  bool setNoDelay( bool );
+  int mSd;
+  State mState;
+  SockAddr *mLocalAddr;
+  SockAddr *mRemoteAddr;
 };
 
-class InetSocket : virtual public Socket
-{
-protected:
-    int mAddressFamily;
+class InetSocket : virtual public Socket {
+ public:
+  int getDomain() const { return mAddressFamily; }
+  virtual socklen_t getAddrSize() const { return SockAddrInet::addrSize(); }
 
-public:
-int getDomain() const {
-  return( mAddressFamily );
-}
-virtual socklen_t getAddrSize() const {
-  return( SockAddrInet::addrSize() );
-}
+ protected:
+  bool connect(const char *host, const char *serv);
+  bool connect(const char *host, int port);
 
-protected:
-  bool connect( const char *host, const char *serv );
-  bool connect( const char *host, int port );
+  bool bind(const char *host, const char *serv);
+  bool bind(const char *host, int port);
+  bool bind(const char *serv);
+  bool bind(int port);
 
-  bool bind( const char *host, const char *serv );
-  bool bind( const char *host, int port );
-  bool bind( const char *serv );
-  bool bind( int port );
+  int mAddressFamily;
 };
 
 class UnixSocket : virtual public Socket {
-public:
-  int getDomain() const {
-    return( AF_UNIX );
-  }
-  virtual socklen_t getAddrSize() const {
-    return( SockAddrUnix::addrSize() );
-  }
+ public:
+  int getDomain() const { return AF_UNIX; }
+  virtual socklen_t getAddrSize() const { return SockAddrUnix::addrSize(); }
 
-protected:
-  bool resolveLocal( const char *serv, const char *proto ) {
+ protected:
+  bool resolveLocal(const char *serv, const char *proto) {
     SockAddrUnix *addr = new SockAddrUnix;
     mLocalAddr = addr;
-    return( addr->resolve( serv, proto ) );
+    return addr->resolve(serv, proto);
   }
 
-  bool resolveRemote( const char *path, const char *proto ) {
+  bool resolveRemote(const char *path, const char *proto) {
     SockAddrUnix *addr = new SockAddrUnix;
     mRemoteAddr = addr;
-    return( addr->resolve( path, proto ) );
+    return addr->resolve(path, proto);
   }
 
-protected:
-  bool bind( const char *path ) {
-    if ( !UnixSocket::resolveLocal( path, getProtocol() ) )
-      return( false );
-    return( Socket::bind() );
+  bool bind(const char *path) {
+    if (!UnixSocket::resolveLocal(path, getProtocol()))
+      return false;
+    return Socket::bind();
   }
 
-  bool connect( const char *path ) {
-    if ( !UnixSocket::resolveRemote( path, getProtocol() ) )
-      return( false );
-    return( Socket::connect() );
+  bool connect(const char *path) {
+    if (!UnixSocket::resolveRemote(path, getProtocol()))
+      return false;
+    return Socket::connect();
   }
 };
 
 class UdpSocket : virtual public Socket {
-public:
-  int getType() const {
-    return( SOCK_DGRAM );
-  }
-  const char *getProtocol() const {
-    return( "udp" );
+ public:
+  int getType() const { return SOCK_DGRAM; }
+  const char *getProtocol() const { return "udp"; }
+
+  virtual int sendto(const void *msg, int len, const SockAddr *addr = nullptr) const {
+    ssize_t nBytes = ::sendto(mSd, msg, len, 0, addr ? addr->getAddr() : nullptr, addr ? addr->getAddrSize() : 0);
+    if (nBytes < 0) {
+      Debug(1, "Sendto of %d bytes on sd %d failed: %s", len, mSd, strerror(errno));
+    }
+    return nBytes;
   }
 
-public:
-  virtual int sendto( const void *msg, int len, const SockAddr *addr=nullptr ) const {
-    ssize_t nBytes = ::sendto( mSd, msg, len, 0, addr?addr->getAddr():nullptr, addr?addr->getAddrSize():0 );
-    if ( nBytes < 0 )
-      Debug( 1, "Sendto of %d bytes on sd %d failed: %s", len, mSd, strerror(errno) );
-    return( nBytes );
-  }
-  virtual int recvfrom( void *msg, int len, SockAddr *addr=0 ) const {
+  virtual int recvfrom(void *msg, int len, SockAddr *addr = nullptr) const {
     ssize_t nBytes = 0;
-    if ( addr ) {
-      struct sockaddr sockAddr;
+    if (addr) {
+      sockaddr sockAddr;
       socklen_t sockLen;
-      nBytes = ::recvfrom( mSd, msg, len, 0, &sockAddr, &sockLen );
-      if ( nBytes < 0 ) {
-        Debug( 1, "Recvfrom of %d bytes max on sd %d (with address) failed: %s", len, mSd, strerror(errno) );
+      nBytes = ::recvfrom(mSd, msg, len, 0, &sockAddr, &sockLen);
+      if (nBytes < 0) {
+        Debug(1, "Recvfrom of %d bytes max on sd %d (with address) failed: %s", len, mSd, strerror(errno));
       }
     } else {
-      nBytes = ::recvfrom( mSd, msg, len, 0, nullptr, 0 );
-      if ( nBytes < 0 )
-        Debug( 1, "Recvfrom of %d bytes max on sd %d (no address) failed: %s", len, mSd, strerror(errno) );
+      nBytes = ::recvfrom(mSd, msg, len, 0, nullptr, nullptr);
+      if (nBytes < 0) {
+        Debug(1, "Recvfrom of %d bytes max on sd %d (no address) failed: %s", len, mSd, strerror(errno));
+      }
     }
-    return( nBytes );
+    return nBytes;
   }
 };
 
 class UdpInetSocket : virtual public UdpSocket, virtual public InetSocket {
-public:
-  bool bind( const char *host, const char *serv ) {
-    return( InetSocket::bind( host, serv ) );
-  }
-  bool bind( const char *host, int port ) {
-    return( InetSocket::bind( host, port ) );
-  }
-  bool bind( const char *serv ) {
-    return( InetSocket::bind( serv ) );
-  }
-  bool bind( int port ) {
-    return( InetSocket::bind( port ) );
+ public:
+  bool bind(const char *host, const char *serv) {
+    return InetSocket::bind(host, serv);
   }
 
-  bool connect( const char *host, const char *serv ) {
-    return( InetSocket::connect( host, serv ) );
+  bool bind(const char *host, int port) {
+    return InetSocket::bind(host, port);
   }
-  bool connect( const char *host, int port ) {
-    return( InetSocket::connect( host, port ) );
+
+  bool bind(const char *serv) {
+    return InetSocket::bind(serv);
+  }
+
+  bool bind(int port) {
+    return InetSocket::bind(port);
+  }
+
+  bool connect(const char *host, const char *serv) {
+    return InetSocket::connect(host, serv);
+  }
+
+  bool connect(const char *host, int port) {
+    return InetSocket::connect(host, port);
   }
 };
 
 class UdpUnixSocket : virtual public UdpSocket, virtual public UnixSocket {
-public:
-  bool bind( const char *path ) {
-    return( UnixSocket::bind( path ) );
+ public:
+  bool bind(const char *path) {
+    return UnixSocket::bind(path);
   }
 
-  bool connect( const char *path ) {
-    return( UnixSocket::connect( path ) );
+  bool connect(const char *path) {
+    return UnixSocket::connect(path);
   }
 };
 
 class UdpInetClient : public UdpInetSocket {
-public:
-  bool connect( const char *host, const char *serv ) {
-    return( UdpInetSocket::connect( host, serv ) );
+ public:
+  bool connect(const char *host, const char *serv) {
+    return UdpInetSocket::connect(host, serv);
   }
-  bool connect( const char *host, int port ) {
-    return( UdpInetSocket::connect( host, port ) );
+
+  bool connect(const char *host, int port) {
+    return UdpInetSocket::connect(host, port);
   }
 };
 
 class UdpUnixClient : public UdpUnixSocket {
-public:
-  bool bind( const char *path ) {
-    return( UdpUnixSocket::bind( path ) );
+ public:
+  bool bind(const char *path) {
+    return UdpUnixSocket::bind(path);
   }
 
-public:
-  bool connect( const char *path ) {
-    return( UdpUnixSocket::connect( path) );
+  bool connect(const char *path) {
+    return UdpUnixSocket::connect(path);
   }
 };
 
 class UdpInetServer : public UdpInetSocket {
-public:
-  bool bind( const char *host, const char *serv ) {
-    return( UdpInetSocket::bind( host, serv ) );
-  }
-  bool bind( const char *host, int port ) {
-    return( UdpInetSocket::bind( host, port ) );
-  }
-  bool bind( const char *serv ) {
-    return( UdpInetSocket::bind( serv ) );
-  }
-  bool bind( int port ) {
-    return( UdpInetSocket::bind( port ) );
+ public:
+  bool bind(const char *host, const char *serv) {
+    return UdpInetSocket::bind(host, serv);
   }
 
-protected:
-  bool connect( const char *host, const char *serv ) {
-    return( UdpInetSocket::connect( host, serv ) );
+  bool bind(const char *host, int port) {
+    return UdpInetSocket::bind(host, port);
   }
-  bool connect( const char *host, int port ) {
-    return( UdpInetSocket::connect( host, port ) );
+
+  bool bind(const char *serv) {
+    return UdpInetSocket::bind(serv);
+  }
+
+  bool bind(int port) {
+    return UdpInetSocket::bind(port);
+  }
+
+ protected:
+  bool connect(const char *host, const char *serv) {
+    return UdpInetSocket::connect(host, serv);
+  }
+
+  bool connect(const char *host, int port) {
+    return UdpInetSocket::connect(host, port);
   }
 };
 
 class UdpUnixServer : public UdpUnixSocket {
-public:
-  bool bind( const char *path ) {
-    return( UdpUnixSocket::bind( path ) );
+ public:
+  bool bind(const char *path) {
+    return UdpUnixSocket::bind(path);
   }
 
-protected:
-  bool connect( const char *path ) {
-    return( UdpUnixSocket::connect( path ) );
+ protected:
+  bool connect(const char *path) {
+    return UdpUnixSocket::connect(path);
   }
 };
 
 class TcpSocket : virtual public Socket {
-public:
-  TcpSocket() {
-  }
-  TcpSocket( const TcpSocket &socket, int newSd ) : Socket( socket, newSd ) {
-  }
+ public:
+  TcpSocket() {}
+  TcpSocket(const TcpSocket &socket, int newSd) : Socket(socket, newSd) {}
 
-public:
-  int getType() const {
-    return( SOCK_STREAM );
-  }
-  const char *getProtocol() const {
-    return( "tcp" );
-  }
+  int getType() const { return SOCK_STREAM; }
+  const char *getProtocol() const { return "tcp"; }
 };
 
 class TcpInetSocket : virtual public TcpSocket, virtual public InetSocket {
-public:
-  TcpInetSocket() {
-  }
-  TcpInetSocket( const TcpInetSocket &socket, int newSd ) : TcpSocket( socket, newSd ) {
-  }
+ public:
+  TcpInetSocket() {}
+  TcpInetSocket(const TcpInetSocket &socket, int newSd)
+      : TcpSocket(socket, newSd) {}
 };
 
 class TcpUnixSocket : virtual public TcpSocket, virtual public UnixSocket {
-public:
-  TcpUnixSocket() {
-  }
-  TcpUnixSocket( const TcpUnixSocket &socket, int newSd ) : TcpSocket( socket, newSd ) {
-  }
+ public:
+  TcpUnixSocket() {}
+  TcpUnixSocket(const TcpUnixSocket &socket, int newSd)
+      : TcpSocket(socket, newSd) {}
 };
 
 class TcpInetClient : public TcpInetSocket {
-public:
-  bool connect( const char *host, const char *serv ) {
-    return( TcpInetSocket::connect( host, serv ) );
+ public:
+  bool connect(const char *host, const char *serv) {
+    return TcpInetSocket::connect(host, serv);
   }
-  bool connect( const char *host, int port ) {
-    return( TcpInetSocket::connect( host, port ) );
+
+  bool connect(const char *host, int port) {
+    return TcpInetSocket::connect(host, port);
   }
 };
 
 class TcpUnixClient : public TcpUnixSocket {
-public:
-  bool connect( const char *path ) {
-    return( TcpUnixSocket::connect( path) );
-  }
+ public:
+  bool connect(const char *path) { return TcpUnixSocket::connect(path); }
 };
 
 class TcpInetServer : public TcpInetSocket {
-public:
-  bool bind( int port ) {
-    return( TcpInetSocket::bind( port ) );
-  }
+ public:
+  bool bind(int port) { return TcpInetSocket::bind(port); }
 
-public:
-  bool isListening() const { return( Socket::isListening() ); }
+  bool isListening() const { return Socket::isListening(); }
   bool listen();
   bool accept();
-  bool accept( TcpInetSocket *&newSocket );
+  bool accept(TcpInetSocket *&newSocket);
 };
 
 class TcpUnixServer : public TcpUnixSocket {
-public:
-  bool bind( const char *path ) {
-    return( TcpUnixSocket::bind( path ) );
-  }
+ public:
+  bool bind(const char *path) { return TcpUnixSocket::bind(path); }
 
-public:
-  bool isListening() const { return( Socket::isListening() ); }
+  bool isListening() const { return Socket::isListening(); }
   bool listen();
   bool accept();
-  bool accept( TcpUnixSocket *&newSocket );
+  bool accept(TcpUnixSocket *&newSocket);
 };
 
 class Select {
-public:
+ public:
   typedef std::set<CommsBase *> CommsSet;
   typedef std::vector<CommsBase *> CommsList;
 
-protected:
-  CommsSet    mReaders;
-  CommsSet    mWriters;
-  CommsList     mReadable;
-  CommsList     mWriteable;
-  bool      mHasTimeout;
-  struct timeval  mTimeout;
-  int       mMaxFd;
+  Select() : mHasTimeout(false), mMaxFd(-1) {}
+  explicit Select(timeval timeout) : mMaxFd(-1) { setTimeout(timeout); }
+  explicit Select(int timeout) : mMaxFd(-1) { setTimeout(timeout); }
+  explicit Select(double timeout) : mMaxFd(-1) { setTimeout(timeout); }
 
-public:
-  Select();
-  explicit Select( struct timeval timeout );
-  explicit Select( int timeout );
-  explicit Select( double timeout );
-
-  void setTimeout( int timeout );
-  void setTimeout( double timeout );
-  void setTimeout( struct timeval timeout );
+  void setTimeout(int timeout);
+  void setTimeout(double timeout);
+  void setTimeout(timeval timeout);
   void clearTimeout();
 
   void calcMaxFd();
 
-  bool addReader( CommsBase *comms );
-  bool deleteReader( CommsBase *comms );
+  bool addReader(CommsBase *comms);
+  bool deleteReader(CommsBase *comms);
   void clearReaders();
 
-  bool addWriter( CommsBase *comms );
-  bool deleteWriter( CommsBase *comms );
+  bool addWriter(CommsBase *comms);
+  bool deleteWriter(CommsBase *comms);
   void clearWriters();
 
   int wait();
 
-  const CommsList &getReadable() const;
-  const CommsList &getWriteable() const;
+  const CommsList &getReadable() const { return mReadable; }
+  const CommsList &getWriteable() const { return mWriteable; }
+
+ protected:
+  CommsSet mReaders;
+  CommsSet mWriters;
+  CommsList mReadable;
+  CommsList mWriteable;
+  bool mHasTimeout;
+  timeval mTimeout;
+  int mMaxFd;
 };
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@
 include(Catch)
 
 set(TEST_SOURCES
+  zm_comms.cpp
   zm_crypt.cpp
   zm_utils.cpp)
 

--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -260,7 +260,7 @@ TEST_CASE("ZM::TcpInetClient basics") {
   REQUIRE(client.isDisconnected() == false);
 }
 
-TEST_CASE("ZM::TcpInetServer basics") {
+TEST_CASE("ZM::TcpInetServer basics", "[notCI]") {
   ZM::TcpInetServer server;
   REQUIRE(server.isClosed() == true);
   REQUIRE(server.isOpen() == false);
@@ -286,7 +286,7 @@ TEST_CASE("ZM::TcpInetServer basics") {
   }
 }
 
-TEST_CASE("ZM::TcpInetClient/Server send/recv") {
+TEST_CASE("ZM::TcpInetClient/Server send/recv", "[notCI]") {
   ZM::TcpInetServer server;
   ZM::TcpInetClient client;
 

--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -18,6 +18,7 @@
 #include "catch2/catch.hpp"
 
 #include "zm_comms.h"
+#include <array>
 
 TEST_CASE("ZM::Pipe basics") {
   ZM::Pipe pipe;
@@ -59,5 +60,34 @@ TEST_CASE("ZM::Pipe basics") {
   SECTION("setBlocking") {
     REQUIRE(pipe.setBlocking(true) == true);
     REQUIRE(pipe.setBlocking(false) == true);
+  }
+}
+
+TEST_CASE("ZM::Pipe read/write") {
+  ZM::Pipe pipe;
+
+  std::array<char, 3> msg = {'a', 'b', 'c'};
+  std::array<char, msg.size()> rcv{};
+
+  SECTION("read/write on non-opened pipe") {
+    REQUIRE(pipe.write(msg.data(), msg.size()) == -1);
+    REQUIRE(pipe.read(rcv.data(), rcv.size()) == -1);
+  }
+
+  SECTION("read/write on opened pipe") {
+    REQUIRE(pipe.open() == true);
+
+    REQUIRE(pipe.write(msg.data(), msg.size()) == msg.size());
+    REQUIRE(pipe.read(rcv.data(), rcv.size()) == msg.size());
+
+    REQUIRE(rcv == msg);
+  }
+
+  SECTION("read/write on closed pipe") {
+    REQUIRE(pipe.open() == true);
+    REQUIRE(pipe.close() == true);
+
+    REQUIRE(pipe.write(msg.data(), msg.size()) == -1);
+    REQUIRE(pipe.read(rcv.data(), rcv.size()) == -1);
   }
 }

--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -91,3 +91,35 @@ TEST_CASE("ZM::Pipe read/write") {
     REQUIRE(pipe.read(rcv.data(), rcv.size()) == -1);
   }
 }
+
+TEST_CASE("ZM::SockAddrInet") {
+  ZM::SockAddrInet addr;
+  REQUIRE(addr.getAddrSize() == sizeof(sockaddr_in));
+
+  SECTION("resolve") {
+    addr.resolve(80, "");
+    REQUIRE(addr.getDomain() == AF_INET);
+
+    SECTION("newSockAddr from resolved addr") {
+      ZM::SockAddr *addr2 = ZM::SockAddr::newSockAddr(&addr);
+      REQUIRE(addr2->getDomain() == AF_INET);
+      REQUIRE(addr2->getAddrSize() == sizeof(sockaddr_in));
+    }
+  }
+}
+
+TEST_CASE("ZM::SockAddrUnix") {
+  ZM::SockAddrUnix addr;
+  REQUIRE(addr.getAddrSize() == sizeof(sockaddr_un));
+
+  SECTION("resovle") {
+    addr.resolve("/", "");
+    REQUIRE(addr.getDomain() == AF_UNIX);
+
+    SECTION("newSockAddr from resolved addr") {
+      ZM::SockAddr *addr2 = ZM::SockAddr::newSockAddr(&addr);
+      REQUIRE(addr2->getDomain() == AF_UNIX);
+      REQUIRE(addr2->getAddrSize() == sizeof(sockaddr_un));
+    }
+  }
+}

--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "catch2/catch.hpp"
+
+#include "zm_comms.h"
+
+TEST_CASE("ZM::Pipe basics") {
+  ZM::Pipe pipe;
+
+  SECTION("setBlocking on non-opened") {
+    REQUIRE(pipe.setBlocking(true) == false);
+    REQUIRE(pipe.setBlocking(false) == false);
+  }
+
+  REQUIRE(pipe.open() == true);
+
+  REQUIRE(pipe.isOpen() == true);
+  REQUIRE(pipe.isClosed() == false);
+  REQUIRE(pipe.getReadDesc() != -1);
+  REQUIRE(pipe.getWriteDesc() != -1);
+
+  SECTION("double open") {
+    REQUIRE(pipe.open() == true); // is this expected?
+  }
+
+  SECTION("close") {
+    REQUIRE(pipe.close() == true);
+
+    REQUIRE(pipe.isOpen() == false);
+    REQUIRE(pipe.isClosed() == true);
+    REQUIRE(pipe.getReadDesc() == -1);
+    REQUIRE(pipe.getWriteDesc() == -1);
+
+    SECTION("double close") {
+      REQUIRE(pipe.close() == true);
+    }
+
+    SECTION("setBlocking on closed") {
+      REQUIRE(pipe.setBlocking(true) == false);
+      REQUIRE(pipe.setBlocking(false) == false);
+    }
+  }
+
+  SECTION("setBlocking") {
+    REQUIRE(pipe.setBlocking(true) == true);
+    REQUIRE(pipe.setBlocking(false) == true);
+  }
+}

--- a/zmconfgen.pl.in
+++ b/zmconfgen.pl.in
@@ -30,7 +30,7 @@ use ZoneMinder::ConfigData qw/:data/;
 
 $| = 1;
 
-my $config_header = '@CMAKE_CURRENT_BINARY_DIR@/src/zm_config_defines.h';
+my $config_header = '@CMAKE_BINARY_DIR@/zm_config_defines.h';
 my $config_sql = '@CMAKE_CURRENT_BINARY_DIR@/db/zm_create.sql';
 
 generateConfigFiles();


### PR DESCRIPTION
Give `zm_comms.{h,cpp}` an auto-format treatment and add some basic unit tests.
Also enable `Woverloaded-virtual` warnings on GCC (they are on per default on clang).