### PR TITLE
Rework the state machine code

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -397,7 +397,7 @@ void Event::AddFrame(Image *image,
   bool write_to_db = false;
   FrameType frame_type = ( ( score > 0 ) ? ALARM : (
       (
-       ( monitor_state == Monitor::TAPE )
+       ( monitor_state == Monitor::IDLE )
        and
        ( config.bulk_frame_interval > 1 )
        and

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -113,8 +113,7 @@ public:
     IDLE,
     PREALARM,
     ALARM,
-    ALERT,
-    TAPE
+    ALERT
   } State;
 
   typedef enum {


### PR DESCRIPTION
Move blending code up to motion detection area where it should be.  Remove event start/stop from the state machine transition logic.  Redo the event open/close logic after the state machine logic using switches.

Todo: finish removing TAPE. Move event_close_mode into each monitor, add an event start time modulus.  