### PR TITLE
Image: Convert API to std::chrono

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -294,17 +294,18 @@ bool Event::WriteFrameImage(
 
   bool rc;
 
-  if ( !config.timestamp_on_capture ) {
+  SystemTimePoint jpeg_timestamp =
+      monitor->Exif() ? SystemTimePoint(zm::chrono::duration_cast<Microseconds>(timestamp)) : SystemTimePoint();
+
+  if (!config.timestamp_on_capture) {
     // stash the image we plan to use in another pointer regardless if timestamped.
     // exif is only timestamp at present this switches on or off for write
     Image *ts_image = new Image(*image);
     monitor->TimestampImage(ts_image, timestamp);
-    rc = ts_image->WriteJpeg(event_file, thisquality,
-        (monitor->Exif() ? timestamp : (timeval){0,0}));
-    delete(ts_image);
+    rc = ts_image->WriteJpeg(event_file, thisquality, jpeg_timestamp);
+    delete ts_image;
   } else {
-    rc = image->WriteJpeg(event_file, thisquality,
-        (monitor->Exif() ? timestamp : (timeval){0,0}));
+    rc = image->WriteJpeg(event_file, thisquality, jpeg_timestamp);
   }
 
   return rc;

--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -25,6 +25,7 @@
 #include "zm_logger.h"
 #include "zm_mem_utils.h"
 #include "zm_rgb.h"
+#include "zm_time.h"
 #include "zm_vector2.h"
 
 #if HAVE_ZLIB_H
@@ -237,9 +238,9 @@ class Image {
     bool WriteJpeg(const char *filename) const;
     bool WriteJpeg(const char *filename, bool on_blocking_abort) const;
     bool WriteJpeg(const char *filename, int quality_override) const;
-    bool WriteJpeg(const char *filename, struct timeval timestamp) const;
-    bool WriteJpeg(const char *filename, int quality_override, struct timeval timestamp) const;
-    bool WriteJpeg(const char *filename, int quality_override, struct timeval timestamp, bool on_blocking_abort) const;
+    bool WriteJpeg(const char *filename, SystemTimePoint timestamp) const;
+    bool WriteJpeg(const char *filename, int quality_override, SystemTimePoint timestamp) const;
+    bool WriteJpeg(const char *filename, int quality_override, SystemTimePoint timestamp, bool on_blocking_abort) const;
 
     bool DecodeJpeg(const JOCTET *inbuffer, int inbuffer_size, unsigned int p_colours, unsigned int p_subpixelorder);
     bool EncodeJpeg(JOCTET *outbuffer, int *outbuffer_size, int quality_override=0) const;
@@ -270,7 +271,7 @@ class Image {
                 Rgb bg_colour = kRGBBlack);
     Image *HighlightEdges( Rgb colour, unsigned int p_colours, unsigned int p_subpixelorder, const Box *limits=0 );
     //Image *HighlightEdges( Rgb colour, const Polygon &polygon );
-    void Timestamp(const char *label, const time_t when, const Vector2 &coord, const int size);
+    void Timestamp(const char *label, SystemTimePoint when, const Vector2 &coord, int label_size);
     void Colourise(const unsigned int p_reqcolours, const unsigned int p_reqsubpixelorder);
     void DeColourise();
 
@@ -300,8 +301,9 @@ class Edge {
   Edge(int32 min_y, int32 max_y, double min_x, double _1_m) : min_y(min_y), max_y(max_y), min_x(min_x), _1_m(_1_m) {}
 
   static bool CompareYX(const Edge &e1, const Edge &e2) {
-    if (e1.min_y == e2.min_y)
+    if (e1.min_y == e2.min_y) {
       return e1.min_x < e2.min_x;
+    }
     return e1.min_y < e2.min_y;
   }
 

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -180,16 +180,6 @@ std::string Base64Encode(const std::string &str) {
   return outString;
 }
 
-void TimespecDiff(struct timespec *start, struct timespec *end, struct timespec *diff) {
-  if (((end->tv_nsec) - (start->tv_nsec)) < 0) {
-    diff->tv_sec = end->tv_sec - start->tv_sec - 1;
-    diff->tv_nsec = 1000000000 + end->tv_nsec - start->tv_nsec;
-  } else {
-    diff->tv_sec = end->tv_sec - start->tv_sec;
-    diff->tv_nsec = end->tv_nsec - start->tv_nsec;
-  }
-}
-
 std::string TimevalToString(timeval tv) {
   tm now = {};
   std::array<char, 26> tm_buf = {};

--- a/src/zm_utils.h
+++ b/src/zm_utils.h
@@ -76,7 +76,6 @@ std::string ByteArrayToHexString(nonstd::span<const uint8> bytes);
 
 std::string Base64Encode(const std::string &str);
 
-void TimespecDiff(timespec *start, timespec *end, timespec *diff);
 std::string TimevalToString(timeval tv);
 
 extern unsigned int sse_version;


### PR DESCRIPTION
Utils: Remove TimespecDiff. It is not used anymore