### PR TITLE
CI: Run basic CI for Xenial

### DIFF
--- a/.github/workflows/ci-xenial.yml
+++ b/.github/workflows/ci-xenial.yml
@@ -1,0 +1,25 @@
+name: CI Xenial
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: sudo apt-get install libavdevice-dev libcurl4-gnutls-dev libvlc-dev libvncserver-dev libdate-manip-perl libdbd-mysql-perl libsys-mmap-perl libpolkit-gobject-1-dev
+      - name: Prepare
+        run: mkdir build
+      - name: Configure
+        run: cd build && cmake .. -DBUILD_MAN=0
+      - name: Build
+        run: cd build && make -j3 | grep --line-buffered -Ev '^(cp lib\/|Installing.+\.pm)' && (exit ${PIPESTATUS[0]})


### PR DESCRIPTION
Tests can't be built since Catch2 is only packaged for Groovy (20.10)