### PR TITLE
Define Date formats in lang file for en_gb resolves #2408

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -69,6 +69,11 @@
 // setlocale( LC_CTYPE, 'en_GB' ); Character class settings 4.3.0 and after
 // setlocale( LC_TIME, 'en_GB' ); Date and time formatting 4.3.0 and after
 
+setlocale( LC_TIME, 'en_GB.utf8' );
+define("DATE_FMT_CONSOLE_LONG", "%a %d %b, %Hh%M");
+define( "STRF_FMT_DATETIME_SHORT", "%d/%m/%y %H:%M:%S" );
+define( "STRF_FMT_DATETIME_SHORTER", "%x %H:%M:%S" );
+
 // Simple String Replacements
 $SLANG = array(
     'SystemLog'             => 'System Log',


### PR DESCRIPTION
Set Locale for time to en_GB.utf8, changed STRF_FMT_DATETIME_SHORTER to %x which is locale aware short date, but does include year. Makes event table wider, not sure if that is a problem for others