### PR TITLE
FfmpegCamera/Videostore: Disable hwaccel for ffmpeg found in Debian Stretch

### DIFF
--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -428,8 +428,8 @@ int FfmpegCamera::OpenFfmpeg() {
 
   if ( use_hwaccel && (hwaccel_name != "") ) {
 #if HAVE_LIBAVUTIL_HWCONTEXT_H
-    // 3.2 doesn't seem to have all the bits in place, so let's require 3.3 and up
-  #if LIBAVCODEC_VERSION_CHECK(57, 89, 0, 89, 0)
+    // 3.2 doesn't seem to have all the bits in place, so let's require 3.4 and up
+  #if LIBAVCODEC_VERSION_CHECK(57, 107, 0, 107, 0)
     // Print out available types
     enum AVHWDeviceType type = AV_HWDEVICE_TYPE_NONE;
     while ( (type = av_hwdevice_iterate_types(type)) != AV_HWDEVICE_TYPE_NONE )

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -37,7 +37,7 @@ extern "C" {
       */
 
 VideoStore::CodecData VideoStore::codec_data[] = {
-#if HAVE_LIBAVUTIL_HWCONTEXT_H
+#if HAVE_LIBAVUTIL_HWCONTEXT_H && LIBAVCODEC_VERSION_CHECK(57, 107, 0, 107, 0)
   { AV_CODEC_ID_H265, "h265", "hevc_vaapi", AV_PIX_FMT_NV12, AV_PIX_FMT_VAAPI, AV_HWDEVICE_TYPE_VAAPI },
   { AV_CODEC_ID_H265, "h265", "hevc_nvenc", AV_PIX_FMT_NV12, AV_PIX_FMT_NV12, AV_HWDEVICE_TYPE_NONE },
   { AV_CODEC_ID_H265, "h265", "libx265", AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV420P, AV_HWDEVICE_TYPE_NONE  },
@@ -246,7 +246,7 @@ bool VideoStore::open() {
            * the motion of the chroma plane does not match the luma plane. */
           video_out_ctx->mb_decision = 2;
         }
-#if HAVE_LIBAVUTIL_HWCONTEXT_H
+#if HAVE_LIBAVUTIL_HWCONTEXT_H && LIBAVCODEC_VERSION_CHECK(57, 107, 0, 107, 0)
         if (codec_data[i].hwdevice_type != AV_HWDEVICE_TYPE_NONE) {
           Debug(1, "Setting up hwdevice");
           ret = av_hwdevice_ctx_create(&hw_device_ctx,

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -37,7 +37,7 @@ class VideoStore {
       const char *codec_name;
       const enum AVPixelFormat sw_pix_fmt;
       const enum AVPixelFormat hw_pix_fmt;
-#if HAVE_LIBAVUTIL_HWCONTEXT_H
+#if HAVE_LIBAVUTIL_HWCONTEXT_H && LIBAVCODEC_VERSION_CHECK(57, 107, 0, 107, 0)
       const AVHWDeviceType hwdevice_type;
 #endif
     };


### PR DESCRIPTION
The av_hwdevice_* API is not complete in 3.2. Enable hwaccel from 3.4 onwards.