### PR TITLE
Build: Make crypto and JWT backends selectable

### DIFF
--- a/.github/workflows/ci-buster.yml
+++ b/.github/workflows/ci-buster.yml
@@ -12,6 +12,20 @@ jobs:
     defaults:
       run:
         shell: bash
+    strategy:
+      matrix:
+        crypto_backend: [ gnutls, openssl ]
+        jwt_backend: [ libjwt, jwt_cpp ]
+        include:
+          - crypto_backend: gnutls
+            crypto_package: libgnutls28-dev
+            jwt_package: libjwt-gnutls-dev
+          - crypto_backend: openssl
+            crypto_package: libssl-dev
+            jwt_package: libjwt-dev
+        exclude:
+          - crypto_backend: gnutls
+            jwt_backend: jwt_cpp
     runs-on: ubuntu-latest
     container: debian:buster
 
@@ -24,10 +38,10 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: apt-get -qq install make cmake g++ default-libmysqlclient-dev libavdevice-dev libcurl4-gnutls-dev libvlc-dev libvncserver-dev libdate-manip-perl libdbd-mysql-perl libsys-mmap-perl libwww-perl libpolkit-gobject-1-dev libssl-dev
+        run: apt-get -qq install make cmake g++ default-libmysqlclient-dev libavdevice-dev libcurl4-gnutls-dev libvlc-dev libvncserver-dev libdate-manip-perl libdbd-mysql-perl libsys-mmap-perl libwww-perl libpolkit-gobject-1-dev ${{ matrix.crypto_package }} ${{ matrix.jwt_package }}
       - name: Prepare
         run: mkdir build
       - name: Configure
-        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0 -DENABLE_WERROR=1
+        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0 -DENABLE_WERROR=1 -DZM_CRYPTO_BACKEND=${{ matrix.crypto_backend }} -DZM_JWT_BACKEND=${{ matrix.jwt_backend }}
       - name: Build
         run: cd build && make -j3 | grep --line-buffered -Ev '^(cp lib\/|Installing.+\.pm)' && (exit ${PIPESTATUS[0]})

--- a/.github/workflows/ci-centos-7.yml
+++ b/.github/workflows/ci-centos-7.yml
@@ -9,6 +9,15 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        crypto_backend: [ gnutls, openssl ]
+        jwt_backend: [ libjwt, jwt_cpp ]
+        exclude:
+          - crypto_backend: gnutls
+            jwt_backend: jwt_cpp
+          - crypto_backend: gnutls
+            jwt_backend: libjwt
     runs-on: ubuntu-latest
     container: centos:7
 
@@ -21,10 +30,10 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: yum -y update && yum -y install make cmake3 gcc-c++ mariadb-devel ffmpeg-devel libcurl-devel vlc-devel libvncserver-devel libjpeg-turbo-devel "perl(Date::Manip)" "perl(DBD::mysql)" "perl(ExtUtils::MakeMaker)" "perl(Sys::Mmap)" "perl(Sys::Syslog)" "perl(LWP::UserAgent)" polkit-devel
+        run: yum -y update && yum -y install make cmake3 gcc-c++ mariadb-devel ffmpeg-devel libcurl-devel vlc-devel libvncserver-devel libjpeg-turbo-devel "perl(Date::Manip)" "perl(DBD::mysql)" "perl(ExtUtils::MakeMaker)" "perl(Sys::Mmap)" "perl(Sys::Syslog)" "perl(LWP::UserAgent)" polkit-devel libjwt-devel
       - name: Prepare
         run: mkdir build
       - name: Configure
-        run: cd build && cmake3 --version && cmake3 .. -DBUILD_MAN=0 -DENABLE_WERROR=1
+        run: cd build && cmake3 --version && cmake3 .. -DBUILD_MAN=0 -DENABLE_WERROR=1 -DZM_CRYPTO_BACKEND=${{ matrix.crypto_backend }} -DZM_JWT_BACKEND=${{ matrix.jwt_backend }}
       - name: Build
         run: cd build && make -j3 | grep --line-buffered -Ev '^(cp lib\/|Installing.+\.pm)' && (exit ${PIPESTATUS[0]})

--- a/.github/workflows/ci-centos-8.yml
+++ b/.github/workflows/ci-centos-8.yml
@@ -9,6 +9,15 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        crypto_backend: [ gnutls, openssl ]
+        jwt_backend: [ libjwt, jwt_cpp ]
+        exclude:
+          - crypto_backend: gnutls
+            jwt_backend: jwt_cpp
+          - crypto_backend: gnutls
+            jwt_backend: libjwt
     runs-on: ubuntu-latest
     container: centos:8
 
@@ -21,11 +30,11 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: yum -y update && yum -y install make cmake gcc-c++ catch-devel mariadb-devel ffmpeg-devel libcurl-devel vlc-devel libvncserver-devel libjpeg-turbo-devel "perl(Date::Manip)" "perl(DBD::mysql)" "perl(ExtUtils::MakeMaker)" "perl(Sys::Mmap)" "perl(Sys::Syslog)" "perl(LWP::UserAgent)" polkit-devel
+        run: yum -y update && yum -y install make cmake gcc-c++ catch-devel mariadb-devel ffmpeg-devel libcurl-devel vlc-devel libvncserver-devel libjpeg-turbo-devel "perl(Date::Manip)" "perl(DBD::mysql)" "perl(ExtUtils::MakeMaker)" "perl(Sys::Mmap)" "perl(Sys::Syslog)" "perl(LWP::UserAgent)" polkit-devel libjwt-devel
       - name: Prepare
         run: mkdir build
       - name: Configure
-        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0 -DBUILD_TEST_SUITE=1 -DENABLE_WERROR=1
+        run: cd build && cmake --version && cmake .. -DBUILD_MAN=0 -DBUILD_TEST_SUITE=1 -DENABLE_WERROR=1  -DZM_CRYPTO_BACKEND=${{ matrix.crypto_backend }} -DZM_JWT_BACKEND=${{ matrix.jwt_backend }}
       - name: Build
         run: cd build && make -j3 | grep --line-buffered -Ev '^(cp lib\/|Installing.+\.pm)' && (exit ${PIPESTATUS[0]})
       - name: Run tests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
         git submodule update --init --recursive
         sudo apt-get update
         sudo apt-get install libavdevice-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev  libjwt-gnutls-dev
-        sudo apt-get install libbz2-dev libgcrypt20-dev libcurl4-gnutls-dev libjpeg-turbo8-dev libturbojpeg0-dev
+        sudo apt-get install libbz2-dev libcurl4-gnutls-dev libjpeg-turbo8-dev libturbojpeg0-dev
         sudo apt-get install default-libmysqlclient-dev libpcre3-dev libpolkit-gobject-1-dev libv4l-dev libvlc-dev
         sudo apt-get install libdate-manip-perl libdbd-mysql-perl libphp-serialization-perl libsys-mmap-perl
         sudo apt-get install libwww-perl libdata-uuid-perl libssl-dev libcrypt-eksblowfish-perl libdata-entropy-perl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,23 +411,6 @@ else()
   set(optlibsnotfound "${optlibsnotfound} PCRE")
 endif()
 
-# gcrypt (using find_library and find_path)
-find_library(GCRYPT_LIBRARIES gcrypt)
-if(GCRYPT_LIBRARIES)
-  set(HAVE_LIBGCRYPT 1)
-  list(APPEND ZM_BIN_LIBS "${GCRYPT_LIBRARIES}")
-  find_path(GCRYPT_INCLUDE_DIR gcrypt.h)
-  if(GCRYPT_INCLUDE_DIR)
-    include_directories("${GCRYPT_INCLUDE_DIR}")
-    set(CMAKE_REQUIRED_INCLUDES "${GCRYPT_INCLUDE_DIR}")
-  endif()
-  mark_as_advanced(FORCE GCRYPT_LIBRARIES GCRYPT_INCLUDE_DIR)
-  check_include_file("gcrypt.h" HAVE_GCRYPT_H)
-  set(optlibsfound "${optlibsfound} GCrypt")
-else()
-  set(optlibsnotfound "${optlibsnotfound} GCrypt")
-endif()
-
 # mysqlclient (using find_library and find_path)
 find_library(MYSQLCLIENT_LIBRARIES mysqlclient PATH_SUFFIXES mysql)
 if(MYSQLCLIENT_LIBRARIES)
@@ -708,10 +691,9 @@ if((NOT HAVE_MD5_OPENSSL) AND (NOT HAVE_DECL_GNUTLS_FINGERPRINT))
      none were found - hashed authentication will not be available")
 endif()
 
-# Dirty fix for zm_user only using openssl's md5 if gnutls and gcrypt are not available.
+# Dirty fix for zm_user only using openssl's md5 if gnutls is not available.
 # This needs to be fixed in zm_user.[h,cpp] but such fix will also require changes to configure.ac
 if(HAVE_LIBCRYPTO AND HAVE_OPENSSL_MD5_H AND HAVE_MD5_OPENSSL)
-  set(HAVE_GCRYPT_H 0)
   set(HAVE_GNUTLS_OPENSSL_H 0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,15 @@ set(ZM_MANPAGE_DEST_PREFIX "share/man" CACHE PATH
     non-standard folder. Most Linux users will not need to change this.
     BSD users may need to set this.")
 
+# Supported crypto backends. Using OpenSSL by default to be compatible with jwt-cpp.
+set(ZM_CRYPTO_BACKEND_OPTIONS gnutls openssl)
+set(ZM_CRYPTO_BACKEND openssl CACHE STRING "Determines which crypto backend should be used.")
+set_property(CACHE ZM_CRYPTO_BACKEND PROPERTY STRINGS ${ZM_CRYPTO_BACKEND_OPTIONS})
+
+if(NOT ZM_CRYPTO_BACKEND IN_LIST ZM_CRYPTO_BACKEND_OPTIONS)
+  message(FATAL_ERROR "Invalid value for ZM_CRYPTO_BACKEND. Possible options: ${ZM_CRYPTO_BACKEND_OPTIONS}")
+endif()
+
 # Reassign some variables if a target distro has been specified
 if((ZM_TARGET_DISTRO MATCHES "^el") OR (ZM_TARGET_DISTRO MATCHES "^fc"))
   set(ZM_RUNDIR "/var/run/zoneminder")
@@ -340,9 +349,9 @@ else()
   set(optlibsnotfound "${optlibsnotfound} LIBJWT")
 endif()
 
-# gnutls (using find_library and find_path)
-if(HAVE_LIBJWT)
-  find_library(GNUTLS_LIBRARIES gnutls)
+# GnuTLS
+if (${ZM_CRYPTO_BACKEND} STREQUAL "gnutls")
+  find_library(GNUTLS_LIBRARIES gnutls REQUIRED)
   if(GNUTLS_LIBRARIES)
     set(HAVE_LIBGNUTLS 1)
     list(APPEND ZM_BIN_LIBS "${GNUTLS_LIBRARIES}")
@@ -357,11 +366,9 @@ if(HAVE_LIBJWT)
   else()
     set(optlibsnotfound "${optlibsnotfound} GnuTLS")
   endif()
-endif()
-
 # OpenSSL
-if(NOT HAVE_LIBGNUTLS OR NOT HAVE_LIBJWT)
-  find_package(OpenSSL)
+elseif (${ZM_CRYPTO_BACKEND} STREQUAL "openssl")
+  find_package(OpenSSL REQUIRED)
   if(OPENSSL_FOUND)
     set(HAVE_LIBOPENSSL 1)
     set(HAVE_LIBCRYPTO 1)
@@ -619,9 +626,9 @@ endif()
 #
 # *** END OF LIBRARY CHECKS ***
 
-# Check for gnutls or crypto
-if((NOT HAVE_LIBCRYPTO) AND (NOT HAVE_LIBGNUTLS))
-  message(FATAL_ERROR "ZoneMinder requires crypto or gnutls but none were found on your system")
+# If libjwt is not present we fall back to jwt-cpp which requires OpenSSL
+if((NOT HAVE_LIBJWT) AND (NOT HAVE_LIBOPENSSL))
+  message(FATAL_ERROR "Using the jwt-cpp backend requires OpenSSL as crypto backend.")
 endif()
 
 # Check for V4L header files and enable ZM_HAS_V4L, ZM_HAS_V4L1, ZM_HAS_V4L2 accordingly
@@ -833,6 +840,8 @@ endif()
 # Print optional libraries detection status
 message(STATUS "Optional libraries found:${optlibsfound}")
 message(STATUS "Optional libraries not found:${optlibsnotfound}")
+
+message(STATUS "Enabled crypto backend: ${ZM_CRYPTO_BACKEND}")
 
 # Run ZM configuration generator
 message(STATUS "Running ZoneMinder configuration generator")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,15 @@ if(NOT ZM_CRYPTO_BACKEND IN_LIST ZM_CRYPTO_BACKEND_OPTIONS)
   message(FATAL_ERROR "Invalid value for ZM_CRYPTO_BACKEND. Possible options: ${ZM_CRYPTO_BACKEND_OPTIONS}")
 endif()
 
+# Supported JWT backends. Using jwt-cpp as default.
+set(ZM_JWT_BACKEND_OPTIONS libjwt jwt_cpp)
+set(ZM_JWT_BACKEND jwt_cpp CACHE STRING "Determines which JWT backend should be used.")
+set_property(CACHE ZM_JWT_BACKEND PROPERTY STRINGS ${ZM_JWT_BACKEND_OPTIONS})
+
+if(NOT ZM_JWT_BACKEND IN_LIST ZM_JWT_BACKEND_OPTIONS)
+  message(FATAL_ERROR "Invalid value for ZM_JWT_BACKEND. Possible options: ${ZM_JWT_BACKEND_OPTIONS}")
+endif()
+
 # Reassign some variables if a target distro has been specified
 if((ZM_TARGET_DISTRO MATCHES "^el") OR (ZM_TARGET_DISTRO MATCHES "^fc"))
   set(ZM_RUNDIR "/var/run/zoneminder")
@@ -339,14 +348,15 @@ else()
     "ZoneMinder requires jpeg but it was not found on your system")
 endif()
 
-# LIBJWT
-find_package(LibJWT)
-if(LIBJWT_FOUND)
-  set(HAVE_LIBJWT 1)
-  set(optlibsfound "${optlibsfound} LIBJWT")
-  list(APPEND ZM_BIN_LIBS "${LIBJWT_LIBRARY}")
-else()
-  set(optlibsnotfound "${optlibsnotfound} LIBJWT")
+# libjwt
+if (${ZM_JWT_BACKEND} STREQUAL "libjwt")
+  find_package(LibJWT REQUIRED COMPONENTS ${ZM_CRYPTO_BACKEND})
+  if(LIBJWT_FOUND)
+    set(HAVE_LIBJWT 1)
+    set(optlibsfound "${optlibsfound} LIBJWT")
+  else()
+    set(optlibsnotfound "${optlibsnotfound} LIBJWT")
+  endif()
 endif()
 
 # GnuTLS
@@ -842,6 +852,7 @@ message(STATUS "Optional libraries found:${optlibsfound}")
 message(STATUS "Optional libraries not found:${optlibsnotfound}")
 
 message(STATUS "Enabled crypto backend: ${ZM_CRYPTO_BACKEND}")
+message(STATUS "Enabled JWT backend: ${ZM_JWT_BACKEND}")
 
 # Run ZM configuration generator
 message(STATUS "Running ZoneMinder configuration generator")

--- a/cmake/Modules/FindLibJWT.cmake
+++ b/cmake/Modules/FindLibJWT.cmake
@@ -1,28 +1,89 @@
-include(FindPackageHandleStandardArgs)
+#[=======================================================================[.rst:
+FindLibJWT
+----------
 
+Find the JWT C Library (libjwt)
+
+
+This module accepts optional COMPONENTS to select the crypto backend (these are mutually exclusive)::
+
+  openssl (default)
+  gnutls
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``JWT::libjwt``
+  The JWT library, if found with the specified crypto backend.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``LIBJWT_FOUND``
+  System has libjwt
+``LIBJWT_INCLUDE_DIR``
+  The libjwt include directory
+``LIBJWT_LIBRARIES``
+  The libraries needed to use libjwt
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
 find_package(PkgConfig QUIET)
+
+if(LibJWT_FIND_COMPONENTS)
+  set(LIBJWT_CRYPTO_BACKEND "")
+  foreach(component IN LISTS LibJWT_FIND_COMPONENTS)
+    if(component MATCHES "^(openssl|gnutls)")
+      if(LIBJWT_CRYPTO_BACKEND)
+        message(FATAL_ERROR "LibJWT: Only one crypto library can be selected.")
+      endif()
+    set(LIBJWT_CRYPTO_BACKEND ${component})
+    else()
+      message(FATAL_ERROR "LibJWT: Wrong crypto backend specified.")
+    endif()
+  endforeach()
+else()
+  set(LIBJWT_CRYPTO_BACKEND "openssl")
+endif()
+
+set(LIBJWT_LIB_NAMES "")
+if(LIBJWT_CRYPTO_BACKEND STREQUAL "openssl")
+  set(LIBJWT_LIB_NAMES "jwt" "libjwt")
+elseif(LIBJWT_CRYPTO_BACKEND STREQUAL "gnutls")
+  set(LIBJWT_LIB_NAMES "jwt-gnutls" "libjwt-gnutls")
+endif()
+
 pkg_check_modules(PC_LIBJWT QUIET libjwt)
 
 find_path(LIBJWT_INCLUDE_DIR
   NAMES jwt.h
-  HINTS ${PC_LIBJWT_INCLUDEDIR} ${PC_LIBJWT_INCLUDE_DIRS}
-  )
+  HINTS
+    ${PC_LIBJWT_INCLUDEDIR}
+    ${PC_LIBJWT_INCLUDE_DIRS})
+mark_as_advanced(LIBJWT_INCLUDE_DIR)
 
 find_library(LIBJWT_LIBRARY
-  NAMES jwt-gnutls libjwt-gnutls liblibjwt-gnutls
-  HINTS ${PC_LIBJWT_LIBDIR} ${PC_LIBJWT_LIBRARY_DIR}
-  )
+  NAMES ${LIBJWT_LIB_NAMES}
+  HINTS
+    ${PC_LIBJWT_LIBDIR}
+    ${PC_LIBJWT_LIBRARY_DIR})
+mark_as_advanced(LIBJWT_LIBRARY)
 
 find_package_handle_standard_args(LibJWT
-  REQUIRED_VARS LIBJWT_INCLUDE_DIR LIBJWT_LIBRARY
-  )
+  REQUIRED_VARS
+    LIBJWT_INCLUDE_DIR
+    LIBJWT_LIBRARY
+  FAIL_MESSAGE
+    "Could NOT find LibJWT with the crypto backend ${LIBJWT_CRYPTO_BACKEND}.")
 
 if(LIBJWT_FOUND)
-  add_library(libjwt STATIC IMPORTED GLOBAL)
-  set_target_properties(libjwt PROPERTIES
-    IMPORTED_LOCATION "${LIBJWT_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${LIBJWT_INCLUDE_DIR}"
-    )
-endif()
+  set(LIBJWT_LIBRARIES ${LIBJWT_LIBRARY})
+  set(LIBJWT_INCLUDE_DIRS ${LIBJWT_INCLUDE_DIR})
 
-mark_as_advanced(LIBJWT_INCLUDE_DIR LIBJWT_LIBRARY)
+  add_library(JWT::libjwt UNKNOWN IMPORTED)
+  set_target_properties(JWT::libjwt PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${LIBJWT_INCLUDE_DIRS}"
+    IMPORTED_LOCATION "${LIBJWT_LIBRARY}")
+endif()

--- a/distros/beowulf/control
+++ b/distros/beowulf/control
@@ -14,7 +14,6 @@ Build-Depends: debhelper, sphinx-doc, dh-linktree, dh-apache2
               ,ffmpeg
               ,net-tools
               ,libbz2-dev
-              ,libgcrypt20-dev
               ,libcurl4-gnutls-dev
               ,libturbojpeg0-dev
               ,default-libmysqlclient-dev | libmysqlclient-dev | libmariadbclient-dev-compat

--- a/distros/debian/control
+++ b/distros/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9), cmake
     , libnetpbm10-dev
     , libvlccore-dev, libvlc-dev
     , libcurl4-gnutls-dev | libcurl4-nss-dev | libcurl4-openssl-dev
-    , libgcrypt11-dev, libpolkit-gobject-1-dev
+    , libpolkit-gobject-1-dev
     , libphp-serialization-perl
     , libdate-manip-perl, libmime-lite-perl, libmime-tools-perl, libdbd-mysql-perl
     , libwww-perl, libarchive-tar-perl, libarchive-zip-perl, libdevice-serialport-perl

--- a/distros/opensuse/zoneminder.cmake.OS13.spec
+++ b/distros/opensuse/zoneminder.cmake.OS13.spec
@@ -27,7 +27,7 @@ Source: ZoneMinder-%{version}.tar.gz
 
 BuildRequires: cmake polkit-devel
 BuildRequires: perl-DBI perl-DBD-mysql perl-Date-Manip perl-Sys-Mmap 
-BuildRequires: libjpeg62 libjpeg62-devel libmysqld-devel libSDL-devel libgcrypt-devel libgnutls-devel
+BuildRequires: libjpeg62 libjpeg62-devel libmysqld-devel libSDL-devel libgnutls-devel
 BuildRequires: libffmpeg-devel x264
 BuildRequires: pcre-devel w32codec-all  
 

--- a/distros/ubuntu1504_cmake_split_packages/control
+++ b/distros/ubuntu1504_cmake_split_packages/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 9), po-debconf (>= 1.0), autoconf, automake, libtoo
 , libdevice-serialport-perl, libarchive-zip-perl, libmime-lite-perl
 , libvlccore-dev, libvlc-dev
 , libcurl4-gnutls-dev | libcurl4-nss-dev | libcurl4-openssl-dev
-, libgcrypt11-dev | libgcrypt20-dev, libpolkit-gobject-1-dev
+, libpolkit-gobject-1-dev
 , libdbi-perl, libnet-sftp-foreign-perl, libexpect-perl, libmime-tools-perl
 Standards-Version: 3.9.6
 Homepage: http://www.zoneminder.com/

--- a/distros/ubuntu1604/control
+++ b/distros/ubuntu1604/control
@@ -14,7 +14,6 @@ Build-Depends: debhelper (>= 9), dh-systemd, python3-sphinx, apache2-dev, dh-lin
               ,ffmpeg | libav-tools
               ,net-tools
               ,libbz2-dev
-              ,libgcrypt-dev | libgcrypt11-dev
               ,libcurl4-gnutls-dev
               ,libgnutls-openssl-dev
               ,libjpeg8-dev | libjpeg9-dev | libjpeg62-turbo-dev

--- a/distros/ubuntu2004/control
+++ b/distros/ubuntu2004/control
@@ -13,7 +13,6 @@ Build-Depends: debhelper (>= 12), sphinx-doc, python3-sphinx, dh-linktree, dh-ap
               ,ffmpeg
               ,net-tools
               ,libbz2-dev
-              ,libgcrypt20-dev
               ,libcurl4-gnutls-dev
               ,libjpeg-turbo8-dev | libjpeg62-turbo-dev | libjpeg8-dev | libjpeg9-dev
               ,libturbojpeg0-dev

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,11 +78,20 @@ target_include_directories(zm
 target_link_libraries(zm
   PUBLIC
     libbcrypt::bcrypt
-    jwt-cpp::jwt-cpp
     RtspServer::RtspServer
     martinmoene::span-lite
   PRIVATE
     zm-core-interface)
+
+if(${ZM_JWT_BACKEND} STREQUAL "jwt_cpp")
+  target_link_libraries(zm
+    PUBLIC
+      jwt-cpp::jwt-cpp)
+elseif(${ZM_JWT_BACKEND} STREQUAL "libjwt")
+  target_link_libraries(zm
+    PUBLIC
+      JWT::libjwt)
+endif()
 
 add_executable(zmc zmc.cpp)
 add_executable(zms zms.cpp)

--- a/src/zm_rtsp_auth.cpp
+++ b/src/zm_rtsp_auth.cpp
@@ -22,26 +22,16 @@
 #include "zm_utils.h"
 #include <cassert>
 #include <cstring>
+#include <utility>
 
 namespace zm {
 
-Authenticator::Authenticator( const std::string &username, const std::string &password) : 
- fCnonce("0a4f113b"),
- fUsername(username),
- fPassword(password)
-  {
-#ifdef HAVE_GCRYPT_H
-  // Special initialisation for libgcrypt
-  if ( !gcry_check_version(GCRYPT_VERSION) ) {
-    Fatal("Unable to initialise libgcrypt");
-  }
-  gcry_control( GCRYCTL_DISABLE_SECMEM, 0 );
-  gcry_control( GCRYCTL_INITIALIZATION_FINISHED, 0 );
-#endif // HAVE_GCRYPT_H
-  
-  fAuthMethod = AUTH_UNDEFINED;
-  nc = 1;
-}
+Authenticator::Authenticator(std::string username, std::string password)
+    : fAuthMethod(AUTH_UNDEFINED),
+      fCnonce("0a4f113b"),
+      fUsername(std::move(username)),
+      fPassword(std::move(password)),
+      nc(1) {}
 
 Authenticator::~Authenticator() {
   reset();

--- a/src/zm_rtsp_auth.h
+++ b/src/zm_rtsp_auth.h
@@ -26,18 +26,16 @@
 #include <gnutls/gnutls.h>
 #endif
 
-#if HAVE_GCRYPT_H
-#include <gcrypt.h>
-#elif HAVE_LIBCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/md5.h>
-#endif // HAVE_GCRYPT_H || HAVE_LIBCRYPTO
+#endif // HAVE_LIBCRYPTO
 
-namespace zm { 
+namespace zm {
 
 enum AuthMethod { AUTH_UNDEFINED = 0, AUTH_BASIC = 1, AUTH_DIGEST = 2 };
 class Authenticator {
 public:
-  Authenticator(const std::string &username, const std::string &password);
+  Authenticator(std::string username, std::string password);
   virtual ~Authenticator();
   void reset();
 

--- a/src/zm_user.cpp
+++ b/src/zm_user.cpp
@@ -29,11 +29,9 @@
 #include <gnutls/gnutls.h>
 #endif
 
-#if HAVE_GCRYPT_H
-#include <gcrypt.h>
-#elif HAVE_LIBCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/md5.h>
-#endif  // HAVE_GCRYPT_H || HAVE_LIBCRYPTO
+#endif  // HAVE_LIBCRYPTO
 
 User::User() {
   id = 0;
@@ -192,15 +190,6 @@ User *zmLoadTokenUser(const std::string &jwt_token_str, bool use_remote_addr) {
 // Function to validate an authentication string
 User *zmLoadAuthUser(const char *auth, bool use_remote_addr) {
 #if HAVE_DECL_MD5 || HAVE_DECL_GNUTLS_FINGERPRINT
-#ifdef HAVE_GCRYPT_H
-  // Special initialisation for libgcrypt
-  if ( !gcry_check_version(GCRYPT_VERSION) ) {
-    Fatal("Unable to initialise libgcrypt");
-  }
-  gcry_control(GCRYCTL_DISABLE_SECMEM, 0);
-  gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
-#endif  // HAVE_GCRYPT_H
-
   const char *remote_addr = "";
   if ( use_remote_addr ) {
     remote_addr = getenv("REMOTE_ADDR");

--- a/zoneminder-config.cmake
+++ b/zoneminder-config.cmake
@@ -35,8 +35,6 @@
 #cmakedefine HAVE_PTHREAD_H
 #cmakedefine HAVE_LIBPCRE 1
 #cmakedefine HAVE_PCRE_H 1
-#cmakedefine HAVE_LIBGCRYPT 1
-#cmakedefine HAVE_GCRYPT_H 1
 #cmakedefine HAVE_LIBGNUTLS 1
 #cmakedefine HAVE_GNUTLS_GNUTLS_H 1
 #cmakedefine HAVE_LIBMYSQLCLIENT 1


### PR DESCRIPTION
Add 2 new CMake options:

- `ZM_CRYPTO_BACKEND`: selects the crypto backend against which ZM should be built. Options: `openssl` (default) and `gnutls`
- `ZM_JWT_BACKEND`: selects the JWT backend against which ZM should be built. Options: `jwt_cpp` (default; in-tree) and `libjwt`

Additionally test all possible combinations during CI.

**Note**: With this an installed crypto library gets mandatory.