### PR TITLE
API: allow option to not load the frames DB table

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -143,6 +143,10 @@ class EventsController extends AppController {
       $mon_options = '';
     }
 
+    $noFrames = $this->request->query('noframes');
+    if ($noFrames=='true')
+        $this->Event->unbindModel(array('hasMany' => array('Frame')));
+
     $options = array('conditions' => array(array('Event.' . $this->Event->primaryKey => $id), $mon_options));
     $event = $this->Event->find('first', $options);
 


### PR DESCRIPTION
The Events model has a `hasMany` relationship with Frames. While mostly useful, if your server isn't powerful and/or many frames then grabbing `/events/<eid>.json` makes it super slow. This PR allows a query parameter to dynamically unlinking the relationship if needed. See https://github.com/pliablepixels/zmNinja/issues/1073