### PR TITLE
SessionDescriptor: Fix a ffmpeg deprecation warning

### DIFF
--- a/src/zm_sdp.cpp
+++ b/src/zm_sdp.cpp
@@ -352,8 +352,6 @@ AVFormatContext *SessionDescriptor::generateFormatContext() const {
 
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
     AVCodecContext *codec_context = avcodec_alloc_context3(nullptr);
-    //avcodec_parameters_to_context(codec_context, stream->codecpar);
-    stream->codec = codec_context;
 #else
     AVCodecContext *codec_context = stream->codec;
 #endif


### PR DESCRIPTION
AVStream::codec is deprecated. The replacement AVStream::codecpar is initialized at the end of the method from the codec context.