### PR TITLE
CI: Only attempt to publish packages on push.

### DIFF
--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -3,8 +3,6 @@ name: Create packages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   package:


### PR DESCRIPTION
Not sure what workflow is actually wanted here, but if I'm understanding the docs correctly, this should build a package on both a push to master & a merge request, but only attempt to publish on a push to master.

I initially had it so that it would skip the publish step if the secrets were not set. That might be a better option if there are people who merge requests but don't have access to publish. I'm not sure of your organizational setup.
