### PR TITLE
Make config file comment on unix socket option a bit clearer

### DIFF
--- a/zm.conf.in
+++ b/zm.conf.in
@@ -37,7 +37,8 @@ ZM_WEB_GROUP=@WEB_GROUP@
 ZM_DB_TYPE=@ZM_DB_TYPE@
 
 # ZoneMinder database hostname or ip address and optionally port or unix socket
-# Acceptable formats include hostname[:port], ip_address[:port], or localhost:unix_socket
+# Acceptable formats include hostname[:port], ip_address[:port], or
+# localhost:/path/to/unix_socket
 ZM_DB_HOST=@ZM_DB_HOST@
 
 # ZoneMinder database name


### PR DESCRIPTION
Initially I took the comment for granted, and the 'unix_socket' string
as a magic string to tell zoneminder to use the mysql default socket.  Alas,
this do not work, as the setting really need to point to the path of the socket.
Rewrite the comment to make this more clear, and less confusing for the
future users.