### PR TITLE
Fixed bug in onvifprobe interface selection

### DIFF
--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -50,7 +50,7 @@ function execONVIF($cmd) {
 
 function probeCameras($localIp) {
   $cameras = array();
-  $lines = @execONVIF('probe 1.1,1.2'.(isset($_REQUEST['interface']) ? ' '.isset($_REQUEST['interface']) : '' ));
+  $lines = @execONVIF('probe 1.1,1.2'.(isset($_REQUEST['interface']) ? ' '.$_REQUEST['interface'] : '' ));
   if ( $lines ) {
     foreach ( $lines as $line ) {
       $line = rtrim($line);


### PR DESCRIPTION
The arguments for "/usr/bin/zmonvif-probe.pl" were always `probe 1.1,1.2 1` with the last argument always being `1` instead of the network interface name selected in the menu.
This change fixes this issue by using the selected interface name instead of the boolean return value of the `isset()` function.