### PR TITLE
Enable gitlab CI to build debian packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+default:
+  image:
+    name: ubuntu:latest
+  before_script:
+    - apt-get update -yq
+    - DEBIAN_FRONTEND=noninteractive apt-get install -yq devscripts sudo
+
+deb:
+  stage: build
+  tags:
+    - docker
+  script:
+    - yes "" | ./utils/do_debian_package.sh --snapshot=stable --branch=1.36.1 --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
+  artifacts:
+    paths:
+      - '*.deb'
+    expire_in: 1 week

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -58,6 +58,14 @@ case $i in
     PACKAGE_VERSION="${i#*=}"
     shift
     ;;
+    -x=*|--debbuild-extra=*)
+    DEBBUILD_EXTRA="${i#*=}"
+    shift
+    ;;
+    --dput=*)
+    DPUT="${i#*=}"
+    shift
+    ;;
     --default)
     DEFAULT=YES
     shift # past argument with no value
@@ -306,9 +314,11 @@ EOF
   if [ "$DEBSIGN_KEYID" != "" ]; then
     DEBUILD="$DEBUILD -k$DEBSIGN_KEYID"
   fi
+  # Add any extra options specified on the CLI
+  DEBUILD="$DEBUILD $DEBBUILD_EXTRA"
   eval $DEBUILD
   if [ $? -ne 0 ]; then
-  echo "Error status code is: $?"
+    echo "Error status code is: $?"
     echo "Build failed.";
     exit $?;
   fi;
@@ -344,8 +354,10 @@ EOF
         dput $PPA $SC
       fi;
     else
-      echo "dputting to $PPA";
-      dput $PPA $SC
+      if [ "$DPUT" != "no" ]; then
+        echo "dputting to $PPA";
+        dput $PPA $SC
+      fi;
     fi;
   fi;
 done; # foreach distro


### PR DESCRIPTION
Adding a .gitlab-ci.yml file so my infrastructure can build .deb packages automatically.

I wanted to reuse as much of the existing code as possible, so I added some options to do_debian_package.sh and made sure they defaulted to values which ensure that everything functions as it did before if they are not specified.

The `yes ""` is to accept defaults when prompted by things like apt, asking if it's okay to install dependence.  If apt detects that the signature doesn't match, it will make the default choice "no".  That is why I chose to always accept the default, rather than always answering "yes".

The || true at the end is required either because of a [bug/limitation in GitLab's CI](https://stackoverflow.com/questions/65412154/gitlab-runner-throws-cleaning-up-file-based-variables-0001-error-job-failed), or there's some command in do_debian_package.sh which is returning a non-zero exit status.  To be clear, do_debian_package.sh builds everything correctly whether run from GitLab CI or in a standalone environment.  The .deb files are produced, they install fine, the dependencies get installed when the package is installed, the database gets set up correctly... really, it's fine.

Instead of changing a bunch of code in do_debian_package.sh to try to make sure everything returns with an exit code of zero (or hacking around limitations of GitLab CI, if that's the problem), so I just slapped the `|| true` on the end.

Finally, the reason the CI specifically builds branch 1.36.1 is because there was some problem of automatically detecting the branch based on `--snapshot=stable`.  More specifically, `$(git rev-list --tags --max-count=1)` returned an empty string on [line 114](https://github.com/ZoneMinder/zoneminder/blob/master/utils/do_debian_package.sh#L114).  Again, this may be because of some limitation of GitLab CI.  I have not yet attempted to debug it and didn't want to muddy up the "add a CI file" pull request up with other changes which were not strictly necessary.  I will likely chase that down in a future release with another small pull request.

Thanks in advance for allowing me to contribute. :heart: 