### PR TITLE
Fixed "Call to undefined function" Exception in control_functions.php

### DIFF
--- a/web/includes/control_functions.php
+++ b/web/includes/control_functions.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once('logger.php');
+
 function buildControlCommand($monitor) {
   $ctrlCommand = '';
   $control = $monitor->Control();
@@ -218,7 +220,7 @@ function buildControlCommand($monitor) {
         }
       }
     } else {
-      Error('Invalid control parameter: ' . $_REQUEST['control'] );
+      ZM\Error('Invalid control parameter: ' . $_REQUEST['control'] );
     }
   } elseif ( isset($_REQUEST['x']) && isset($_REQUEST['y']) ) {
     if ( $_REQUEST['control'] == 'moveMap' ) {


### PR DESCRIPTION
Fixed bug causing "Call to undefined function Error()" in control_functions.php. Problem was due to logger.php not being included in control_functions.php.