### PR TITLE
Fixed broken wiki links

### DIFF
--- a/docs/userguide/options/options_email.rst
+++ b/docs/userguide/options/options_email.rst
@@ -101,6 +101,6 @@ FROM_EMAIL - The emails or messages that will be sent to you informing you of ev
 
 URL - The emails or messages that will be sent to you informing you of events can include a link to the events themselves for easy viewing. If you intend to use this feature then set this option to the url of your installation as it would appear from where you read your email, e.g. ``http://host.your.domain/zm/index.php``.
 
-SSMTP_MAIL - SSMTP is a lightweight and efficient method to send email. The SSMTP application is not installed by default. NEW_MAIL_MODULES must also be enabled. Please visit the ZoneMinder `SSMTP Wiki page <http://www.zoneminder.com/wiki/index.php/How_to_get_ssmtp_working_with_Zoneminder>`__ for setup and configuration help. 
+SSMTP_MAIL - SSMTP is a lightweight and efficient method to send email. The SSMTP application is not installed by default. NEW_MAIL_MODULES must also be enabled. Please visit the ZoneMinder `SSMTP Wiki page <https://wiki.zoneminder.com/How_to_get_ssmtp_working_with_Zoneminder>`__ for setup and configuration help. 
 
 SSMTP_PATH - The path to the SSMTP application. If path is not defined. Zoneminder will try to determine the path via shell command. Example path: /usr/sbin/ssmtp.

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -3766,7 +3766,7 @@ our @options = (
       SSMTP is a lightweight and efficient method to send email.
       The SSMTP application is not installed by default.
       NEW_MAIL_MODULES must also be enabled.
-      Please visit the ZoneMinder [SSMTP Wiki page](http://www.zoneminder.com/wiki/index.php/How_to_get_ssmtp_working_with_Zoneminder)
+      Please visit the ZoneMinder [SSMTP Wiki page](https://wiki.zoneminder.com/How_to_get_ssmtp_working_with_Zoneminder)
       for setup and configuration help.
       `,
     type        => $types{boolean},

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/DCS5020L.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/DCS5020L.pm
@@ -283,7 +283,7 @@ None by default.
 =head1 SEE ALSO
 
 See if there are better instructions for the DCS-5020L at
-http://www.zoneminder.com/wiki/index.php/Dlink
+https://wiki.zoneminder.com/Dlink
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Fixed broken wiki links from old http://www.zoneminder.com/wiki to new https://wiki.zoneminder.com/