### PR TITLE
Set en_us.php date/time locale to the proper mm/dd/yyyy format

### DIFF
--- a/web/lang/en_us.php
+++ b/web/lang/en_us.php
@@ -70,6 +70,7 @@ require_once( 'lang/en_gb.php' );
 // setlocale( LC_TIME, 'en_GB' ); Date and time formatting 4.3.0 and after
 
 // Simple String Replacements
+setlocale( LC_TIME, 'en_US' );
 $SLANG['24BitColour']          = '24 bit color';
 $SLANG['32BitColour']          = '32 bit color';
 $SLANG['8BitGrey']             = '8 bit grayscale';


### PR DESCRIPTION
Changed the en_us.php locale file to use the en_US date/time format of mm/dd/yyyy HH:MM:SS, which is expected when the Locale is set to en_US