### PR TITLE
use zm_timezone to initialize IntlDateFormatter

### DIFF
--- a/web/includes/config.php.in
+++ b/web/includes/config.php.in
@@ -139,20 +139,25 @@ define('SCALE_BASE', 100);           // The additional scaling factor used to he
 define('STRF_FMT_DATETIME_DB', 'Y-m-d H:i:s');      // Strftime format for database queries, don't change
 define('MYSQL_FMT_DATETIME_SHORT', 'Y/m/d H:i:s');  // MySQL date_format shorter format for dates with time
 
-global $dateFormatter;
-global $dateTimeFormatter;
-global $timeFormatter;
-$dateFormatter = new IntlDateFormatter(null, IntlDateFormatter::SHORT, IntlDateFormatter::NONE);
-$dateTimeFormatter = new IntlDateFormatter(null, IntlDateFormatter::SHORT, IntlDateFormatter::LONG);
-$timeFormatter = new IntlDateFormatter(null, IntlDateFormatter::NONE, IntlDateFormatter::LONG);
+// we need zm_timezone from system to add it to DateFormatter.
 
 require_once('database.php');
 require_once('logger.php');
 loadConfig();
+
+
+global $dateFormatter;
+global $dateTimeFormatter;
+global $timeFormatter;
+$dateFormatter = new IntlDateFormatter(null, IntlDateFormatter::SHORT, IntlDateFormatter::NONE,ZM_TIMEZONE);
+$dateTimeFormatter = new IntlDateFormatter(null, IntlDateFormatter::SHORT, IntlDateFormatter::LONG,ZM_TIMEZONE);
+$timeFormatter = new IntlDateFormatter(null, IntlDateFormatter::NONE, IntlDateFormatter::LONG,ZM_TIMEZONE);
+
+
 if (ZM_LOCALE_DEFAULT) {
-  $dateFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::SHORT, IntlDateFormatter::NONE);
-  $dateTimeFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::SHORT, IntlDateFormatter::LONG);
-  $timeFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::NONE, IntlDateFormatter::LONG);
+  $dateFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::SHORT, IntlDateFormatter::NONE,ZM_TIMEZONE);
+  $dateTimeFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::SHORT, IntlDateFormatter::LONG,ZM_TIMEZONE);
+  $timeFormatter = new IntlDateFormatter(ZM_LOCALE_DEFAULT, IntlDateFormatter::NONE, IntlDateFormatter::LONG,ZM_TIMEZONE);
 }
 if (ZM_DATE_FORMAT_PATTERN) {
   $dateFormatter->setPattern(ZM_DATE_FORMAT_PATTERN);


### PR DESCRIPTION
it seems time zone is necessary to get IntlDateFormatter to use correct hour

https://www.php.net/manual/en/intldateformatter.format.php