### PR TITLE
Fix when using a custom state with zmpkg.pl

### DIFF
--- a/scripts/zmpkg.pl.in
+++ b/scripts/zmpkg.pl.in
@@ -60,7 +60,7 @@ my $dbh = zmDbConnect();
 Debug("Command: $command");
 if ( $command and ( $command !~ /^(?:start|stop|restart|status|logrot|version)$/ ) ) {
   # Check to see if it's a valid run state
-  if ($state = ZoneMinder->find_one(Name=>$command)) {
+  if ($state = ZoneMinder::State->find_one(Name=>$command)) {
     $state->{Definitions} = [];
     foreach (split(',', $state->{Definition})) {
       my @state = split(':', $_);


### PR DESCRIPTION
Fix when passing a custom state to zmpkg.pl like # zmpkg.pl AllCameras

Previous to this fix, this was the error:

Can't locate object method "find_one" via package "ZoneMinder" at /usr/bin/zmpkg.pl line 63