### PR TITLE
Restore video export capability from an event of still images

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -154,7 +154,11 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
 ?>
         <a class="btn btn-normal" href="<?php echo $Event->getStreamSrc(array('mode'=>'mp4'),'&amp;')?>" download><i class="fa fa-download"></i></a>
 <?php
-  } 
+  } else {
+?>
+        <button id="videoEvent" class="btn btn-normal" data-toggle="tooltip" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Download') ?>" onclick="videoEvent();"><i class="fa fa-download"></i></button>
+<?php
+  } // end if Event->DefaultVideo
 ?>
         <button id="statsBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Stats') ?>" ><i class="fa fa-info"></i></button>
         <button id="framesBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Frames') ?>" ><i class="fa fa-picture-o"></i></button>

--- a/web/skins/classic/views/video.php
+++ b/web/skins/classic/views/video.php
@@ -108,7 +108,8 @@ xhtmlHeaders(__FILE__, translate('Video'));
       <div class="float-left pl-3">
         <button type="button" id="backBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Back') ?>" disabled><i class="fa fa-arrow-left"></i></button>
         <button type="button" id="refreshBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Refresh') ?>" ><i class="fa fa-refresh"></i></button>
-        <button type="button" id="videoBtn" class="btn btn-normal" data-on-click="generateVideo" data-toggle="tooltip" data-placement="top" title="<?php echo translate('GenerateVideo') ?>" disabled><i class="fa fa-file-video-o"></i></button>
+        <button type="button" id="videoBtn" class="btn btn-normal" data-on-click="generateVideo" data-toggle="tooltip" data-placement="top" title="<?php echo translate('GenerateVideo') ?>" <?php if ( !ZM_OPT_FFMPEG ) { ?> disabled="disabled"<?php } ?>><i class="fa fa-file-video-o"></i></button>
+
       </div>
       <div class="w-100 pt-2">
         <h2><?php echo translate('Video') ?></h2>


### PR DESCRIPTION
This is my first ever pull request on GitHub, so if I make a mistake I genuinely apologize and would like to know what I could do better next time. Thanks :)

After I upgraded to the latest PPA of 1.36.4-focall on Ubuntu 20.04 from a much older version, I found that the ability to generate and export a video from still images captured from an mjpeg/jpeg camera was lost. It looks like some merges dropped some code necessary to maintain the functionality.

I restored the lost functionality and apply the design changes found in 1.36.