### PR TITLE
fix posix/musl build

### DIFF
--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -26,6 +26,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 StreamBase::~StreamBase() {
 #if HAVE_LIBAVCODEC


### PR DESCRIPTION
Fix compilation error on posix/musl libc environments (in this case Alpine Linux):
```
/home/user/aports/community/zoneminder/src/zoneminder-1.36.10/src/zm_stream.cpp: In member function 'virtual void StreamBase::openComms()':
/home/user/aports/community/zoneminder/src/zoneminder-1.36.10/src/zm_stream.cpp:342:36: error: 'O_CREAT' was not declared in this scope
  342 |     lock_fd = open(sock_path_lock, O_CREAT|O_WRONLY, S_IRUSR | S_IWUSR);
      |                                    ^~~~~~~
/home/user/aports/community/zoneminder/src/zoneminder-1.36.10/src/zm_stream.cpp:342:44: error: 'O_WRONLY' was not declared in this scope
  342 |     lock_fd = open(sock_path_lock, O_CREAT|O_WRONLY, S_IRUSR | S_IWUSR);
      |                                            ^~~~~~~~
[ 88%] Building CXX object src/CMakeFiles/zm.dir/zm_videostore.cpp.o
/home/user/aports/community/zoneminder/src/zoneminder-1.36.10/src/zm_stream.cpp:342:15: error: 'open' was not declared in this scope; did you mean 'popen'?
  342 |     lock_fd = open(sock_path_lock, O_CREAT|O_WRONLY, S_IRUSR | S_IWUSR);
      |               ^~~~
      |               popen
make[2]: *** [src/CMakeFiles/zm.dir/build.make:818: src/CMakeFiles/zm.dir/zm_stream.cpp.o] Error 1
```
