### PR TITLE
[Backport 1.36] Utils: Fix possible name clash between std::clamp and ZM::clamp

### DIFF
--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -96,7 +96,7 @@ constexpr const T &clamp(const T &v, const T &lo, const T &hi, Compare comp) {
 
 template<class T>
 constexpr const T &clamp(const T &v, const T &lo, const T &hi) {
-  return clamp(v, lo, hi, std::less<T>{});
+  return ZM::clamp(v, lo, hi, std::less<T>{});
 }
 }
 


### PR DESCRIPTION
The naming was ambiguous when compinling in C++17 mode.

(cherry picked from commit a335e740f3b8abcd3085afaa06820074e4f20e95)