### PR TITLE
Add SQL opTypes IN, NOT IN to filter view, #3432

### DIFF
--- a/web/skins/classic/views/filter.php
+++ b/web/skins/classic/views/filter.php
@@ -130,6 +130,8 @@ $opTypes = array(
     '!~'  => translate('OpNotMatches'),
     '=[]' => translate('OpIn'),
     '![]' => translate('OpNotIn'),
+    'IN'  => translate('OpIn'),
+    'NOT IN' => translate('OpNotIn'),
     'IS'  => translate('OpIs'),
     'IS NOT'  => translate('OpIsNot'),
     'LIKE' => translate('OpLike'),


### PR DESCRIPTION
This possibly fixes the issue where changing the filter for an event
view via the filter button would produce invalid SQL and SQL errors.
```
web_php[43835].ERR [1.2.3.4] [SQL-ERR 'SQLSTATE[HY000]: General error: 4078 Illegal parameter data types int and row for operation '='', statement was 'SELECT E.*, M.Name AS Monitor FROM `Events` AS E INNER JOIN Monitors AS M ON E.MonitorId = M.Id WHERE ( ( E.StartDateTime >= '2022-02-14 00:47:41'
 and E.StartDateTime <= '2022-02-14 11:47:41' )
 and E.MonitorId = ('1','3')
) ORDER BY E.StartDateTime DESC' params:] at /usr/share/zoneminder/www/includes/database.php line 161
```
When in the events view, clicking the filterBtn sends us to the filter view with this query term (url-decoded):
```
&filter[Query][terms][2][attr]=MonitorId&filter[Query][terms][2][op]=IN&filter[Query][terms][2][val]=1,3&filter[Query][sort_asc]=0
```
but the filter view displays this as "equals", not "in set", because it doesn't know IN from opTypes, only =[].