### PR TITLE
Set mysql character set to utf8 explicitly

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -107,6 +107,7 @@ sub zmDbConnect {
         .$socket . $sslOptions . ($options?join(';', '', map { $_.'='.$$options{$_} } keys %{$options} ) : '')
         , $ZoneMinder::Config::Config{ZM_DB_USER}
         , $ZoneMinder::Config::Config{ZM_DB_PASS}
+        , { mysql_enable_utf8 => 1, }
         );
     };
     if ( !$dbh or $@ ) {

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -102,6 +102,7 @@ bool zmDbConnect() {
   if ( mysql_query(&dbconn, "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED") ) {
     Error("Can't set isolation level: %s", mysql_error(&dbconn));
   }
+  mysql_set_character_set(&dbconn, "utf8");
   zmDbConnected = true;
   return zmDbConnected;
 }


### PR DESCRIPTION
Set mysql character set to utf8 explicitly to support chinese characts (or other special characters).

Zm will report errors if it enconter chinese characters in storage path

<html>
<body>
<!--StartFragment-->

Can't mkdir /mnt/a/????/events/1: No such file or directory | zm_event.cpp | 130
-- | -- | --


<!--EndFragment-->
</body>
</html>

 In fact, the `????` here in the path is actually the chinese characters "中文目录". I can set the path contains chinese characters correctly, but zm will no longer be able to save the records due to the charset problem.

After set the charset as utf8 explicitly in zm_db.cpp, evething works fine.