### PR TITLE
Fix semaphore_tries on systems without System V

### DIFF
--- a/web/ajax/stream.php
+++ b/web/ajax/stream.php
@@ -25,7 +25,7 @@ while ( $semaphore_tries ) {
   usleep(100000);
   $semaphore_tries -= 1;
 }
-if ($have_semaphore) {
+if ($have_semaphore !== false) {
   if ( !($socket = @socket_create(AF_UNIX, SOCK_DGRAM, 0)) ) {
     ajaxError('socket_create() failed: '.socket_strerror(socket_last_error()));
   }


### PR DESCRIPTION
This appears to be impacting systems without php System V semaphore support
have_semaphore is not a boolean

1.36.18 and main dev branch are impacted

Issue is discussed here: https://forums.zoneminder.com/viewtopic.php?t=31255

Signed-off-by: Nic Boet <nic@boet.cc>