### PR TITLE
Remove variable-length arrays from the codebase

### DIFF
--- a/cmake/compiler/clang/settings.cmake
+++ b/cmake/compiler/clang/settings.cmake
@@ -3,7 +3,8 @@ target_compile_options(zm-warning-interface
     -Wall
     -Wextra
     -Wimplicit-fallthrough
-    -Wno-unused-parameter)
+    -Wno-unused-parameter
+    -Wvla)
 
 if(ENABLE_WERROR)
   target_compile_options(zm-warning-interface

--- a/cmake/compiler/gcc/settings.cmake
+++ b/cmake/compiler/gcc/settings.cmake
@@ -7,7 +7,8 @@ target_compile_options(zm-warning-interface
     -Wno-cast-function-type
     $<$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>:-Wno-clobbered>
     -Wno-unused-parameter
-    -Woverloaded-virtual)
+    -Woverloaded-virtual
+    -Wvla)
 
 if(ENABLE_WERROR)
   target_compile_options(zm-warning-interface

--- a/src/zm_comms.cpp
+++ b/src/zm_comms.cpp
@@ -36,7 +36,7 @@
 
 int ZM::CommsBase::readV(int iovcnt, /* const void *, int, */ ...) {
   va_list arg_ptr;
-  iovec iov[iovcnt];
+  std::vector<iovec> iov(iovcnt);
 
   va_start(arg_ptr, iovcnt);
   for (int i = 0; i < iovcnt; i++) {
@@ -45,7 +45,7 @@ int ZM::CommsBase::readV(int iovcnt, /* const void *, int, */ ...) {
   }
   va_end(arg_ptr);
 
-  int nBytes = ::readv(mRd, iov, iovcnt);
+  int nBytes = ::readv(mRd, iov.data(), iovcnt);
   if (nBytes < 0) {
     Debug(1, "Readv of %d buffers max on rd %d failed: %s", iovcnt, mRd, strerror(errno));
   }
@@ -54,7 +54,7 @@ int ZM::CommsBase::readV(int iovcnt, /* const void *, int, */ ...) {
 
 int ZM::CommsBase::writeV(int iovcnt, /* const void *, int, */ ...) {
   va_list arg_ptr;
-  iovec iov[iovcnt];
+  std::vector<iovec> iov(iovcnt);
 
   va_start(arg_ptr, iovcnt);
   for (int i = 0; i < iovcnt; i++) {
@@ -63,7 +63,7 @@ int ZM::CommsBase::writeV(int iovcnt, /* const void *, int, */ ...) {
   }
   va_end(arg_ptr);
 
-  ssize_t nBytes = ::writev(mWd, iov, iovcnt);
+  ssize_t nBytes = ::writev(mWd, iov.data(), iovcnt);
   if (nBytes < 0) {
     Debug(1, "Writev of %d buffers on wd %d failed: %s", iovcnt, mWd, strerror(errno));
   }

--- a/src/zm_comms.h
+++ b/src/zm_comms.h
@@ -243,27 +243,27 @@ class Socket : public CommsBase {
     return nBytes;
   }
 
-  virtual int recv(std::string &msg) const {
-    char buffer[msg.capacity()];
-    int nBytes = 0;
-    if ((nBytes = ::recv(mSd, buffer, sizeof(buffer), 0)) < 0) {
-      Debug(1, "Recv of %zd bytes max to string on sd %d failed: %s", sizeof(buffer), mSd, strerror(errno));
+  virtual ssize_t recv(std::string &msg) const {
+    std::vector<char> buffer(msg.capacity());
+    ssize_t nBytes;
+    if ((nBytes = ::recv(mSd, buffer.data(), buffer.size(), 0)) < 0) {
+      Debug(1, "Recv of %zd bytes max to string on sd %d failed: %s", msg.size(), mSd, strerror(errno));
       return nBytes;
     }
     buffer[nBytes] = '\0';
-    msg = buffer;
+    msg = {buffer.begin(), buffer.begin() + nBytes};
     return nBytes;
   }
 
-  virtual int recv(std::string &msg, size_t maxLen) const {
-    char buffer[maxLen];
-    int nBytes = 0;
-    if ((nBytes = ::recv(mSd, buffer, sizeof(buffer), 0)) < 0) {
+  virtual ssize_t recv(std::string &msg, size_t maxLen) const {
+    std::vector<char> buffer(maxLen);
+    ssize_t nBytes;
+    if ((nBytes = ::recv(mSd, buffer.data(), buffer.size(), 0)) < 0) {
       Debug(1, "Recv of %zd bytes max to string on sd %d failed: %s", maxLen, mSd, strerror(errno));
       return nBytes;
     }
     buffer[nBytes] = '\0';
-    msg = buffer;
+    msg = {buffer.begin(), buffer.begin() + nBytes};
     return nBytes;
   }
 

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -2469,7 +2469,7 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
 
   size_t n_coords = polygon.GetVertices().size();
 
-  std::vector<Edge> global_edges;
+  std::vector<PolygonFill::Edge> global_edges;
   global_edges.reserve(n_coords);
   for (size_t j = 0, i = n_coords - 1; j < n_coords; i = j++) {
     const Vector2 &p1 = polygon.GetVertices()[i];
@@ -2487,9 +2487,9 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
                               d.x_ / static_cast<double>(d.y_));
 
   }
-  std::sort(global_edges.begin(), global_edges.end(), Edge::CompareYX);
+  std::sort(global_edges.begin(), global_edges.end(), PolygonFill::Edge::CompareYX);
 
-  std::vector<Edge> active_edges;
+  std::vector<PolygonFill::Edge> active_edges;
   active_edges.reserve(global_edges.size());
 
   int32 scan_line = global_edges[0].min_y;
@@ -2513,7 +2513,7 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
         ++it;
       }
     }
-    std::sort(active_edges.begin(), active_edges.end(), Edge::CompareX);
+    std::sort(active_edges.begin(), active_edges.end(), PolygonFill::Edge::CompareX);
 
     if (!(scan_line % density)) {
       for (auto it = active_edges.begin(); it != active_edges.end(); ++it) {
@@ -2553,10 +2553,6 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
 
     scan_line++;
   }
-}
-
-void Image::Fill(Rgb colour, const Polygon &polygon) {
-  Fill(colour, 1, polygon);
 }
 
 void Image::Rotate(int angle) {

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -2458,9 +2458,9 @@ void Image::Outline( Rgb colour, const Polygon &polygon ) {
   } // end foreach coordinate in the polygon
 }
 
-/* RGB32 compatible: complete */
+// Polygon filling is based on the Scan-line Polygon filling algorithm
 void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
-  if ( !(colours == ZM_COLOUR_GRAY8 || colours == ZM_COLOUR_RGB24 || colours == ZM_COLOUR_RGB32 ) ) {
+  if (!(colours == ZM_COLOUR_GRAY8 || colours == ZM_COLOUR_RGB24 || colours == ZM_COLOUR_RGB32)) {
     Panic("Attempt to fill image with unexpected colours %d", colours);
   }
 
@@ -2468,115 +2468,91 @@ void Image::Fill(Rgb colour, int density, const Polygon &polygon) {
   colour = rgb_convert(colour, subpixelorder);
 
   size_t n_coords = polygon.GetVertices().size();
-  int n_global_edges = 0;
-  Edge global_edges[n_coords];
+
+  std::vector<Edge> global_edges;
+  global_edges.reserve(n_coords);
   for (size_t j = 0, i = n_coords - 1; j < n_coords; i = j++) {
     const Vector2 &p1 = polygon.GetVertices()[i];
     const Vector2 &p2 = polygon.GetVertices()[j];
 
-    int x1 = p1.x_;
-    int x2 = p2.x_;
-    int y1 = p1.y_;
-    int y2 = p2.y_;
-
-    //Debug( 9, "x1:%d,y1:%d x2:%d,y2:%d", x1, y1, x2, y2 );
-    if ( y1 == y2 )
+    // Do not add horizontal edges to the global edge table.
+    if (p1.y_ == p2.y_)
       continue;
 
-    double dx = x2 - x1;
-    double dy = y2 - y1;
+    Vector2 d = p2 - p1;
 
-    global_edges[n_global_edges].min_y = y1<y2?y1:y2;
-    global_edges[n_global_edges].max_y = y1<y2?y2:y1;
-    global_edges[n_global_edges].min_x = y1<y2?x1:x2;
-    global_edges[n_global_edges]._1_m = dx/dy;
-    n_global_edges++;
+    global_edges.emplace_back(std::min(p1.y_, p2.y_),
+                              std::max(p1.y_, p2.y_),
+                              p1.y_ < p2.y_ ? p1.x_ : p2.x_,
+                              d.x_ / static_cast<double>(d.y_));
+
   }
-  std::sort(global_edges, global_edges + n_global_edges, Edge::CompareYX);
+  std::sort(global_edges.begin(), global_edges.end(), Edge::CompareYX);
 
-#ifndef ZM_DBG_OFF
-  if ( logLevel() >= Logger::DEBUG9 ) {
-    for ( int i = 0; i < n_global_edges; i++ ) {
-      Debug(9, "%d: min_y: %d, max_y:%d, min_x:%.2f, 1/m:%.2f",
-          i, global_edges[i].min_y, global_edges[i].max_y, global_edges[i].min_x, global_edges[i]._1_m);
-    }
-  }
-#endif
+  std::vector<Edge> active_edges;
+  active_edges.reserve(global_edges.size());
 
-  int n_active_edges = 0;
-  Edge active_edges[n_global_edges];
-  int y = global_edges[0].min_y;
-  do {
-    for ( int i = 0; i < n_global_edges; i++ ) {
-      if ( global_edges[i].min_y == y ) {
-        Debug(9, "Moving global edge");
-        active_edges[n_active_edges++] = global_edges[i];
-        if ( i < (n_global_edges-1) ) {
-          memmove(&global_edges[i], &global_edges[i + 1], sizeof(*global_edges) * (n_global_edges - i - 1));
-          i--;
-        }
-        n_global_edges--;
+  int32 scan_line = global_edges[0].min_y;
+  while (!global_edges.empty() || !active_edges.empty()) {
+    // Deactivate edges with max_y < current scan line
+    for (auto it = active_edges.begin(); it != active_edges.end();) {
+      if (scan_line >= it->max_y) {
+        it = active_edges.erase(it);
       } else {
-        break;
+        it->min_x += it->_1_m;
+        ++it;
       }
     }
-    std::sort(active_edges, active_edges + n_active_edges, Edge::CompareX);
-#ifndef ZM_DBG_OFF
-    if ( logLevel() >= Logger::DEBUG9 ) {
-      for ( int i = 0; i < n_active_edges; i++ ) {
-        Debug(9, "%d - %d: min_y: %d, max_y:%d, min_x:%.2f, 1/m:%.2f",
-            y, i, active_edges[i].min_y, active_edges[i].max_y, active_edges[i].min_x, active_edges[i]._1_m );
+
+    // Activate edges with min_y == current scan line
+    for (auto it = global_edges.begin(); it != global_edges.end();) {
+      if (it->min_y == scan_line) {
+        active_edges.emplace_back(*it);
+        it = global_edges.erase(it);
+      } else {
+        ++it;
       }
     }
-#endif
-    if ( !(y%density) ) {
-      //Debug( 9, "%d", y );
-      for ( int i = 0; i < n_active_edges; ) {
-        int lo_x = int(round(active_edges[i++].min_x));
-        int hi_x = int(round(active_edges[i++].min_x));
-        if ( colours == ZM_COLOUR_GRAY8 ) {
-          unsigned char *p = &buffer[(y*width)+lo_x];
-          for ( int x = lo_x; x <= hi_x; x++, p++) {
-            if ( !(x%density) ) {
-              //Debug( 9, " %d", x );
+    std::sort(active_edges.begin(), active_edges.end(), Edge::CompareX);
+
+    if (!(scan_line % density)) {
+      for (auto it = active_edges.begin(); it != active_edges.end(); ++it) {
+        int32 lo_x = static_cast<int32>(it->min_x);
+        int32 hi_x = static_cast<int32>(std::next(it)->min_x);
+        if (colours == ZM_COLOUR_GRAY8) {
+          uint8 *p = &buffer[(scan_line * width) + lo_x];
+
+          for (int32 x = lo_x; x <= hi_x; x++, p++) {
+            if (!(x % density)) {
               *p = colour;
             }
           }
-        } else if ( colours == ZM_COLOUR_RGB24 ) {
-          unsigned char *p = &buffer[colours*((y*width)+lo_x)];
-          for ( int x = lo_x; x <= hi_x; x++, p += 3) {
-            if ( !(x%density) ) {
-              RED_PTR_RGBA(p) = RED_VAL_RGBA(colour);
-              GREEN_PTR_RGBA(p) = GREEN_VAL_RGBA(colour);
-              BLUE_PTR_RGBA(p) = BLUE_VAL_RGBA(colour);
+        } else if (colours == ZM_COLOUR_RGB24) {
+          constexpr uint8 bytesPerPixel = 3;
+          uint8 *ptr = &buffer[((scan_line * width) + lo_x) * bytesPerPixel];
+
+          for (int32 x = lo_x; x <= hi_x; x++, ptr += bytesPerPixel) {
+            if (!(x % density)) {
+              RED_PTR_RGBA(ptr) = RED_VAL_RGBA(colour);
+              GREEN_PTR_RGBA(ptr) = GREEN_VAL_RGBA(colour);
+              BLUE_PTR_RGBA(ptr) = BLUE_VAL_RGBA(colour);
             }
           }
-        } else if( colours == ZM_COLOUR_RGB32 ) {
-          Rgb *p = (Rgb*)&buffer[((y*width)+lo_x)<<2];
-          for ( int x = lo_x; x <= hi_x; x++, p++) {
-            if ( !(x%density) ) {
-              /* Fast, copies the entire pixel in a single pass */
-              *p = colour;
+        } else if (colours == ZM_COLOUR_RGB32) {
+          constexpr uint8 bytesPerPixel = 4;
+          Rgb *ptr = reinterpret_cast<Rgb *>(&buffer[((scan_line * width) + lo_x) * bytesPerPixel]);
+
+          for (int32 x = lo_x; x <= hi_x; x++, ptr++) {
+            if (!(x % density)) {
+              *ptr = colour;
             }
           }
         }
       }
     }
-    y++;
-    for ( int i = n_active_edges-1; i >= 0; i-- ) {
-      if ( y >= active_edges[i].max_y ) {
-        // Or >= as per sheets
-        Debug(9, "Deleting active_edge");
-        if ( i < (n_active_edges-1) ) {
-          //memcpy( &active_edges[i], &active_edges[i+1], sizeof(*active_edges)*(n_active_edges-i) );
-          memmove( &active_edges[i], &active_edges[i+1], sizeof(*active_edges)*(n_active_edges-i) );
-        }
-        n_active_edges--;
-      } else {
-        active_edges[i].min_x += active_edges[i]._1_m;
-      }
-    }
-  } while ( n_global_edges || n_active_edges );
+
+    scan_line++;
+  }
 }
 
 void Image::Fill(Rgb colour, const Polygon &polygon) {

--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -278,7 +278,7 @@ class Image {
     void Fill( Rgb colour, const Box *limits=0 );
     void Fill( Rgb colour, int density, const Box *limits=0 );
     void Outline( Rgb colour, const Polygon &polygon );
-    void Fill(Rgb colour, const Polygon &polygon);
+    void Fill(Rgb colour, const Polygon &polygon) { Fill(colour, 1, polygon); };
     void Fill(Rgb colour, int density, const Polygon &polygon);
 
     void Rotate( int angle );
@@ -291,6 +291,31 @@ class Image {
     void Deinterlace_Blend_CustomRatio(int divider);
     void Deinterlace_4Field(const Image* next_image, unsigned int threshold);
 };
+
+// Scan-line polygon fill algorithm
+namespace PolygonFill {
+class Edge {
+ public:
+  Edge() = default;
+  Edge(int32 min_y, int32 max_y, double min_x, double _1_m) : min_y(min_y), max_y(max_y), min_x(min_x), _1_m(_1_m) {}
+
+  static bool CompareYX(const Edge &e1, const Edge &e2) {
+    if (e1.min_y == e2.min_y)
+      return e1.min_x < e2.min_x;
+    return e1.min_y < e2.min_y;
+  }
+
+  static bool CompareX(const Edge &e1, const Edge &e2) {
+    return e1.min_x < e2.min_x;
+  }
+
+ public:
+  int32 min_y;
+  int32 max_y;
+  double min_x;
+  double _1_m;
+};
+}
 
 #endif // ZM_IMAGE_H
 

--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -278,8 +278,8 @@ class Image {
     void Fill( Rgb colour, const Box *limits=0 );
     void Fill( Rgb colour, int density, const Box *limits=0 );
     void Outline( Rgb colour, const Polygon &polygon );
-    void Fill( Rgb colour, const Polygon &polygon );
-    void Fill( Rgb colour, int density, const Polygon &polygon );
+    void Fill(Rgb colour, const Polygon &polygon);
+    void Fill(Rgb colour, int density, const Polygon &polygon);
 
     void Rotate( int angle );
     void Flip( bool leftright );

--- a/src/zm_poly.h
+++ b/src/zm_poly.h
@@ -23,11 +23,10 @@
 #include "zm_box.h"
 #include <vector>
 
-struct Edge {
-  int min_y;
-  int max_y;
-  double min_x;
-  double _1_m;
+class Edge {
+ public:
+  Edge() = default;
+  Edge(int32 min_y, int32 max_y, double min_x, double _1_m) : min_y(min_y), max_y(max_y), min_x(min_x), _1_m(_1_m) {}
 
   static bool CompareYX(const Edge &e1, const Edge &e2) {
     if (e1.min_y == e2.min_y)
@@ -38,6 +37,12 @@ struct Edge {
   static bool CompareX(const Edge &e1, const Edge &e2) {
     return e1.min_x < e2.min_x;
   }
+
+ public:
+  int32 min_y;
+  int32 max_y;
+  double min_x;
+  double _1_m;
 };
 
 // This class represents convex or concave non-self-intersecting polygons.

--- a/src/zm_poly.h
+++ b/src/zm_poly.h
@@ -23,28 +23,6 @@
 #include "zm_box.h"
 #include <vector>
 
-class Edge {
- public:
-  Edge() = default;
-  Edge(int32 min_y, int32 max_y, double min_x, double _1_m) : min_y(min_y), max_y(max_y), min_x(min_x), _1_m(_1_m) {}
-
-  static bool CompareYX(const Edge &e1, const Edge &e2) {
-    if (e1.min_y == e2.min_y)
-      return e1.min_x < e2.min_x;
-    return e1.min_y < e2.min_y;
-  }
-
-  static bool CompareX(const Edge &e1, const Edge &e2) {
-    return e1.min_x < e2.min_x;
-  }
-
- public:
-  int32 min_y;
-  int32 max_y;
-  double min_x;
-  double _1_m;
-};
-
 // This class represents convex or concave non-self-intersecting polygons.
 class Polygon {
  public:

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -131,9 +131,9 @@ std::string Authenticator::computeDigestResponse(const std::string &method, cons
 #if HAVE_DECL_MD5 || HAVE_DECL_GNUTLS_FINGERPRINT
   // The "response" field is computed as:
   //  md5(md5(<username>:<realm>:<password>):<nonce>:md5(<cmd>:<url>))
-  size_t md5len = 16;
-  unsigned char md5buf[md5len];
-  char md5HexBuf[md5len*2+1];
+  constexpr size_t md5len = 16;
+  uint8 md5buf[md5len];
+  char md5HexBuf[md5len * 2 + 1];
   
   // Step 1: md5(<username>:<realm>:<password>)
   std::string ha1Data = username() + ":" + realm() + ":" + password();

--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -236,8 +236,8 @@ User *zmLoadAuthUser(const char *auth, bool use_remote_addr) {
   }
   char auth_key[512] = "";
   char auth_md5[32+1] = "";
-  size_t md5len = 16;
-  unsigned char md5sum[md5len];
+  constexpr size_t md5len = 16;
+  uint8 md5sum[md5len];
 
   const char * hex = "0123456789abcdef";
   while ( MYSQL_ROW dbrow = mysql_fetch_row(result) ) {


### PR DESCRIPTION
VLAs are a C99 feature that never was specified for C++ (due to better alternatives). Remove VLA usage from the codebase and switch on `Wvla` so we get notified on accidental introduction.