### PR TITLE
Fixed in export.php "Class 'Filter' not found" and SQL query with wrong syntax

### DIFF
--- a/web/skins/classic/views/export.php
+++ b/web/skins/classic/views/export.php
@@ -86,7 +86,7 @@ $limitQuery = '';
 if ( $user['MonitorIds'] ) {
   $user_monitor_ids = ' M.Id in ('.$user['MonitorIds'].')';
   $eventsSql .= $user_monitor_ids;
-} else {
+} else if ( !isset($_REQUEST['filter']) ) {
   $eventsSql .= ' 1';
 }
 
@@ -98,7 +98,7 @@ if ( isset($_REQUEST['eid']) and $_REQUEST['eid'] ) {
   $eventsValues += $_REQUEST['eids'];
 } else if ( isset($_REQUEST['filter']) ) {
   parseSort();
-  $filter = Filter::parse($_REQUEST['filter']);
+  $filter = ZM\Filter::parse($_REQUEST['filter']);
   $filterQuery = $filter->querystring();
 
   if ( $filter->sql() ) {


### PR DESCRIPTION
A couple of fixes in export.php:

- Class Filter was not defined.
- SQL query built from filter was being appended "1" after WHERE, ending up with the wrong syntax. Error:
`SQL-ERR 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'E.EndDateTime >= '2022-02-03 19:00:00' and E.MonitorId = '4' ORDER BY E.StartD' at line 1', statement was 'SELECT E.*,M.Name AS MonitorName FROM Monitors AS M INNER JOIN Events AS E on (M.Id = E.MonitorId) WHERE 1 E.EndDateTime >= '2022-02-03 19:00:00' and E.MonitorId = '4' ORDER BY E.StartDateTime asc LIMIT 100'`