### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci-bionic.yml
+++ b/.github/workflows/ci-bionic.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:

--- a/.github/workflows/ci-bullseye.yml
+++ b/.github/workflows/ci-bullseye.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:

--- a/.github/workflows/ci-buster.yml
+++ b/.github/workflows/ci-buster.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:

--- a/.github/workflows/ci-centos-7.yml
+++ b/.github/workflows/ci-centos-7.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci-centos-8.yml
+++ b/.github/workflows/ci-centos-8.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci-eslint.yml
+++ b/.github/workflows/ci-eslint.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-stretch.yml
+++ b/.github/workflows/ci-stretch.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     defaults:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,15 @@ on:
   schedule:
     - cron: '0 3 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
