### PR TITLE
Adds the gsoap package to Build-Depends

### DIFF
--- a/distros/ubuntu2004/control
+++ b/distros/ubuntu2004/control
@@ -32,6 +32,7 @@ Build-Depends: debhelper (>= 11), sphinx-doc, python3-sphinx, dh-linktree, dh-ap
               ,libvncserver-dev
               ,libjwt-gnutls-dev|libjwt-dev
               ,libgsoap-dev
+              ,gsoap
 Standards-Version: 4.5.0
 Homepage: https://www.zoneminder.com/
 


### PR DESCRIPTION
A binary in the gsoap package is needed for building.