### PR TITLE
Monitor: Fix a crash when destroying a monitor (shutdown)

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -3116,6 +3116,9 @@ int Monitor::PrimeCapture() {
 int Monitor::PreCapture() const { return camera->PreCapture(); }
 int Monitor::PostCapture() const { return camera->PostCapture(); }
 int Monitor::Close() {
+  if (close_event_thread.joinable()) {
+    close_event_thread.join();
+  }
   // Because the stream indexes may change we have to clear out the packetqueue
   if (decoder) {
     decoder->Stop();


### PR DESCRIPTION
We have to make sure close_event_thread is joined before we destroy the thread object,
otherwise std::terminate will be called.