### PR TITLE
Automated debian build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ ubuntu_deb:
   script:
     - DEBIAN_FRONTEND=noninteractive TZ=America/Chicago apt-get -y install tzdata
     - yes "" | ./utils/do_debian_package.sh --snapshot=stable --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
-  timeout: 2h
+  timeout: 3h
   artifacts:
     paths:
       - '*.deb'
@@ -26,7 +26,7 @@ debian_deb:
     name: debian:latest
   script:
     - yes "" | ./utils/do_debian_package.sh --snapshot=stable --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
-  timeout: 2h
+  timeout: 3h
   artifacts:
     paths:
       - '*.deb'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,25 @@ default:
     - apt-get update -yq
     - DEBIAN_FRONTEND=noninteractive apt-get install -yq devscripts sudo
 
-deb:
+ubuntu_deb:
   stage: build
   tags:
     - docker
+  script:
+    - DEBIAN_FRONTEND=noninteractive TZ=America/Chicago apt-get -y install tzdata
+    - yes "" | ./utils/do_debian_package.sh --snapshot=stable --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
+  timeout: 2h
+  artifacts:
+    paths:
+      - '*.deb'
+    expire_in: 1 week
+
+debian_deb:
+  stage: build
+  tags:
+    - docker
+  image:
+    name: debian:latest
   script:
     - yes "" | ./utils/do_debian_package.sh --snapshot=stable --type=binary --interactive=no --dput=no --debbuild-extra=--no-sign || true
   timeout: 2h


### PR DESCRIPTION
The Ubuntu build broke with the release of 22.04 (jammy) due to the Docker image not having the timezone set and that causing user interaction.

Also added a job to build the Debian version of the package and bumped up the timeout to deal with build servers that are slow sometimes.