### PR TITLE
Enable Werror for CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ task:
     - mkdir build
     - cd build
     - cmake --version
-    - cmake ../ -DBUILD_MAN=0 -DBUILD_TEST_SUITE=1
+    - cmake ../ -DBUILD_MAN=0 -DBUILD_TEST_SUITE=1 -DENABLE_WERROR=1
 
   build_script:
     - cd build

--- a/.github/workflows/ci-xenial.yml
+++ b/.github/workflows/ci-xenial.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Prepare
         run: mkdir build
       - name: Configure
-        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0
+        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0 -DENABLE_WERROR=1
       - name: Build
         run: cd build && make -j3 | grep --line-buffered -Ev '^(cp lib\/|Installing.+\.pm)' && (exit ${PIPESTATUS[0]})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ mark_as_advanced(
   ZM_SYSTEMD
   ZM_MANPAGE_DEST_PREFIX)
 
+option(ENABLE_WERROR "Fail the build if a compiler warning is emitted" 0)
 option(BUILD_TEST_SUITE "Build the test suite" 0)
 option(BUILD_MAN "Build man pages" 1)
 option(ASAN "DEBUGGING: Build with AddressSanitizer (ASan) support" 0)

--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -5,6 +5,12 @@ target_compile_options(zm-warning-interface
     -Wimplicit-fallthrough
     -Wno-unused-parameter)
 
+if(ENABLE_WERROR)
+  target_compile_options(zm-warning-interface
+    INTERFACE
+      -Werror)
+endif()
+
 if(ASAN)
   target_compile_options(zm-compile-option-interface
     INTERFACE

--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -9,6 +9,12 @@ target_compile_options(zm-warning-interface
     -Wno-unused-parameter
     -Woverloaded-virtual)
 
+if(ENABLE_WERROR)
+  target_compile_options(zm-warning-interface
+    INTERFACE
+      -Werror)
+endif()
+
 if(ASAN)
   target_compile_options(zm-compile-option-interface
     INTERFACE

--- a/distros/redhat/zoneminder.spec
+++ b/distros/redhat/zoneminder.spec
@@ -9,7 +9,7 @@
 %global ceb_version 1.0-zm
 
 # RtspServer is configured as a git submodule
-%global rtspserver_commit     65f625e27ed9f96fa5ae068f6d49ec9fa5795629
+%global rtspserver_commit     cd7fd49becad6010a1b8466bfebbd93999a39878
 
 %global sslcert %{_sysconfdir}/pki/tls/certs/localhost.crt
 %global sslkey %{_sysconfdir}/pki/tls/private/localhost.key

--- a/src/zm_rtsp_server.cpp
+++ b/src/zm_rtsp_server.cpp
@@ -330,13 +330,16 @@ int main(int argc, char *argv[]) {
   } // end while !zm_terminate
   Info("RTSP Server shutting down");
 
-  for (auto it = monitors.begin(); it != monitors.end(); ++it) {
-    auto &monitor = it->second;
-    unsigned int i = it->first;
-    if (video_sources.find(i) != video_sources.end()) delete video_sources[i];
-    if (audio_sources.find(i) != audio_sources.end()) delete audio_sources[i];
+  for (const std::pair<const unsigned int, std::shared_ptr<Monitor>> &mon_pair : monitors) {
+    unsigned int i = mon_pair.first;
+    if (video_sources.find(i) != video_sources.end()) {
+      delete video_sources[i];
+    }
+    if (audio_sources.find(i) != audio_sources.end()) {
+      delete audio_sources[i];
+    }
     if (sessions.find(i) != sessions.end()) {
-      Debug(1, "Removing session for %s", monitors[i]->Name());
+      Debug(1, "Removing session for %s", mon_pair.second->Name());
       rtspServer->RemoveSession(sessions[i]->GetMediaSessionId());
       sessions.erase(i);
     }

--- a/utils/packpack/startpackpack.sh
+++ b/utils/packpack/startpackpack.sh
@@ -118,7 +118,7 @@ commonprep () {
         fi
     fi
 
-    RTSPVER="65f625e27ed9f96fa5ae068f6d49ec9fa5795629"
+    RTSPVER="cd7fd49becad6010a1b8466bfebbd93999a39878"
     if [ -e "build/RtspServer-${RTSPVER}.tar.gz" ]; then
         echo "Found existing RtspServer ${RTSPVER} tarball..."
     else


### PR DESCRIPTION
Make sure we fail any CI build that has warnings present, so this case can be easily detected.