### PR TITLE
Fixed a bug in Image::Buffer 

### DIFF
--- a/src/zm_image.h
+++ b/src/zm_image.h
@@ -181,7 +181,7 @@ class Image {
 
     /* Internal buffer should not be modified from functions outside of this class */
     inline const uint8_t* Buffer() const { return buffer; }
-    inline const uint8_t* Buffer(unsigned int x, unsigned int y=0) const { return &buffer[(y*linesize)+x]; }
+    inline const uint8_t* Buffer(unsigned int x, unsigned int y=0) const { return &buffer[(y*linesize) + x*colours]; }
     /* Request writeable buffer */
     uint8_t* WriteBuffer(const unsigned int p_width, const unsigned int p_height, const unsigned int p_colours, const unsigned int p_subpixelorder);
     // Is only acceptable on a pre-allocated buffer


### PR DESCRIPTION
Image::Buffer would return the wrong location in the image if there were > 1 channels (and if the request were for x > 0).