### PR TITLE
Fix logging format string mismatches

### DIFF
--- a/src/zm_analysis_thread.cpp
+++ b/src/zm_analysis_thread.cpp
@@ -24,7 +24,8 @@ void AnalysisThread::Start() {
 void AnalysisThread::Run() {
   Microseconds analysis_rate = Microseconds(monitor_->GetAnalysisRate());
   Seconds analysis_update_delay = Seconds(monitor_->GetAnalysisUpdateDelay());
-  Debug(2, "AnalysisThread::Run() have update delay %d", analysis_update_delay);
+  Debug(2, "AnalysisThread::Run() has an update delay of %" PRId64 "s",
+        static_cast<int64>(analysis_update_delay.count()));
 
   monitor_->UpdateAdaptiveSkip();
 

--- a/src/zm_curl_camera.cpp
+++ b/src/zm_curl_camera.cpp
@@ -100,7 +100,7 @@ void cURLCamera::Initialise() {
   /* cURL initialization */
   CURLcode cRet = (*curl_global_init_f)(CURL_GLOBAL_ALL);
   if(cRet != CURLE_OK) {
-    Error("libcurl initialization failed: ", (*curl_easy_strerror_f)(cRet));
+    Error("libcurl initialization failed: %s", (*curl_easy_strerror_f)(cRet));
     dlclose(curl_lib);
     return;
   }
@@ -432,7 +432,7 @@ void* cURLCamera::thread_func() {
   /* Set URL */
   cRet = (*curl_easy_setopt_f)(c, CURLOPT_URL, mPath.c_str());
   if(cRet != CURLE_OK) {
-    Error("Failed setting libcurl URL: %s", *(curl_easy_strerror_f)(cRet));
+    Error("Failed setting libcurl URL: %s", (*curl_easy_strerror_f)(cRet));
     tRet = -52;
     return (void*)tRet;
   }
@@ -468,7 +468,7 @@ void* cURLCamera::thread_func() {
   /* Progress callback */
   cRet = (*curl_easy_setopt_f)(c, CURLOPT_NOPROGRESS, 0);
   if(cRet != CURLE_OK) {
-    Error("Failed enabling libcurl progress callback function: %s", (*curl_easy_strerror_f)(cRet));  
+    Error("Failed enabling libcurl progress callback function: %s", (*curl_easy_strerror_f)(cRet));
     tRet = -57;
     return (void*)tRet;
   }

--- a/src/zm_define.h
+++ b/src/zm_define.h
@@ -39,8 +39,6 @@ typedef std::uint32_t uint32;
 typedef std::uint16_t uint16;
 typedef std::uint8_t uint8;
 
-#define SZFMTD "%" PRIuPTR
-
 #ifndef FALLTHROUGH
 #if defined(__clang__)
 #define FALLTHROUGH [[clang::fallthrough]]

--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -66,7 +66,7 @@ void log_libav_callback(void *ptr, int level, const char *fmt, va_list vargs) {
       if (static_cast<size_t>(length) > sizeof(logString)-1) length = sizeof(logString)-1;
       // ffmpeg logs have a carriage return, so replace it with terminator
       logString[length-1] = 0;
-      log->logPrint(false, __FILE__, __LINE__, log_level, logString);
+      log->logPrint(false, __FILE__, __LINE__, log_level, "%s", logString);
     } else {
       log->logPrint(false, __FILE__, __LINE__, AV_LOG_ERROR, "Can't encode log from av. fmt was %s", fmt);
     }
@@ -636,8 +636,7 @@ int zm_resample_audio(
         av_make_error_string(ret).c_str());
     return 0;
   }
-  Debug(3,"swr_get_delay %d",
-      swr_get_delay(resample_ctx, out_frame->sample_rate));
+  Debug(3, "swr_get_delay %" PRIi64, swr_get_delay(resample_ctx, out_frame->sample_rate));
 #else
 #if defined(HAVE_LIBAVRESAMPLE)
   if (!in_frame) {

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -308,15 +308,13 @@ void zm_dump_codec(const AVCodecContext *codec);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
 void zm_dump_codecpar(const AVCodecParameters *par);
 #endif
-#define zm_dump_frame(frame, text) Debug(1, "%s: format %d %s sample_rate %" PRIu32 " nb_samples %d channels %d" \
-      " duration %" PRId64 \
-      " layout %d pts %" PRId64, \
+#define zm_dump_frame(frame, text) Debug(1, "%s: format %d %s sample_rate %" PRIu32 " nb_samples %d" \
+      " layout %" PRIu64 " pts %" PRId64, \
       text, \
       frame->format, \
       av_get_sample_fmt_name((AVSampleFormat)frame->format), \
       frame->sample_rate, \
       frame->nb_samples, \
-      0, 0, \
       frame->channel_layout, \
       frame->pts \
       );

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -623,7 +623,9 @@ int FfmpegCamera::FfmpegInterruptCallback(void *ctx) {
   }
   time_t now = time(nullptr);
   if (now - start_read_time > 10) {
-    Debug(1, "timeout in ffmpeg camera now %d - %d > 10", now, start_read_time);
+    Debug(1, "timeout in ffmpeg camera now %" PRIi64 " - %" PRIi64 " > 10",
+          static_cast<int64>(now),
+          static_cast<int64>(start_read_time));
     return 1;
   }
   return 0;

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -647,7 +647,7 @@ void Image::AssignDirect(
     return;
   }
 
-  unsigned int new_buffer_size = p_width * p_height * p_colours;
+  size_t new_buffer_size = p_width * p_height * p_colours;
 
   if ( buffer_size < new_buffer_size ) {
     Error("Attempt to directly assign buffer from an undersized buffer of size: %zu, needed %dx%d*%d colours = %zu",

--- a/src/zm_libvlc_camera.cpp
+++ b/src/zm_libvlc_camera.cpp
@@ -227,11 +227,11 @@ int LibvlcCamera::PrimeCapture() {
 
   if ( opVect.size() > 0 ) {
     mOptArgV = new char*[opVect.size()];
-    Debug(2, "Number of Options: %d",opVect.size());
+    Debug(2, "Number of Options: %zu", opVect.size());
     for (size_t i=0; i< opVect.size(); i++) {
       opVect[i] = TrimSpaces(opVect[i]);
       mOptArgV[i] = (char *)opVect[i].c_str();
-      Debug(2, "set option %d to '%s'", i,  opVect[i].c_str());
+      Debug(2, "set option %zu to '%s'", i, opVect[i].c_str());
     }
   }
 
@@ -319,9 +319,9 @@ void LibvlcCamera::log_callback(void *ptr, int level, const libvlc_log_t *ctx, c
   }
 
   if ( log ) {
-    char            logString[8192];
-    vsnprintf(logString, sizeof(logString)-1, fmt, vargs);
-    log->logPrint(false, __FILE__, __LINE__, log_level, logString);
+    char logString[8192];
+    vsnprintf(logString, sizeof(logString) - 1, fmt, vargs);
+    log->logPrint(false, __FILE__, __LINE__, log_level, "%s", logString);
   }
 }
 #endif // HAVE_LIBVLC

--- a/src/zm_libvnc_camera.cpp
+++ b/src/zm_libvnc_camera.cpp
@@ -44,7 +44,7 @@ static void GotFrameBufferUpdateCallback(rfbClient *rfb, int x, int y, int w, in
 }
 
 static char* GetPasswordCallback(rfbClient* cl) {
-  Debug(1, "Getcredentials: %s", (*rfbClientGetClientData_f)(cl, &TAG_1));
+  Debug(1, "Getcredentials: %s", static_cast<char *>((*rfbClientGetClientData_f)(cl, &TAG_1)));
   return strdup((const char *)(*rfbClientGetClientData_f)(cl, &TAG_1));
 }
 
@@ -55,7 +55,9 @@ static rfbCredential* GetCredentialsCallback(rfbClient* cl, int credentialType){
   }
   rfbCredential *c = (rfbCredential *)malloc(sizeof(rfbCredential));
 
-  Debug(1, "Getcredentials: %s:%s", (*rfbClientGetClientData_f)(cl, &TAG_1), (*rfbClientGetClientData_f)(cl, &TAG_2));
+  Debug(1, "Getcredentials: %s:%s",
+        static_cast<char *>((*rfbClientGetClientData_f)(cl, &TAG_1)),
+        static_cast<char *>((*rfbClientGetClientData_f)(cl, &TAG_2)));
   c->userCredential.password = strdup((const char *)(*rfbClientGetClientData_f)(cl, &TAG_1));
   c->userCredential.username = strdup((const char *)(*rfbClientGetClientData_f)(cl, &TAG_2));
   return c;

--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -665,7 +665,7 @@ LocalCamera::LocalCamera(
     unsigned int pSize = avpicture_get_size(imagePixFormat, width, height);
 #endif
     if ( pSize != imagesize ) {
-      Fatal("Image size mismatch. Required: %d Available: %u", pSize, imagesize);
+      Fatal("Image size mismatch. Required: %d Available: %llu", pSize, imagesize);
     }
 
     imgConversionContext = sws_getContext(

--- a/src/zm_logger.cpp
+++ b/src/zm_logger.cpp
@@ -415,7 +415,7 @@ void Logger::closeSyslog() {
   (void) closelog();
 }
 
-void Logger::logPrint(bool hex, const char * const filepath, const int line, const int level, const char *fstring, ...) {
+void Logger::logPrint(bool hex, const char *filepath, int line, int level, const char *fstring, ...) {
   if (level > mEffectiveLevel) return;
   if (level < PANIC || level > DEBUG9)
     Panic("Invalid logger level %d", level);

--- a/src/zm_logger.h
+++ b/src/zm_logger.h
@@ -173,8 +173,13 @@ private:
   void closeSyslog();
   void closeDatabase();
 
-public:
-  void logPrint(bool hex, const char * const filepath, const int line, const int level, const char *fstring, ...);
+ public:
+  void logPrint(bool hex,
+                const char *filepath,
+                int line,
+                int level,
+                const char *fstring,
+                ...) __attribute__((format(printf, 6, 7)));
 };
 
 void logInit(const char *name, const Logger::Options &options=Logger::Options());

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -439,10 +439,14 @@ public:
 
   inline int ShmValid() const {
     if ( shared_data && shared_data->valid ) {
-      struct timeval now;
+      timeval now = {};
       gettimeofday(&now, nullptr);
-      Debug(3, "Shared data is valid, checking heartbeat %u - %u = %d < %f",
-          now.tv_sec, shared_data->zmc_heartbeat_time, (now.tv_sec - shared_data->zmc_heartbeat_time), config.watch_max_delay);
+      Debug(3, "Shared data is valid, checking heartbeat %" PRIi64 " - %" PRIi64 " = %" PRIi64"  < %f",
+            static_cast<int64>(now.tv_sec),
+            static_cast<int64>(shared_data->zmc_heartbeat_time),
+            static_cast<int64>(now.tv_sec - shared_data->zmc_heartbeat_time),
+            config.watch_max_delay);
+
       if ((now.tv_sec - shared_data->zmc_heartbeat_time) < config.watch_max_delay)
         return true;
     }

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -795,14 +795,17 @@ void MonitorStream::runStream() {
     if ( sleep_time > MonitorStream::MAX_SLEEP_USEC ) {
       // Shouldn't sleep for long because we need to check command queue, etc.
       sleep_time = MonitorStream::MAX_SLEEP_USEC;
-      Debug(3, "Sleeping for MAX_SLEEP_USEC %dus", sleep_time);
+      Debug(3, "Sleeping for MAX_SLEEP_USEC %luus", sleep_time);
     } else {
-      Debug(3, "Sleeping for %dus", sleep_time);
+      Debug(3, "Sleeping for %luus", sleep_time);
     }
     usleep(sleep_time);
     if ( ttl ) {
       if ( (now.tv_sec - stream_start_time) > ttl ) {
-        Debug(2, "now(%d) - start(%d) > ttl(%d) break", now.tv_sec, stream_start_time, ttl);
+        Debug(2, "now(%" PRIi64 ") - start(%" PRIi64 " ) > ttl(%" PRIi64 ") break",
+              static_cast<int64>(now.tv_sec),
+              static_cast<int64>(stream_start_time),
+              static_cast<int64>(ttl));
         break;
       }
     }

--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -101,7 +101,7 @@ void VideoStream::SetupFormat( ) {
 	ofc = s;
 #endif
 	if ( !ofc ) {
-		Fatal("avformat_alloc_..._context failed: %d", ofc);
+		Fatal("avformat_alloc_..._context failed");
 	}
 
 	of = ofc->oformat;

--- a/src/zm_packetqueue.cpp
+++ b/src/zm_packetqueue.cpp
@@ -121,8 +121,14 @@ bool PacketQueue::queuePacket(ZMPacket* add_packet) {
 
             pktQueue.pop_front();
             packet_counts[zm_packet->packet.stream_index] -= 1;
-            Debug(1, "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%d",
-                zm_packet->packet.stream_index, zm_packet->image_index, zm_packet->keyframe, packet_counts[video_stream_id], max_video_packet_count, pktQueue.size());
+            Debug(1,
+                  "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
+                  zm_packet->packet.stream_index,
+                  zm_packet->image_index,
+                  zm_packet->keyframe,
+                  packet_counts[video_stream_id],
+                  max_video_packet_count,
+                  pktQueue.size());
             delete zm_packet;
           } // end while
         }
@@ -216,8 +222,14 @@ void PacketQueue::clearPackets(ZMPacket *add_packet) {
 
       pktQueue.pop_front();
       packet_counts[zm_packet->packet.stream_index] -= 1;
-      Debug(1, "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%d",
-          zm_packet->packet.stream_index, zm_packet->image_index, zm_packet->keyframe, packet_counts[video_stream_id], pre_event_video_packet_count, pktQueue.size());
+      Debug(1,
+            "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
+            zm_packet->packet.stream_index,
+            zm_packet->image_index,
+            zm_packet->keyframe,
+            packet_counts[video_stream_id],
+            pre_event_video_packet_count,
+            pktQueue.size());
       delete zm_packet;
     } // end while
     return;
@@ -276,8 +288,14 @@ void PacketQueue::clearPackets(ZMPacket *add_packet) {
         continue;
       }
 
-      Debug(1, "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%d",
-          zm_packet->packet.stream_index, zm_packet->image_index, zm_packet->keyframe, packet_counts[video_stream_id], pre_event_video_packet_count, pktQueue.size());
+      Debug(1,
+            "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
+            zm_packet->packet.stream_index,
+            zm_packet->image_index,
+            zm_packet->keyframe,
+            packet_counts[video_stream_id],
+            pre_event_video_packet_count,
+            pktQueue.size());
       pktQueue.pop_front();
       packet_counts[zm_packet->packet.stream_index] -= 1;
       delete zm_packet;
@@ -289,7 +307,7 @@ void PacketQueue::clearPackets(ZMPacket *add_packet) {
 } // end voidPacketQueue::clearPackets(ZMPacket* zm_packet)
 
 ZMLockedPacket* PacketQueue::popPacket( ) {
-  Debug(4, "pktQueue size %d", pktQueue.size());
+  Debug(4, "pktQueue size %zu", pktQueue.size());
 	if ( pktQueue.empty() ) {
 		return nullptr;
 	}
@@ -328,7 +346,7 @@ ZMLockedPacket* PacketQueue::popPacket( ) {
  */
 
 unsigned int PacketQueue::clear(unsigned int frames_to_keep, int stream_id) {
-  Debug(3, "Clearing all but %d frames, queue has %d", frames_to_keep, pktQueue.size());
+  Debug(3, "Clearing all but %d frames, queue has %zu", frames_to_keep, pktQueue.size());
 
 	if ( pktQueue.empty() ) {
     return 0;
@@ -372,8 +390,8 @@ unsigned int PacketQueue::clear(unsigned int frames_to_keep, int stream_id) {
 
   // Else not at beginning, are pointing at packet before the last video packet
   while ( pktQueue.begin() != it ) {
-    Debug(4, "Deleting a packet from the front, count is (%d), queue size is %d",
-        delete_count, pktQueue.size());
+    Debug(4, "Deleting a packet from the front, count is (%d), queue size is %zu",
+          delete_count, pktQueue.size());
     zm_packet = pktQueue.front();
     for (
         std::list<packetqueue_iterator *>::iterator iterators_it = iterators.begin();
@@ -394,7 +412,7 @@ unsigned int PacketQueue::clear(unsigned int frames_to_keep, int stream_id) {
 
     delete_count += 1;
   } // while our iterator is not the first packet
-  Debug(3, "Deleted %d packets, %d remaining", delete_count, pktQueue.size());
+  Debug(3, "Deleted %d packets, %zu remaining", delete_count, pktQueue.size());
   return delete_count; 
 } // end unsigned int PacketQueue::clear( unsigned int frames_to_keep, int stream_id )
 
@@ -446,7 +464,7 @@ unsigned int PacketQueue::clear(struct timeval *duration, int streamId) {
   timersub(t, duration, &keep_from);
   ++it;
 
-  Debug(3, "Looking for frame before queue keep time with stream id (%d), queue has %d packets",
+  Debug(3, "Looking for frame before queue keep time with stream id (%d), queue has %zu packets",
         streamId, pktQueue.size());
   for ( ; it != pktQueue.rend(); ++it) {
     ZMPacket *zm_packet = *it;
@@ -456,10 +474,10 @@ unsigned int PacketQueue::clear(struct timeval *duration, int streamId) {
         and
         timercmp(zm_packet->timestamp, &keep_from, <=)
         ) {
-        Debug(3, "Found frame before keep time with stream index %d at %d.%d",
-                 av_packet->stream_index,
-                 zm_packet->timestamp->tv_sec,
-                 zm_packet->timestamp->tv_usec);
+      Debug(3, "Found frame before keep time with stream index %d at %" PRIi64 ".%" PRIi64,
+            av_packet->stream_index,
+            static_cast<int64>(zm_packet->timestamp->tv_sec),
+            static_cast<int64>(zm_packet->timestamp->tv_usec));
         break;
     }
   }
@@ -479,10 +497,10 @@ unsigned int PacketQueue::clear(struct timeval *duration, int streamId) {
         and
        (av_packet->stream_index == streamId)
        ) {
-      Debug(3, "Found keyframe before start with stream index %d at %d.%d",
-               av_packet->stream_index,
-               zm_packet->timestamp->tv_sec,
-               zm_packet->timestamp->tv_usec );
+      Debug(3, "Found keyframe before start with stream index %d at %" PRIi64 ".%" PRIi64,
+            av_packet->stream_index,
+            static_cast<int64>(zm_packet->timestamp->tv_sec),
+            static_cast<int64>(zm_packet->timestamp->tv_usec));
       break;
     }
   }
@@ -535,7 +553,7 @@ ZMLockedPacket *PacketQueue::get_packet(packetqueue_iterator *it) {
     return nullptr;
 
   Debug(4, "Locking in get_packet using it %p queue end? %d, packet %p",
-      *it, (*it == pktQueue.end()), *(*it));
+        std::addressof(*it), (*it == pktQueue.end()), *(*it));
   std::unique_lock<std::mutex> lck(mutex);
   Debug(4, "Have Lock in get_packet");
 
@@ -544,7 +562,7 @@ ZMLockedPacket *PacketQueue::get_packet(packetqueue_iterator *it) {
     while (*it == pktQueue.end()) {
       if (deleting or zm_terminate)
         return nullptr;
-      Debug(2, "waiting.  Queue size %d it == end? %d", pktQueue.size(), (*it == pktQueue.end()));
+      Debug(2, "waiting.  Queue size %zu it == end? %d", pktQueue.size(), (*it == pktQueue.end()));
       condition.wait(lck);
     }
     if (deleting or zm_terminate)
@@ -556,7 +574,7 @@ ZMLockedPacket *PacketQueue::get_packet(packetqueue_iterator *it) {
       return nullptr;
     }
     Debug(4, "get_packet using it %p locking index %d, packet %p",
-        *it, p->image_index, p);
+          std::addressof(*it), p->image_index, p);
     // Packets are only deleted by packetqueue, so lock must be held.
     // We shouldn't have to trylock. Someone else might hold the lock but not for long
 
@@ -579,14 +597,14 @@ void PacketQueue::unlock(ZMLockedPacket *lp) {
 }
 
 bool PacketQueue::increment_it(packetqueue_iterator *it) {
-  Debug(2, "Incrementing %p, queue size %d, end? %d", it, pktQueue.size(), ((*it) == pktQueue.end()));
+  Debug(2, "Incrementing %p, queue size %zu, end? %d", it, pktQueue.size(), ((*it) == pktQueue.end()));
   if ((*it) == pktQueue.end() or deleting) {
     return false;
   }
   std::unique_lock<std::mutex> lck(mutex);
   ++(*it);
   if (*it != pktQueue.end()) {
-    Debug(2, "Incrementing %p, %p still not at end %p, so returning true", it, *it, pktQueue.end());
+    Debug(2, "Incrementing %p, %p still not at end, so returning true", it, std::addressof(*it));
     return true;
   }
   Debug(2, "At end");
@@ -595,7 +613,7 @@ bool PacketQueue::increment_it(packetqueue_iterator *it) {
 
 // Increment it only considering packets for a given stream
 bool PacketQueue::increment_it(packetqueue_iterator *it, int stream_id) {
-  Debug(2, "Incrementing %p, queue size %d, end? %d", it, pktQueue.size(), (*it == pktQueue.end()));
+  Debug(2, "Incrementing %p, queue size %zu, end? %d", it, pktQueue.size(), (*it == pktQueue.end()));
   if ( *it == pktQueue.end() ) {
     return false;
   }
@@ -696,7 +714,7 @@ packetqueue_iterator * PacketQueue::get_video_it(bool wait) {
 
   if ( wait ) {
     while ( ((! pktQueue.size()) or (*it == pktQueue.end())) and !zm_terminate and !deleting ) {
-      Debug(2, "waiting for packets in queue.  Queue size %d it == end? %d", pktQueue.size(), ( *it == pktQueue.end() ) );
+      Debug(2, "waiting for packets in queue. Queue size %zu it == end? %d", pktQueue.size(), (*it == pktQueue.end()));
       condition.wait(lck);
       *it = pktQueue.begin();
     }
@@ -749,7 +767,7 @@ bool PacketQueue::is_there_an_iterator_pointing_to_packet(ZMPacket *zm_packet) {
     if ( *iterator_it == pktQueue.end() ) {
       continue;
     }
-    Debug(4, "Checking iterator %p == packet ? %d", (*iterator_it), ( *(*iterator_it) == zm_packet ));
+    Debug(4, "Checking iterator %p == packet ? %d", std::addressof(*iterator_it), ( *(*iterator_it) == zm_packet ));
     // Have to check each iterator and make sure it doesn't point to the packet we are about to delete
     if ( *(*iterator_it) == zm_packet ) {
       return true;

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -211,7 +211,9 @@ int RemoteCameraHttp::ReadData(Buffer &buffer, unsigned int bytes_expected) {
 
   int n_found = select(sd+1, &rfds, nullptr, nullptr, &temp_timeout);
   if (n_found == 0) {
-    Debug(1, "Select timed out timeout was %d secs %d usecs", temp_timeout.tv_sec, temp_timeout.tv_usec);
+    Debug(1, "Select timed out timeout was %" PRIi64 " secs %" PRIi64" usecs",
+          static_cast<int64>(temp_timeout.tv_sec),
+          static_cast<int64>(temp_timeout.tv_usec));
     int error = 0;
     socklen_t len = sizeof(error);
     int retval = getsockopt(sd, SOL_SOCKET, SO_ERROR, &error, &len);

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -202,7 +202,7 @@ int RemoteCameraRtsp::PrimeCapture() {
 #endif
 
   if ( (unsigned int)pSize != imagesize ) {
-    Fatal("Image size mismatch. Required: %d Available: %d", pSize, imagesize);
+    Fatal("Image size mismatch. Required: %d Available: %llu", pSize, imagesize);
   }
 
   return 1;

--- a/src/zm_rtp_ctrl.cpp
+++ b/src/zm_rtp_ctrl.cpp
@@ -289,15 +289,14 @@ void RtpCtrlThread::Run() {
         unsigned char *bufferPtr = buffer;
         bufferPtr += generateRr( bufferPtr, sizeof(buffer)-(bufferPtr-buffer) );
         bufferPtr += generateSdes( bufferPtr, sizeof(buffer)-(bufferPtr-buffer) );
-        Debug( 3, "Preventing timeout by sending %zd bytes on sd %d. Time since last receive: %d",
-            bufferPtr-buffer, rtpCtrlServer.getWriteDesc(), ( now-last_receive) );
+        Debug(3, "Preventing timeout by sending %zd bytes on sd %d. Time since last receive: %" PRIi64,
+              bufferPtr - buffer, rtpCtrlServer.getWriteDesc(), static_cast<int64>(now - last_receive));
         if ( (nBytes = rtpCtrlServer.send(buffer, bufferPtr-buffer)) < 0 )
           Error("Unable to send: %s", strerror(errno));
         timeout = true;
         continue;
       } else {
-        //Error( "RTCP timed out" );
-        Debug(1, "RTCP timed out. Time since last receive: %d", ( now-last_receive) );
+        Debug(1, "RTCP timed out. Time since last receive: %" PRIi64, static_cast<int64>(now - last_receive));
         continue;
         //break;
       }

--- a/src/zm_rtp_source.cpp
+++ b/src/zm_rtp_source.cpp
@@ -165,14 +165,12 @@ void RtpSource::updateJitter( const RtpDataHeader *header ) {
     uint32_t localTimeRtp = mBaseTimeRtp + uint32_t(tvDiffSec(mBaseTimeReal) * mRtpFactor);
     uint32_t packetTransit = localTimeRtp - ntohl(header->timestampN);
 
-    Debug(5, "Delta rtp = %.6f\n"
-        "Local RTP time = %x",
-        "Packet RTP time = %x",
-        "Packet transit RTP time = %x",
-        tvDiffSec(mBaseTimeReal),
-        localTimeRtp,
-        ntohl(header->timestampN),
-        packetTransit);
+    Debug(5,
+          "Delta rtp = %.6f\n Local RTP time = %x Packet RTP time = %x Packet transit RTP time = %x",
+          tvDiffSec(mBaseTimeReal),
+          localTimeRtp,
+          ntohl(header->timestampN),
+          packetTransit);
 
     if ( mTransit > 0 ) {
       // Jitter
@@ -239,19 +237,13 @@ void RtpSource::updateRtcpStats() {
     mLostFraction = (lostInterval << 8) / expectedInterval;
 
   Debug(5,
-      "Expected packets = %d\n",
-      "Lost packets = %d\n",
-      "Expected interval = %d\n",
-      "Received interval = %d\n",
-      "Lost interval = %d\n",
-      "Lost fraction = %d\n",
-
-      mExpectedPackets,
-      mLostPackets,
-      expectedInterval,
-      receivedInterval,
-      lostInterval,
-      mLostFraction);
+        "Expected packets = %d\n Lost packets = %d\n Expected interval = %d\n Received interval = %d\n Lost interval = %d\n Lost fraction = %d\n",
+        mExpectedPackets,
+        mLostPackets,
+        expectedInterval,
+        receivedInterval,
+        lostInterval,
+        mLostFraction);
 }
 
 bool RtpSource::handlePacket(const unsigned char *packet, size_t packetLen) {

--- a/src/zm_rtsp.cpp
+++ b/src/zm_rtsp.cpp
@@ -173,7 +173,7 @@ RtspThread::RtspThread(
   
   mNeedAuth = false;
   StringVector parts = Split(auth, ":");
-  Debug(2, "# of auth parts %d", parts.size());
+  Debug(2, "# of auth parts %zu", parts.size());
   if ( parts.size() > 1 ) 
     mAuthenticator = new zm::Authenticator(parts[0], parts[1]);
   else
@@ -372,7 +372,7 @@ void RtspThread::Run() {
     mSessDesc = new SessionDescriptor( mUrl, sdp );
     mFormatContext = mSessDesc->generateFormatContext();
   } catch ( const Exception &e ) {
-    Error(e.getMessage().c_str());
+    Error("%s", e.getMessage().c_str());
     return;
   }
 
@@ -589,8 +589,12 @@ void RtspThread::Run() {
       while (!mTerminate) {
         now = time(nullptr);
         // Send a keepalive message if the server supports this feature and we are close to the timeout expiration
-        Debug(5, "sendkeepalive %d, timeout %d, now: %d last: %d since: %d",
-            sendKeepalive, timeout, now, lastKeepalive, (now-lastKeepalive) );
+        Debug(5, "sendkeepalive %d, timeout %d, now: %" PRIi64 " last: %" PRIi64 " since: %" PRIi64,
+              sendKeepalive,
+              timeout,
+              static_cast<int64>(now),
+              static_cast<int64>(lastKeepalive),
+              static_cast<int64>(now - lastKeepalive));
         if ( sendKeepalive && (timeout > 0) && ((now-lastKeepalive) > (timeout-5)) ) {
           if ( !sendCommand( message ) )
             return;
@@ -709,7 +713,12 @@ void RtspThread::Run() {
         // FIXME: Is this really necessary when using tcp ?
         now = time(nullptr);
         // Send a keepalive message if the server supports this feature and we are close to the timeout expiration
-Debug(5, "sendkeepalive %d, timeout %d, now: %d last: %d since: %d", sendKeepalive, timeout, now, lastKeepalive, (now-lastKeepalive) );
+        Debug(5, "sendkeepalive %d, timeout %d, now: %" PRIi64 " last: %" PRIi64 " since: %" PRIi64,
+              sendKeepalive,
+              timeout,
+              static_cast<int64>(now),
+              static_cast<int64>(lastKeepalive),
+              static_cast<int64>(now - lastKeepalive));
         if ( sendKeepalive && (timeout > 0) && ((now-lastKeepalive) > (timeout-5)) )
         {
           if ( !sendCommand( message ) )

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -205,7 +205,7 @@ void Authenticator::checkAuthResponse(const std::string &response) {
 
     if ( strncasecmp(lines[i].c_str(), authenticate_match, authenticate_match_len) == 0 ) {
       authLine = lines[i];
-      Debug(2, "Found auth line at %d:", i);
+      Debug(2, "Found auth line at %zu:", i);
       //break;
     }
   }

--- a/src/zm_rtsp_server_fifo_h264_source.cpp
+++ b/src/zm_rtsp_server_fifo_h264_source.cpp
@@ -196,7 +196,7 @@ unsigned char * H26X_ZoneMinderFifoSource::findMarker(
 // extract a frame
 unsigned char*  H26X_ZoneMinderFifoSource::extractFrame(unsigned char* frame, size_t& size, size_t& outsize) {
 	unsigned char *outFrame = nullptr;
-  Debug(4, "ExtractFrame: %p %d", frame, size);
+	Debug(4, "ExtractFrame: %p %zu", frame, size);
 	outsize = 0;
 	size_t markerLength = 0;
 	size_t endMarkerLength = 0;
@@ -205,7 +205,7 @@ unsigned char*  H26X_ZoneMinderFifoSource::extractFrame(unsigned char* frame, si
   if ( size >= 3 )
     startFrame = this->findMarker(frame, size, markerLength);
 	if ( startFrame != nullptr ) {
-    Debug(4, "startFrame: %p marker Length %d", startFrame, markerLength);
+		Debug(4, "startFrame: %p marker Length %zu", startFrame, markerLength);
 		m_frameType = startFrame[markerLength];
 
 		int remainingSize = size-(startFrame-frame+markerLength);
@@ -213,7 +213,7 @@ unsigned char*  H26X_ZoneMinderFifoSource::extractFrame(unsigned char* frame, si
     if ( remainingSize > 3 ) {
       endFrame = this->findMarker(startFrame+markerLength, remainingSize, endMarkerLength);
     }
-    Debug(4, "endFrame: %p marker Length %d, remaining size %d", endFrame, endMarkerLength, remainingSize);
+		Debug(4, "endFrame: %p marker Length %zu, remaining size %d", endFrame, endMarkerLength, remainingSize);
 
 		if ( m_keepMarker ) {
 			size -=  startFrame-frame;
@@ -229,9 +229,9 @@ unsigned char*  H26X_ZoneMinderFifoSource::extractFrame(unsigned char* frame, si
 			outsize = size;
 		}
 		size -= outsize;
-    Debug(4, "Have frame type: %d size %d, keepmarker %d", m_frameType, outsize, m_keepMarker);
+		Debug(4, "Have frame type: %d size %zu, keepmarker %d", m_frameType, outsize, m_keepMarker);
 	} else if ( size >= sizeof(H264shortmarker) ) {
-		 Info("No marker found size %d", size);
+		Info("No marker found size %zu", size);
 	}
 
 	return outFrame;

--- a/src/zm_rtsp_server_fifo_source.cpp
+++ b/src/zm_rtsp_server_fifo_source.cpp
@@ -78,7 +78,7 @@ void ZoneMinderFifoSource::WriteRun() {
 
     if (nal) {
       if (1 and (nal->size() > maxNalSize)) {
-        Debug(1, "SPlitting NAL %d", nal->size());
+        Debug(1, "Splitting NAL %zu", nal->size());
         size_t nalRemaining = nal->size();
         u_int8_t *nalSrc = nal->buffer();
 
@@ -123,9 +123,9 @@ void ZoneMinderFifoSource::WriteRun() {
           nalSrc += fuNalSize;
           nal_count += 1;
         }
-        Debug(1, "Sending %d NALs @ %d and 1 @ %d", nal_count, maxNalSize, fuNal.size());
+        Debug(1, "Sending %d NALs @ %zu and 1 @ %zu", nal_count, maxNalSize, fuNal.size());
       } else {
-        Debug(3, "Pushing nal of size %d at %" PRId64, nal->size(), nal->pts());
+        Debug(3, "Pushing nal of size %zu at %" PRId64, nal->size(), nal->pts());
         PushFrame(nal->buffer(), nal->size(), nal->pts());
       }
       delete nal;
@@ -214,8 +214,8 @@ int ZoneMinderFifoSource::getNextFrame() {
       return 0;
     }
     if (header_start != m_buffer) {
-      Debug(4, "ZM Packet didn't start at beginning of buffer %u. %c%c",
-          header_start-m_buffer.head(), m_buffer[0], m_buffer[1]);
+      Debug(4, "ZM Packet didn't start at beginning of buffer %ld. %c%c",
+            header_start - m_buffer.head(), m_buffer[0], m_buffer[1]);
     }
 
     // read_into may invalidate packet_start
@@ -244,7 +244,10 @@ int ZoneMinderFifoSource::getNextFrame() {
     size_t bytes_remaining = data_size;
     std::list< std::pair<unsigned char*, size_t> > framesList = this->splitFrames(packet_start, bytes_remaining);
     m_buffer.consume(data_size+header_size);
-    Debug(3, "Got %d frames, consuming %d bytes, remaining %d", framesList.size(), data_size+header_size, bytes_remaining);
+    Debug(3, "Got %zu frames, consuming %d bytes, remaining %zu",
+          framesList.size(),
+          data_size + header_size,
+          bytes_remaining);
 
     {
       std::unique_lock<std::mutex> lck(mutex_);

--- a/src/zm_rtsp_server_frame.h
+++ b/src/zm_rtsp_server_frame.h
@@ -53,15 +53,16 @@ class NAL_Frame {
       }
       return false;
     }
+
     void debug() {
-      if ( m_size <= 4 ) {
-      Debug(1, "NAL: %d: %.2x %.2x %.2x %.2x", m_size,
-          m_buffer[0], m_buffer[1], m_buffer[2], m_buffer[3]);
+      if (m_size <= 4) {
+        Debug(1, "NAL: %zu: %.2x %.2x %.2x %.2x", m_size,
+              m_buffer[0], m_buffer[1], m_buffer[2], m_buffer[3]);
       } else {
-        Debug(1, "NAL: %d: %.2x %.2x %.2x %.2x   %.2x %.2x %.2x %.2x ", m_size,
-            m_buffer[0], m_buffer[1], m_buffer[2], m_buffer[3],
-            m_buffer[4], m_buffer[5], m_buffer[6], m_buffer[7]
-            );
+        Debug(1, "NAL: %zu: %.2x %.2x %.2x %.2x   %.2x %.2x %.2x %.2x ", m_size,
+              m_buffer[0], m_buffer[1], m_buffer[2], m_buffer[3],
+              m_buffer[4], m_buffer[5], m_buffer[6], m_buffer[7]
+        );
       }
     }
 

--- a/src/zm_signal.cpp
+++ b/src/zm_signal.cpp
@@ -104,8 +104,7 @@ RETSIGTYPE zm_die_handler(int signal)
 	}
 	free(messages);
 
-	Info("Backtrace complete, please execute the following command for more information");
-	Info(cmd);
+	Info("Backtrace complete, please execute the following command for more information: %s", cmd);
   #endif				// ( !defined(ZM_NO_CRASHTRACE) && HAVE_DECL_BACKTRACE && HAVE_DECL_BACKTRACE_SYMBOLS )
 #endif                          // (defined(__i386__) || defined(__x86_64__)
 	exit(signal);

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -359,7 +359,7 @@ void StreamBase::openComms() {
     // Unlink before bind, in case it already exists
     unlink(loc_sock_path);
     if ( sizeof(loc_addr.sun_path) < length ) {
-      Error("Not enough space %d in loc_addr.sun_path for socket file %s", sizeof(loc_addr.sun_path), loc_sock_path);
+      Error("Not enough space %zu in loc_addr.sun_path for socket file %s", sizeof(loc_addr.sun_path), loc_sock_path);
     }
 
     strncpy(loc_addr.sun_path, loc_sock_path, sizeof(loc_addr.sun_path));

--- a/src/zm_swscale.cpp
+++ b/src/zm_swscale.cpp
@@ -124,7 +124,7 @@ int SWScale::Convert(
     unsigned int new_width,
     unsigned int new_height
     ) {
-  Debug(1, "Convert: in_buffer %p in_buffer_size %d out_buffer %p size %d width %d height %d width %d height %d %d %d", 
+  Debug(1, "Convert: in_buffer %p in_buffer_size %zu out_buffer %p size %zu width %d height %d width %d height %d %d %d",
       in_buffer, in_buffer_size, out_buffer, out_buffer_size, width, height, new_width, new_height,
       in_pf, out_pf);
   /* Parameter checking */
@@ -163,12 +163,19 @@ int SWScale::Convert(
   /* Check the buffer sizes */
   size_t needed_insize = GetBufferSize(in_pf, width, height);
   if ( needed_insize > in_buffer_size ) {
-    Debug(1, "The input buffer size does not match the expected size for the input format. Required: %d for %dx%d %d Available: %d",
-        needed_insize, width, height, in_pf, in_buffer_size);
+    Debug(1,
+          "The input buffer size does not match the expected size for the input format. Required: %zu for %dx%d %d Available: %zu",
+          needed_insize,
+          width,
+          height,
+          in_pf,
+          in_buffer_size);
   }
   size_t needed_outsize = GetBufferSize(out_pf, new_width, new_height);
   if ( needed_outsize > out_buffer_size ) {
-    Error("The output buffer is undersized for the output format. Required: %d Available: %d", needed_outsize, out_buffer_size);
+    Error("The output buffer is undersized for the output format. Required: %zu Available: %zu",
+          needed_outsize,
+          out_buffer_size);
     return -5;
   }
 

--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -232,7 +232,7 @@ User *zmLoadAuthUser(const char *auth, bool use_remote_addr) {
     Warning("No value set for ZM_AUTH_HASH_TTL. Defaulting to 2.");
     hours = 2;
   } else {
-    Debug(1, "AUTH_HASH_TTL is %d, time is %d", hours, now);
+    Debug(1, "AUTH_HASH_TTL is %d, time is %" PRIi64, hours, static_cast<int64>(now));
   }
   char auth_key[512] = "";
   char auth_md5[32+1] = "";

--- a/src/zmc.cpp
+++ b/src/zmc.cpp
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
     Error("No monitors found");
     exit(-1);
   } else {
-	  Debug(2, "%d monitors loaded", monitors.size());
+	  Debug(2, "%zu monitors loaded", monitors.size());
   }
 
   Info("Starting Capture version %s", ZM_VERSION);
@@ -294,20 +294,20 @@ int main(int argc, char *argv[]) {
         monitors[i]->CheckAction();
 
         if (monitors[i]->PreCapture() < 0) {
-          Error("Failed to pre-capture monitor %d %d (%d/" SZFMTD ")",
-              monitors[i]->Id(), monitors[i]->Name(), i+1, monitors.size());
+          Error("Failed to pre-capture monitor %d %s (%zu/%zu)",
+                monitors[i]->Id(), monitors[i]->Name(), i + 1, monitors.size());
           result = -1;
           break;
         }
         if (monitors[i]->Capture() < 0) {
-          Error("Failed to capture image from monitor %d %s (%d/" SZFMTD ")",
-              monitors[i]->Id(), monitors[i]->Name(), i+1, monitors.size());
+          Error("Failed to capture image from monitor %d %s (%zu/%zu)",
+                monitors[i]->Id(), monitors[i]->Name(), i + 1, monitors.size());
           result = -1;
           break;
         }
         if (monitors[i]->PostCapture() < 0) {
-          Error("Failed to post-capture monitor %d %s (%d/" SZFMTD ")",
-              monitors[i]->Id(), monitors[i]->Name(), i+1, monitors.size());
+          Error("Failed to post-capture monitor %d %s (%zu/%zu)",
+                monitors[i]->Id(), monitors[i]->Name(), i + 1, monitors.size());
           result = -1;
           break;
         }
@@ -322,13 +322,15 @@ int main(int argc, char *argv[]) {
 
             // You have to add back in the previous sleep time
             sleep_time = delay - (delta_time.delta - sleep_time);
-            Debug(4, "Sleep time is %d from now:%d.%d last:%d.%d delta %d delay: %d",
-                sleep_time,
-                now.tv_sec, now.tv_usec,
-                last_capture_times[i].tv_sec, last_capture_times[i].tv_usec,
-                delta_time.delta,
-                delay
-                );
+            Debug(4,
+                  "Sleep time is %d from now: %" PRIi64 ".%" PRIi64" last: %" PRIi64 ".% " PRIi64 " delta %lu delay: %d",
+                  sleep_time,
+                  static_cast<int64>(now.tv_sec),
+                  static_cast<int64>(now.tv_usec),
+                  static_cast<int64>(last_capture_times[i].tv_sec),
+                  static_cast<int64>(last_capture_times[i].tv_usec),
+                  delta_time.delta,
+                  delay);
 
             if (sleep_time > 0) {
               Debug(4, "usleeping (%d)", sleep_time);

--- a/src/zmu.cpp
+++ b/src/zmu.cpp
@@ -734,7 +734,7 @@ int main(int argc, char *argv[]) {
       if (!result) {
         exit_zmu(-1);
       }
-      Debug(1, "Got %d monitors", mysql_num_rows(result));
+      Debug(1, "Got %" PRIu64 " monitors", static_cast<uint64>(mysql_num_rows(result)));
 
       printf("%4s%5s%6s%9s%14s%6s%6s%8s%8s\n", "Id", "Func", "State", "TrgState", "LastImgTim", "RdIdx", "WrIdx", "LastEvt", "FrmRate");
       for ( int i = 0; MYSQL_ROW dbrow = mysql_fetch_row(result); i++ ) {

--- a/tests/zm_font.cpp
+++ b/tests/zm_font.cpp
@@ -147,7 +147,7 @@ TEST_CASE("ZmFont: load font file") {
   SECTION("valid file") {
     REQUIRE(font.LoadFontFile("data/fonts/04_valid.zmfnt") == FontLoadError::kOk);
 
-    uint8 var_idx = GENERATE(range(static_cast<decltype(kNumFontSizes)>(0), kNumFontSizes));
+    uint8 var_idx = GENERATE(range(static_cast<std::remove_cv<decltype(kNumFontSizes)>::type>(0), kNumFontSizes));
     FontVariant variant = font.GetFontVariant(var_idx);
     REQUIRE(variant.GetCharHeight() == 10 + var_idx);
     REQUIRE(variant.GetCharWidth() == 10 + var_idx);


### PR DESCRIPTION
By annotating `Logger::logPrint` with the `format` attribute we can leverage the compiler to check for parameter type/format string mismatches.