### PR TITLE
Gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ deb:
   tags:
     - docker
   script:
-    - yes "" | ./utils/do_debian_package.sh --snapshot=stable --branch=1.36.1 --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
+    - yes "" | ./utils/do_debian_package.sh --snapshot=stable --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
   artifacts:
     paths:
       - '*.deb'

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -118,6 +118,8 @@ else
   fi;
   if [ "$SNAPSHOT" == "stable" ]; then
     if [ "$BRANCH" == "" ]; then
+      echo "About to run some basic commands for debugging..."
+      pwd; ls; git remote -v; git branch -v
       echo "About to get the hash of the most recent tag"
       REV=$(git rev-list --tags --max-count=1)
       echo "REV = $REV"

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -123,8 +123,8 @@ else
       if [ -z "$BRANCH" ]; then
         # This should only happen in CI environments where tag info isn't available
         BRANCH=`grep ' release$' distros/fedora/zoneminder.spec | head -n 1 | sed -e 's/ release//g' -e 's/[^0-9]*//'`
+        echo "Building branch $BRANCH"
       fi
-      echo "BRANCH = $BRANCH"
       if [ "$BRANCH" == "" ]; then
         echo "Unable to determine latest stable branch!"
         exit 0;

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -119,7 +119,7 @@ else
   if [ "$SNAPSHOT" == "stable" ]; then
     if [ "$BRANCH" == "" ]; then
       echo "About to run some basic commands for debugging..."
-      pwd; ls; git remote -v; git branch -v
+      pwd; ls; git remote -v; git branch -v; git tag -l
       echo "About to get the hash of the most recent tag"
       REV=$(git rev-list --tags --max-count=1)
       echo "REV = $REV"

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -118,8 +118,11 @@ else
   fi;
   if [ "$SNAPSHOT" == "stable" ]; then
     if [ "$BRANCH" == "" ]; then
-      #REV=$(git rev-list --tags --max-count=1)
+      echo "About to get the hash of the most recent tag"
+      REV=$(git rev-list --tags --max-count=1)
+      echo "REV = $REV"
       BRANCH=`git describe --tags $(git rev-list --tags --max-count=1)`;
+      echo "BRANCH = $BRANCH"
       if [ "$BRANCH" == "" ]; then
         echo "Unable to determine latest stable branch!"
         exit 0;

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -118,16 +118,12 @@ else
   fi;
   if [ "$SNAPSHOT" == "stable" ]; then
     if [ "$BRANCH" == "" ]; then
-      echo "About to run some basic commands for debugging..."
-      pwd; ls; git remote -v; git branch -v; git status
-      echo "Listing all of the tags for this repo:"
-      git tag -l
-      echo "About to get the hash of the most recent tag"
-      REV=$(git rev-list --tags --max-count=1)
-      echo "REV = $REV"
+      #REV=$(git rev-list --tags --max-count=1)
       BRANCH=`git describe --tags $(git rev-list --tags --max-count=1)`;
-      echo "BRANCH = $BRANCH"
-      BRANCH=`git tag -l | sort | grep -v '^v.*' | tail -n 1`
+      if [ -z "$BRANCH" ]; then
+        # This should only happen in CI environments where tag info isn't available
+        BRANCH=`grep ' release$' distros/fedora/zoneminder.spec | head -n 1 | sed -e 's/ release//g' -e 's/[^0-9]*//'`
+      fi
       echo "BRANCH = $BRANCH"
       if [ "$BRANCH" == "" ]; then
         echo "Unable to determine latest stable branch!"

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -119,11 +119,15 @@ else
   if [ "$SNAPSHOT" == "stable" ]; then
     if [ "$BRANCH" == "" ]; then
       echo "About to run some basic commands for debugging..."
-      pwd; ls; git remote -v; git branch -v; git tag -l
+      pwd; ls; git remote -v; git branch -v; git status
+      echo "Listing all of the tags for this repo:"
+      git tag -l
       echo "About to get the hash of the most recent tag"
       REV=$(git rev-list --tags --max-count=1)
       echo "REV = $REV"
       BRANCH=`git describe --tags $(git rev-list --tags --max-count=1)`;
+      echo "BRANCH = $BRANCH"
+      BRANCH=`git tag -l | sort | grep -v '^v.*' | tail -n 1`
       echo "BRANCH = $BRANCH"
       if [ "$BRANCH" == "" ]; then
         echo "Unable to determine latest stable branch!"


### PR DESCRIPTION
This is a change to have GitLab CI build the latest version instead of always building v1.36.1. The original PR had it hard-coded because the automatic detection of the latest tag wasn't working in the CI environment (despite working just fine when running the same commands manually).

The workaround is to search distros/fedora/zoneminder.spec for the latest version number. This is admittedly inferior to using git tags, and so it is only ever used if the git tags fail to get the version number. The fallback method should always work, as that .spec file seems to be a reliable format and updated on each release.

Most importantly it doesn't require any extra work for the maintainers (i.e., you), such as requiring someone to update a VERSION file on each release.