### PR TITLE
Switch from av_init_packet() to av_packet_alloc()

### DIFF
--- a/src/zm_curl_camera.cpp
+++ b/src/zm_curl_camera.cpp
@@ -323,7 +323,7 @@ int cURLCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
           }
           zm_packet->keyframe = 1;
           zm_packet->codec_type = AVMEDIA_TYPE_VIDEO;
-          zm_packet->packet.stream_index = mVideoStreamId;
+          zm_packet->packet->stream_index = mVideoStreamId;
           zm_packet->stream = mVideoStream;
           zm_packet->image->DecodeJpeg(databuffer.extract(frame_content_length), frame_content_length, colours, subpixelorder);
           frameComplete = true;
@@ -351,7 +351,7 @@ int cURLCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
           }
           zm_packet->keyframe = 1;
           zm_packet->codec_type = AVMEDIA_TYPE_VIDEO;
-          zm_packet->packet.stream_index = mVideoStreamId;
+          zm_packet->packet->stream_index = mVideoStreamId;
           zm_packet->stream = mVideoStream;
           zm_packet->image->DecodeJpeg(databuffer.extract(single_offsets.front()), single_offsets.front(), colours, subpixelorder);
           single_offsets.pop_front();

--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -734,9 +734,8 @@ bool EventStream::sendFrame(Microseconds delta_us) {
         FrameData *frame_data = &event_data->frames[curr_frame_id-1];
         AVFrame *frame =
             ffmpeg_input->get_frame(ffmpeg_input->get_video_stream_id(), FPSeconds(frame_data->offset).count());
-        if ( frame ) {
+        if (frame) {
           image = new Image(frame);
-          //av_frame_free(&frame);
         } else {
           Error("Failed getting a frame.");
           return false;

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -23,6 +23,8 @@
 #include "zm_config.h"
 #include "zm_define.h"
 
+#include <memory>
+
 extern "C" {
 #include <libswresample/swresample.h>
 
@@ -177,34 +179,34 @@ void zm_dump_codecpar(const AVCodecParameters *par);
   Debug(2, "%s: pts: %" PRId64 ", dts: %" PRId64 \
     ", size: %d, stream_index: %d, flags: %04x, keyframe(%d) pos: %" PRId64 ", duration: %" AV_PACKET_DURATION_FMT, \
     text,\
-    pkt.pts,\
-    pkt.dts,\
-    pkt.size,\
-    pkt.stream_index,\
-    pkt.flags,\
-    pkt.flags & AV_PKT_FLAG_KEY,\
-    pkt.pos,\
-    pkt.duration)
+    pkt->pts,\
+    pkt->dts,\
+    pkt->size,\
+    pkt->stream_index,\
+    pkt->flags,\
+    pkt->flags & AV_PKT_FLAG_KEY,\
+    pkt->pos,\
+    pkt->duration)
 
 # define ZM_DUMP_STREAM_PACKET(stream, pkt, text) \
   if (logDebugging()) { \
-    double pts_time = static_cast<double>(av_rescale_q(pkt.pts, stream->time_base, AV_TIME_BASE_Q)) / AV_TIME_BASE; \
+    double pts_time = static_cast<double>(av_rescale_q(pkt->pts, stream->time_base, AV_TIME_BASE_Q)) / AV_TIME_BASE; \
     \
     Debug(2, "%s: pts: %" PRId64 " * %u/%u=%f, dts: %" PRId64 \
       ", size: %d, stream_index: %d, %s flags: %04x, keyframe(%d) pos: %" PRId64", duration: %" AV_PACKET_DURATION_FMT, \
       text, \
-      pkt.pts, \
+      pkt->pts, \
       stream->time_base.num, \
       stream->time_base.den, \
       pts_time, \
-      pkt.dts, \
-      pkt.size, \
-      pkt.stream_index, \
+      pkt->dts, \
+      pkt->size, \
+      pkt->stream_index, \
       av_get_media_type_string(CODEC_TYPE(stream)), \
-      pkt.flags, \
-      pkt.flags & AV_PKT_FLAG_KEY, \
-      pkt.pos, \
-    pkt.duration); \
+      pkt->flags, \
+      pkt->flags & AV_PKT_FLAG_KEY, \
+      pkt->pos, \
+    pkt->duration); \
   }
 
 #else
@@ -237,5 +239,15 @@ int zm_resample_get_delay(SwrContext *resample_ctx, int time_base);
 
 int zm_add_samples_to_fifo(AVAudioFifo *fifo, AVFrame *frame);
 int zm_get_samples_from_fifo(AVAudioFifo *fifo, AVFrame *frame);
+
+struct zm_free_av_packet
+{
+    void operator()(AVPacket *pkt) const
+    {
+        av_packet_free(&pkt);
+    }
+};
+
+using av_packet_ptr = std::unique_ptr<AVPacket, zm_free_av_packet>;
 
 #endif // ZM_FFMPEG_H

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -284,4 +284,14 @@ private:
     AVPacket *packet;
 };
 
+struct zm_free_av_frame
+{
+    void operator()(AVFrame *frame) const
+    {
+        av_frame_free(&frame);
+    }
+};
+
+using av_frame_ptr = std::unique_ptr<AVFrame, zm_free_av_frame>;
+
 #endif // ZM_FFMPEG_H

--- a/src/zm_ffmpeg.h
+++ b/src/zm_ffmpeg.h
@@ -250,4 +250,38 @@ struct zm_free_av_packet
 
 using av_packet_ptr = std::unique_ptr<AVPacket, zm_free_av_packet>;
 
+struct av_packet_guard
+{
+    av_packet_guard() : packet{nullptr}
+    {
+    }
+    explicit av_packet_guard(const av_packet_ptr& p) : packet{p.get()}
+    {
+    }
+    explicit av_packet_guard(AVPacket *p) : packet{p}
+    {
+    }
+    ~av_packet_guard()
+    {
+	if (packet)
+	    av_packet_unref(packet);
+    }
+
+    void acquire(const av_packet_ptr& p)
+    {
+	packet = p.get();
+    }
+    void acquire(AVPacket *p)
+    {
+	packet = p;
+    }
+    void release()
+    {
+	packet = nullptr;
+    }
+
+private:
+    AVPacket *packet;
+};
+
 #endif // ZM_FFMPEG_H

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -221,6 +221,8 @@ int FfmpegCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
     return -1;
   }
 
+  av_packet_guard pkt_guard{packet};
+
   AVStream *stream = formatContextPtr->streams[packet->stream_index];
   ZM_DUMP_STREAM_PACKET(stream, packet, "ffmpeg_camera in");
 
@@ -243,7 +245,6 @@ int FfmpegCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
       mLastAudioPTS = packet->pts - mFirstAudioPTS;
     }
   }
-  zm_av_packet_unref(packet.get());
 
   return 1;
 } // FfmpegCamera::Capture

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -152,6 +152,7 @@ FfmpegCamera::FfmpegCamera(
     Panic("Unexpected colours: %d", colours);
   }
 
+  packet = av_packet_ptr{av_packet_alloc()};
 }  // FfmpegCamera::FfmpegCamera
 
 FfmpegCamera::~FfmpegCamera() {
@@ -204,7 +205,7 @@ int FfmpegCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
         );
   }
 
-  if ((ret = av_read_frame(formatContextPtr, &packet)) < 0) {
+  if ((ret = av_read_frame(formatContextPtr, packet.get())) < 0) {
     if (
         // Check if EOF.
         (ret == AVERROR_EOF || (formatContextPtr->pb && formatContextPtr->pb->eof_reached)) ||
@@ -212,37 +213,37 @@ int FfmpegCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
         (ret == -110)
        ) {
       Info("Unable to read packet from stream %d: error %d \"%s\".",
-          packet.stream_index, ret, av_make_error_string(ret).c_str());
+          packet->stream_index, ret, av_make_error_string(ret).c_str());
     } else {
       Error("Unable to read packet from stream %d: error %d \"%s\".",
-          packet.stream_index, ret, av_make_error_string(ret).c_str());
+          packet->stream_index, ret, av_make_error_string(ret).c_str());
     }
     return -1;
   }
 
-  AVStream *stream = formatContextPtr->streams[packet.stream_index];
+  AVStream *stream = formatContextPtr->streams[packet->stream_index];
   ZM_DUMP_STREAM_PACKET(stream, packet, "ffmpeg_camera in");
 
   zm_packet->codec_type = stream->codecpar->codec_type;
 
-  bytes += packet.size;
-  zm_packet->set_packet(&packet);
+  bytes += packet->size;
+  zm_packet->set_packet(packet.get());
   zm_packet->stream = stream;
-  zm_packet->pts = av_rescale_q(packet.pts, stream->time_base, AV_TIME_BASE_Q);
-  if (packet.pts != AV_NOPTS_VALUE) {
+  zm_packet->pts = av_rescale_q(packet->pts, stream->time_base, AV_TIME_BASE_Q);
+  if (packet->pts != AV_NOPTS_VALUE) {
     if (stream == mVideoStream) {
       if (mFirstVideoPTS == AV_NOPTS_VALUE)
-        mFirstVideoPTS = packet.pts;
+        mFirstVideoPTS = packet->pts;
 
-      mLastVideoPTS = packet.pts - mFirstVideoPTS;
+      mLastVideoPTS = packet->pts - mFirstVideoPTS;
     } else {
       if (mFirstAudioPTS == AV_NOPTS_VALUE)
-        mFirstAudioPTS = packet.pts;
+        mFirstAudioPTS = packet->pts;
 
-      mLastAudioPTS = packet.pts - mFirstAudioPTS;
+      mLastAudioPTS = packet->pts - mFirstAudioPTS;
     }
   }
-  zm_av_packet_unref(&packet);
+  zm_av_packet_unref(packet.get());
 
   return 1;
 } // FfmpegCamera::Capture

--- a/src/zm_ffmpeg_camera.h
+++ b/src/zm_ffmpeg_camera.h
@@ -58,7 +58,7 @@ class FfmpegCamera : public Camera {
     // Used to store the incoming packet, it will get copied when queued. 
     // We only ever need one at a time, so instead of constantly allocating
     // and freeing this structure, we will just make it a member of the object.
-    AVPacket packet;       
+    av_packet_ptr packet;
 
     int OpenFfmpeg();
     int Close() override;

--- a/src/zm_ffmpeg_input.cpp
+++ b/src/zm_ffmpeg_input.cpp
@@ -139,6 +139,11 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
   int frameComplete = false;
   av_packet_ptr packet{av_packet_alloc()};
 
+  if (!packet) {
+    Error("Unable to allocate packet.");
+    return nullptr;
+  }
+
   while ( !frameComplete ) {
     int ret = av_read_frame(input_format_context, packet.get());
     if ( ret < 0 ) {
@@ -157,9 +162,10 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
     }
     ZM_DUMP_STREAM_PACKET(input_format_context->streams[packet->stream_index], packet, "Received packet");
 
+    av_packet_guard pkt_guard{packet};
+
     if ( (stream_id >= 0) && (packet->stream_index != stream_id) ) {
       Debug(1,"Packet is not for our stream (%d)", packet->stream_index );
-      zm_av_packet_unref(packet.get());
       continue;
     }
 
@@ -175,7 +181,6 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
     if ( ret < 0 ) {
       Error("Unable to decode frame at frame %d: %d %s, continuing",
           streams[packet->stream_index].frame_count, ret, av_make_error_string(ret).c_str());
-      zm_av_packet_unref(packet.get());
       av_frame_free(&frame);
       continue;
     } else {
@@ -194,7 +199,6 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
         input_format_context->streams[stream_id]->time_base
         );
 
-    zm_av_packet_unref(packet.get());
   } // end while !frameComplete
   return frame;
 }  // end AVFrame *FFmpeg_Input::get_frame

--- a/src/zm_ffmpeg_input.cpp
+++ b/src/zm_ffmpeg_input.cpp
@@ -137,11 +137,10 @@ int FFmpeg_Input::Close( ) {
 
 AVFrame *FFmpeg_Input::get_frame(int stream_id) {
   int frameComplete = false;
-  AVPacket packet;
-  av_init_packet(&packet);
+  av_packet_ptr packet{av_packet_alloc()};
 
   while ( !frameComplete ) {
-    int ret = av_read_frame(input_format_context, &packet);
+    int ret = av_read_frame(input_format_context, packet.get());
     if ( ret < 0 ) {
       if (
           // Check if EOF.
@@ -153,17 +152,18 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
         return nullptr;
       }
       Error("Unable to read packet from stream %d: error %d \"%s\".",
-          packet.stream_index, ret, av_make_error_string(ret).c_str());
+          packet->stream_index, ret, av_make_error_string(ret).c_str());
       return nullptr;
     }
-    ZM_DUMP_STREAM_PACKET(input_format_context->streams[packet.stream_index], packet, "Received packet");
+    ZM_DUMP_STREAM_PACKET(input_format_context->streams[packet->stream_index], packet, "Received packet");
 
-    if ( (stream_id >= 0) && (packet.stream_index != stream_id) ) {
-      Debug(1,"Packet is not for our stream (%d)", packet.stream_index );
+    if ( (stream_id >= 0) && (packet->stream_index != stream_id) ) {
+      Debug(1,"Packet is not for our stream (%d)", packet->stream_index );
+      zm_av_packet_unref(packet.get());
       continue;
     }
 
-    AVCodecContext *context = streams[packet.stream_index].context;
+    AVCodecContext *context = streams[packet->stream_index].context;
 
     if ( frame ) {
       av_frame_free(&frame);
@@ -171,15 +171,15 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
     } else {
       frame = zm_av_frame_alloc();
     }
-    ret = zm_send_packet_receive_frame(context, frame, packet);
+    ret = zm_send_packet_receive_frame(context, frame, *packet);
     if ( ret < 0 ) {
       Error("Unable to decode frame at frame %d: %d %s, continuing",
-          streams[packet.stream_index].frame_count, ret, av_make_error_string(ret).c_str());
-      zm_av_packet_unref(&packet);
+          streams[packet->stream_index].frame_count, ret, av_make_error_string(ret).c_str());
+      zm_av_packet_unref(packet.get());
       av_frame_free(&frame);
       continue;
     } else {
-      if ( is_video_stream(input_format_context->streams[packet.stream_index]) ) {
+      if ( is_video_stream(input_format_context->streams[packet->stream_index]) ) {
         zm_dump_video_frame(frame, "resulting video frame");
       } else {
         zm_dump_frame(frame, "resulting frame");
@@ -194,7 +194,7 @@ AVFrame *FFmpeg_Input::get_frame(int stream_id) {
         input_format_context->streams[stream_id]->time_base
         );
 
-    zm_av_packet_unref(&packet);
+    zm_av_packet_unref(packet.get());
   } // end while !frameComplete
   return frame;
 }  // end AVFrame *FFmpeg_Input::get_frame

--- a/src/zm_ffmpeg_input.h
+++ b/src/zm_ffmpeg_input.h
@@ -2,6 +2,7 @@
 #define ZM_FFMPEG_INPUT_H
 
 #include "zm_define.h"
+#include "zm_ffmpeg.h"
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -49,7 +50,7 @@ class FFmpeg_Input {
     int video_stream_id;
     int audio_stream_id;
     AVFormatContext *input_format_context;
-    AVFrame *frame;
+    av_frame_ptr frame;
 		int64_t last_seek_request;
 };
 

--- a/src/zm_ffmpeg_output.cpp
+++ b/src/zm_ffmpeg_output.cpp
@@ -84,13 +84,12 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
   Debug(1, "Getting frame from stream %d", stream_id );
 
   int frameComplete = false;
-  AVPacket packet;
-  av_init_packet( &packet );
+  av_packet_ptr packet{av_packet_alloc()};
   AVFrame *frame = zm_av_frame_alloc();
   char errbuf[AV_ERROR_MAX_STRING_SIZE];
 
   while ( !frameComplete ) {
-    int ret = av_read_frame( input_format_context, &packet );
+    int ret = av_read_frame( input_format_context, packet.get() );
     if ( ret < 0 ) {
       av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
       if (
@@ -102,20 +101,20 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
         Info( "av_read_frame returned %s.", errbuf );
         return NULL;
       }
-      Error( "Unable to read packet from stream %d: error %d \"%s\".", packet.stream_index, ret, errbuf );
+      Error( "Unable to read packet from stream %d: error %d \"%s\".", packet->stream_index, ret, errbuf );
       return NULL;
     }
 
-    if ( (stream_id < 0 ) || ( packet.stream_index == stream_id ) ) {
-      Debug(1,"Packet is for our stream (%d)", packet.stream_index );
+    if ( (stream_id < 0 ) || ( packet->stream_index == stream_id ) ) {
+      Debug(1,"Packet is for our stream (%d)", packet->stream_index );
 
-      AVCodecContext *context = streams[packet.stream_index].context;
+      AVCodecContext *context = streams[packet->stream_index].context;
 
-    ret = avcodec_send_packet( context, &packet );
+    ret = avcodec_send_packet( context, packet.get() );
     if ( ret < 0 ) {
       av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
-      Error( "Unable to send packet at frame %d: %s, continuing", streams[packet.stream_index].frame_count, errbuf );
-      zm_av_packet_unref( &packet );
+      Error( "Unable to send packet at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
+      zm_av_packet_unref( packet.get() );
       continue;
     } else {
       Debug(1, "Success getting a packet");
@@ -126,15 +125,15 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
       ret = avcodec_receive_frame( context, hwFrame );
       if ( ret < 0 ) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
-        Error( "Unable to receive frame %d: %s, continuing", streams[packet.stream_index].frame_count, errbuf );
-        zm_av_packet_unref( &packet );
+        Error( "Unable to receive frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
+        zm_av_packet_unref( packet.get() );
         continue;
       }
       ret = av_hwframe_transfer_data(frame, hwFrame, 0);
       if (ret < 0) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
-        Error( "Unable to transfer frame at frame %d: %s, continuing", streams[packet.stream_index].frame_count, errbuf );
-        zm_av_packet_unref( &packet );
+        Error( "Unable to transfer frame at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
+        zm_av_packet_unref( packet.get() );
         continue;
       }
     } else {
@@ -143,8 +142,8 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
       ret = avcodec_receive_frame( context, frame );
       if ( ret < 0 ) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
-        Error( "Unable to send packet at frame %d: %s, continuing", streams[packet.stream_index].frame_count, errbuf );
-        zm_av_packet_unref( &packet );
+        Error( "Unable to send packet at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
+        zm_av_packet_unref( packet.get() );
         continue;
       }
 
@@ -155,7 +154,7 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
     frameComplete = 1;
   } // end if it's the right stream
 
-      zm_av_packet_unref( &packet );
+      zm_av_packet_unref( packet.get() );
 
   } // end while ! frameComplete
   return frame;

--- a/src/zm_ffmpeg_output.cpp
+++ b/src/zm_ffmpeg_output.cpp
@@ -85,11 +85,16 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
 
   int frameComplete = false;
   av_packet_ptr packet{av_packet_alloc()};
-  AVFrame *frame = zm_av_frame_alloc();
   char errbuf[AV_ERROR_MAX_STRING_SIZE];
 
   if (!packet) {
-    Error("Unable to allocate packet.");
+    Error("Unable to allocate packet.", );
+    return nullptr;
+  }
+
+  frame = av_frame_ptr{zm_av_frame_alloc()};
+  if (!frame) {
+    Error("Unable to allocate frame.");
     return nullptr;
   }
 
@@ -143,7 +148,7 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
     } else {
 #endif
       Debug(1,"Getting a frame?");
-      ret = avcodec_receive_frame( context, frame );
+      ret = avcodec_receive_frame( context, frame.get() );
       if ( ret < 0 ) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
         Error( "Unable to send packet at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
@@ -158,6 +163,6 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
   } // end if it's the right stream
 
   } // end while ! frameComplete
-  return frame;
+  return frame.get();
 
 } //  end AVFrame *FFmpeg_Output::get_frame

--- a/src/zm_ffmpeg_output.cpp
+++ b/src/zm_ffmpeg_output.cpp
@@ -88,6 +88,11 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
   AVFrame *frame = zm_av_frame_alloc();
   char errbuf[AV_ERROR_MAX_STRING_SIZE];
 
+  if (!packet) {
+    Error("Unable to allocate packet.");
+    return nullptr;
+  }
+
   while ( !frameComplete ) {
     int ret = av_read_frame( input_format_context, packet.get() );
     if ( ret < 0 ) {
@@ -105,6 +110,8 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
       return NULL;
     }
 
+    av_packet_guard pkt_guard{packet};
+
     if ( (stream_id < 0 ) || ( packet->stream_index == stream_id ) ) {
       Debug(1,"Packet is for our stream (%d)", packet->stream_index );
 
@@ -114,7 +121,6 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
     if ( ret < 0 ) {
       av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
       Error( "Unable to send packet at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
-      zm_av_packet_unref( packet.get() );
       continue;
     } else {
       Debug(1, "Success getting a packet");
@@ -126,14 +132,12 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
       if ( ret < 0 ) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
         Error( "Unable to receive frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
-        zm_av_packet_unref( packet.get() );
         continue;
       }
       ret = av_hwframe_transfer_data(frame, hwFrame, 0);
       if (ret < 0) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
         Error( "Unable to transfer frame at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
-        zm_av_packet_unref( packet.get() );
         continue;
       }
     } else {
@@ -143,7 +147,6 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
       if ( ret < 0 ) {
         av_strerror( ret, errbuf, AV_ERROR_MAX_STRING_SIZE );
         Error( "Unable to send packet at frame %d: %s, continuing", streams[packet->stream_index].frame_count, errbuf );
-        zm_av_packet_unref( packet.get() );
         continue;
       }
 
@@ -153,8 +156,6 @@ AVFrame *FFmpeg_Output::get_frame( int stream_id ) {
 
     frameComplete = 1;
   } // end if it's the right stream
-
-      zm_av_packet_unref( packet.get() );
 
   } // end while ! frameComplete
   return frame;

--- a/src/zm_ffmpeg_output.h
+++ b/src/zm_ffmpeg_output.h
@@ -35,6 +35,7 @@ class FFmpeg_Output {
     int video_stream_id;
     int audio_stream_id;
     AVFormatContext *input_format_context;
+    av_frame_ptr frame;
 };
 
 #endif

--- a/src/zm_fifo.cpp
+++ b/src/zm_fifo.cpp
@@ -99,9 +99,9 @@ bool Fifo::close() {
 bool Fifo::writePacket(const ZMPacket &packet) {
   if (!(outfile or open())) return false;
 
-  Debug(2, "Writing header ZM %u %" PRId64,  packet.packet.size, packet.pts);
+  Debug(2, "Writing header ZM %u %" PRId64,  packet.packet->size, packet.pts);
   // Going to write a brief header
-  if (fprintf(outfile, "ZM %u %" PRId64 "\n", packet.packet.size, packet.pts) < 0) {
+  if (fprintf(outfile, "ZM %u %" PRId64 "\n", packet.packet->size, packet.pts) < 0) {
     if (errno != EAGAIN) {
       Error("Problem during writing: %s", strerror(errno));
     } else {
@@ -110,7 +110,7 @@ bool Fifo::writePacket(const ZMPacket &packet) {
     return false;
   }
 
-  if (fwrite(packet.packet.data, packet.packet.size, 1, outfile) != 1) {
+  if (fwrite(packet.packet->data, packet.packet->size, 1, outfile) != 1) {
     Debug(1, "Unable to write to '%s': %s", path.c_str(), strerror(errno));
     return false;
   }
@@ -129,8 +129,8 @@ bool Fifo::writePacket(const std::string &filename, const ZMPacket &packet) {
     return false;
   }
 
-  Debug(4, "Writing packet of size %d pts %" PRId64, packet.packet.size, packet.pts);
-  if (fwrite(packet.packet.data, packet.packet.size, 1, outfile) != 1) {
+  Debug(4, "Writing packet of size %d pts %" PRId64, packet.packet->size, packet.pts);
+  if (fwrite(packet.packet->data, packet.packet->size, 1, outfile) != 1) {
     Debug(1, "Unable to write to '%s': %s", filename.c_str(), strerror(errno));
     fclose(outfile);
     return false;

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -289,7 +289,11 @@ bool Image::Assign(const AVFrame *frame) {
 
   // Desired format
   AVPixelFormat format = (AVPixelFormat)AVPixFormat();
-  AVFrame *dest_frame = zm_av_frame_alloc();
+  av_frame_ptr dest_frame{zm_av_frame_alloc()};
+  if (!dest_frame) {
+    Error("Unable to allocate destination frame");
+    return false;
+  }
   sws_convert_context = sws_getCachedContext(
       sws_convert_context,
       frame->width, frame->height, (AVPixelFormat)frame->format,
@@ -301,8 +305,7 @@ bool Image::Assign(const AVFrame *frame) {
     Error("Unable to create conversion context");
     return false;
   }
-  bool result = Assign(frame, sws_convert_context, dest_frame);
-  av_frame_free(&dest_frame);
+  bool result = Assign(frame, sws_convert_context, dest_frame.get());
   update_function_pointers();
   return result;
 }  // end Image::Assign(const AVFrame *frame)

--- a/src/zm_libvlc_camera.cpp
+++ b/src/zm_libvlc_camera.cpp
@@ -288,7 +288,7 @@ int LibvlcCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
 
   mLibvlcData.mutex.lock();
   zm_packet->image->Assign(width, height, colours, subpixelorder, mLibvlcData.buffer, width * height * mBpp);
-  zm_packet->packet.stream_index = mVideoStreamId;
+  zm_packet->packet->stream_index = mVideoStreamId;
   zm_packet->stream = mVideoStream;
   mLibvlcData.mutex.unlock();
 

--- a/src/zm_libvnc_camera.cpp
+++ b/src/zm_libvnc_camera.cpp
@@ -214,7 +214,7 @@ int VncCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
   }
   zm_packet->keyframe = 1;
   zm_packet->codec_type = AVMEDIA_TYPE_VIDEO;
-  zm_packet->packet.stream_index = mVideoStreamId;
+  zm_packet->packet->stream_index = mVideoStreamId;
   zm_packet->stream = mVideoStream;
 
   uint8_t *directbuffer = zm_packet->image->WriteBuffer(width, height, colours, subpixelorder);

--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -219,7 +219,7 @@ int LocalCamera::vid_fd = -1;
 int LocalCamera::v4l_version = 0;
 LocalCamera::V4L2Data LocalCamera::v4l2_data;
 
-AVFrame **LocalCamera::capturePictures = nullptr;
+av_frame_ptr *LocalCamera::capturePictures;
 
 LocalCamera *LocalCamera::last_camera = nullptr;
 
@@ -436,7 +436,7 @@ LocalCamera::LocalCamera(
 
   /* Initialize swscale stuff */
   if (capture and (conversion_type == 1)) {
-    tmpPicture = av_frame_alloc();
+    tmpPicture = av_frame_ptr{zm_av_frame_alloc()};
 
     if (!tmpPicture)
       Fatal("Could not allocate temporary picture");
@@ -456,7 +456,6 @@ LocalCamera::LocalCamera(
       Fatal("Unable to initialise image scaling context");
     }
   } else {
-    tmpPicture = nullptr;
     imgConversionContext = nullptr;
   } // end if capture and conversion_tye == swscale
   if (capture and device_prime)
@@ -471,8 +470,6 @@ LocalCamera::~LocalCamera() {
   if (capture && (conversion_type == 1)) {
     sws_freeContext(imgConversionContext);
     imgConversionContext = nullptr;
-
-    av_frame_free(&tmpPicture);
   }
 } // end LocalCamera::~LocalCamera
 
@@ -658,7 +655,7 @@ void LocalCamera::Initialise() {
       channel_count, v4l_multi_buffer, v4l2_data.reqbufs.count);
 
   v4l2_data.buffers = new V4L2MappedBuffer[v4l2_data.reqbufs.count];
-  capturePictures = new AVFrame *[v4l2_data.reqbufs.count];
+  capturePictures = new av_frame_ptr[v4l2_data.reqbufs.count];
 
   for (unsigned int i = 0; i < v4l2_data.reqbufs.count; i++) {
     struct v4l2_buffer vid_buf;
@@ -681,7 +678,7 @@ void LocalCamera::Initialise() {
       Fatal("Can't map video buffer %u (%u bytes) to memory: %s(%d)",
           i, vid_buf.length, strerror(errno), errno);
 
-    capturePictures[i] = av_frame_alloc();
+    capturePictures[i] = av_frame_ptr{zm_av_frame_alloc()};
 
     if (!capturePictures[i])
       Fatal("Could not allocate picture");
@@ -738,7 +735,7 @@ void LocalCamera::Terminate() {
 
     Debug(3, "Unmapping video buffers");
     for ( unsigned int i = 0; i < v4l2_data.reqbufs.count; i++ ) {
-      av_frame_free(&capturePictures[i]);
+      capturePictures[i] = nullptr;
 
       if ( munmap(v4l2_data.buffers[i].start, v4l2_data.buffers[i].length) < 0 )
         Error("Failed to munmap buffer %d: %s", i, strerror(errno));

--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -1376,7 +1376,7 @@ int LocalCamera::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
     zm_packet->image->Assign(width, height, colours, subpixelorder, buffer, imagesize);
   } // end if doing conversion or not
 
-  zm_packet->packet.stream_index = mVideoStreamId;
+  zm_packet->packet->stream_index = mVideoStreamId;
   zm_packet->stream = mVideoStream;
   zm_packet->codec_type = AVMEDIA_TYPE_VIDEO;
   zm_packet->keyframe = 1;

--- a/src/zm_local_camera.h
+++ b/src/zm_local_camera.h
@@ -73,11 +73,11 @@ protected:
 
   static V4L2Data         v4l2_data;
 
-  static AVFrame      **capturePictures;
+  static av_frame_ptr    *capturePictures;
   _AVPIXELFORMAT         imagePixFormat;
   _AVPIXELFORMAT         capturePixFormat;
   struct SwsContext   *imgConversionContext;
-  AVFrame             *tmpPicture;    
+  av_frame_ptr        tmpPicture;
 
   static LocalCamera      *last_camera;
 

--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -2469,10 +2469,10 @@ int Monitor::Capture() {
       shared_data->last_write_time = std::chrono::system_clock::to_time_t(packet->timestamp);
     }
     Debug(2, "Have packet stream_index:%d ?= videostream_id: %d q.vpktcount %d event? %d image_count %d",
-        packet->packet.stream_index, video_stream_id, packetqueue.packet_count(video_stream_id), ( event ? 1 : 0 ), image_count);
+        packet->packet->stream_index, video_stream_id, packetqueue.packet_count(video_stream_id), ( event ? 1 : 0 ), image_count);
 
     if (packet->codec_type == AVMEDIA_TYPE_VIDEO) {
-      packet->packet.stream_index = video_stream_id; // Convert to packetQueue's index
+      packet->packet->stream_index = video_stream_id; // Convert to packetQueue's index
       if (video_fifo) {
         if (packet->keyframe) {
           // avcodec strips out important nals that describe the stream and
@@ -2493,7 +2493,7 @@ int Monitor::Capture() {
       if (record_audio and (packetqueue.packet_count(video_stream_id) or event)) {
         packet->image_index=-1;
         Debug(2, "Queueing audio packet");
-        packet->packet.stream_index = audio_stream_id; // Convert to packetQueue's index
+        packet->packet->stream_index = audio_stream_id; // Convert to packetQueue's index
         packetqueue.queuePacket(packet);
       } else {
         Debug(4, "Not Queueing audio packet");
@@ -2601,7 +2601,7 @@ bool Monitor::Decode() {
     return true; // Don't need decode
   }
 
-  if ((!packet->image) and packet->packet.size and !packet->in_frame) {
+  if ((!packet->image) and packet->packet->size and !packet->in_frame) {
     if ((decoding == DECODING_ALWAYS)
         or
         ((decoding == DECODING_ONDEMAND) and this->hasViewers() )
@@ -2632,7 +2632,7 @@ bool Monitor::Decode() {
           }  // end if have convert_context
         }  // end if need transfer to image
       } else {
-        Debug(1, "No packet.size(%d) or packet->in_frame(%p). Not decoding", packet->packet.size, packet->in_frame);
+        Debug(1, "No packet.size(%d) or packet->in_frame(%p). Not decoding", packet->packet->size, packet->in_frame);
       }
     } else {
       Debug(1, "Not Decoding ? %s", Decoding_Strings[decoding].c_str());
@@ -3268,7 +3268,7 @@ void Monitor::get_ref_image() {
 
   std::shared_ptr<ZMPacket> snap = snap_lock->packet_;
   Debug(1, "get_ref_image: packet.stream %d ?= video_stream %d, packet image id %d packet image %p",
-      snap->packet.stream_index, video_stream_id, snap->image_index, snap->image );
+      snap->packet->stream_index, video_stream_id, snap->image_index, snap->image );
   // Might not have been decoded yet FIXME
   if (snap->image) {
     ref_image.Assign(width, height, camera->Colours(),

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -523,7 +523,7 @@ protected:
   std::unique_ptr<AnalysisThread> analysis_thread;
   packetqueue_iterator  *decoder_it;
   std::unique_ptr<DecoderThread> decoder;
-  AVFrame *dest_frame;                    // Used by decoding thread doing colorspace conversions
+  av_frame_ptr dest_frame;                    // Used by decoding thread doing colorspace conversions
   SwsContext   *convert_context;
   std::thread  close_event_thread;
 

--- a/src/zm_mpeg.h
+++ b/src/zm_mpeg.h
@@ -22,6 +22,7 @@
 
 #include "zm_ffmpeg.h"
 #include <pthread.h>
+#include <array>
 
 class VideoStream {
 protected:
@@ -59,7 +60,7 @@ protected:
   pthread_mutex_t *buffer_copy_lock;
   int buffer_copy_size;
   int buffer_copy_used;
-  AVPacket** packet_buffers;
+  std::array<av_packet_ptr, 2> packet_buffers;
   int packet_index;
   int SendPacket(AVPacket *packet);
   static void* StreamingThreadCallback(void *ctx);

--- a/src/zm_mpeg.h
+++ b/src/zm_mpeg.h
@@ -46,8 +46,8 @@ protected:
   AVStream *ost;
   AVCodecContext *codec_context;
   const AVCodec *codec;
-  AVFrame *opicture;
-  AVFrame *tmp_opicture;
+  av_frame_ptr opicture;
+  av_frame_ptr tmp_opicture;
   uint8_t *video_outbuf;
   int video_outbuf_size;
   double last_pts;

--- a/src/zm_packet.h
+++ b/src/zm_packet.h
@@ -44,7 +44,7 @@ class ZMPacket {
 
     int keyframe;
     AVStream  *stream;            // Input stream
-    AVPacket  packet;             // Input packet, undecoded
+    av_packet_ptr packet;         // Input packet, undecoded
     AVFrame   *in_frame;          // Input image, decoded Theoretically only filled if needed.
     AVFrame   *out_frame;         // output image, Only filled if needed.
     SystemTimePoint timestamp;
@@ -61,7 +61,7 @@ class ZMPacket {
     std::string  alarm_cause;
 
   public:
-    AVPacket *av_packet() { return &packet; }
+    AVPacket *av_packet() { return packet.get(); }
     AVPacket *set_packet(AVPacket *p) ;
     AVFrame *av_frame() { return out_frame; }
     Image *get_image(Image *i=nullptr);

--- a/src/zm_packet.h
+++ b/src/zm_packet.h
@@ -45,10 +45,9 @@ class ZMPacket {
     int keyframe;
     AVStream  *stream;            // Input stream
     av_packet_ptr packet;         // Input packet, undecoded
-    AVFrame   *in_frame;          // Input image, decoded Theoretically only filled if needed.
-    AVFrame   *out_frame;         // output image, Only filled if needed.
+    av_frame_ptr in_frame;        // Input image, decoded Theoretically only filled if needed.
+    av_frame_ptr out_frame;       // output image, Only filled if needed.
     SystemTimePoint timestamp;
-    uint8_t   *buffer;            // buffer used in image
     Image     *image;
     Image     *analysis_image;
     int       score;
@@ -63,7 +62,7 @@ class ZMPacket {
   public:
     AVPacket *av_packet() { return packet.get(); }
     AVPacket *set_packet(AVPacket *p) ;
-    AVFrame *av_frame() { return out_frame; }
+    AVFrame *av_frame() { return out_frame.get(); }
     Image *get_image(Image *i=nullptr);
     Image *set_image(Image *);
     ssize_t ram();

--- a/src/zm_packetqueue.cpp
+++ b/src/zm_packetqueue.cpp
@@ -99,13 +99,13 @@ bool PacketQueue::queuePacket(std::shared_ptr<ZMPacket> add_packet) {
       }
     }  // end foreach iterator
 
-    packet_counts[add_packet->packet.stream_index] += 1;
+    packet_counts[add_packet->packet->stream_index] += 1;
     Debug(2, "packet counts for %d is %d",
-        add_packet->packet.stream_index,
-        packet_counts[add_packet->packet.stream_index]);
+        add_packet->packet->stream_index,
+        packet_counts[add_packet->packet->stream_index]);
 
     if (
-        (add_packet->packet.stream_index == video_stream_id)
+        (add_packet->packet->stream_index == video_stream_id)
         and
         (max_video_packet_count > 0)
         and
@@ -153,17 +153,17 @@ bool PacketQueue::queuePacket(std::shared_ptr<ZMPacket> add_packet) {
         }  // end foreach iterator
 
         it = pktQueue.erase(it);
-        packet_counts[zm_packet->packet.stream_index] -= 1;
+        packet_counts[zm_packet->packet->stream_index] -= 1;
         Debug(1,
             "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
-            zm_packet->packet.stream_index,
+            zm_packet->packet->stream_index,
             zm_packet->image_index,
             zm_packet->keyframe,
             packet_counts[video_stream_id],
             max_video_packet_count,
             pktQueue.size());
 
-        if (zm_packet->packet.stream_index == video_stream_id)
+        if (zm_packet->packet->stream_index == video_stream_id)
           break;
       }  // end while
     } else if (warned_count > 0) {
@@ -192,7 +192,7 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
   if (deleting) return;
 
   if (keep_keyframes and ! (
-        add_packet->packet.stream_index == video_stream_id
+        add_packet->packet->stream_index == video_stream_id
         and
         add_packet->keyframe
         and
@@ -202,7 +202,7 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
         )
      ) {
     Debug(3, "stream index %d ?= video_stream_id %d, keyframe %d, keep_keyframes %d,  counts %d > pre_event_count %d at begin %d",
-        add_packet->packet.stream_index, video_stream_id, add_packet->keyframe, keep_keyframes, packet_counts[video_stream_id], pre_event_video_packet_count, 
+        add_packet->packet->stream_index, video_stream_id, add_packet->keyframe, keep_keyframes, packet_counts[video_stream_id], pre_event_video_packet_count,
         ( *(pktQueue.begin()) != add_packet )
         );
     return;
@@ -215,7 +215,7 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
     packetqueue_iterator it = pktQueue.end();
     --it;
     while (*it != add_packet) {
-      if ((*it)->packet.stream_index == video_stream_id)
+      if ((*it)->packet->stream_index == video_stream_id)
         ++tail_count;
       --it;
     }
@@ -239,10 +239,10 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
       }
 
       pktQueue.pop_front();
-      packet_counts[zm_packet->packet.stream_index] -= 1;
+      packet_counts[zm_packet->packet->stream_index] -= 1;
       Debug(1,
             "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
-            zm_packet->packet.stream_index,
+            zm_packet->packet->stream_index,
             zm_packet->image_index,
             zm_packet->keyframe,
             packet_counts[video_stream_id],
@@ -295,7 +295,7 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
     }
 #endif
 
-    if (zm_packet->packet.stream_index == video_stream_id) {
+    if (zm_packet->packet->stream_index == video_stream_id) {
       if (zm_packet->keyframe) {
         Debug(4, "Have a video keyframe so setting next front to it. Keyframe interval so far is %d", keyframe_interval);
         keyframe_interval = 1;
@@ -331,14 +331,14 @@ void PacketQueue::clearPackets(const std::shared_ptr<ZMPacket> &add_packet) {
 
       Debug(1,
             "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
-            zm_packet->packet.stream_index,
+            zm_packet->packet->stream_index,
             zm_packet->image_index,
             zm_packet->keyframe,
             packet_counts[video_stream_id],
             pre_event_video_packet_count,
             pktQueue.size());
       pktQueue.pop_front();
-      packet_counts[zm_packet->packet.stream_index] -= 1;
+      packet_counts[zm_packet->packet->stream_index] -= 1;
     }
   }  // end if have at least max_video_packet_count video packets remaining
 
@@ -365,13 +365,13 @@ void PacketQueue::clear() {
     lp->lock();
     Debug(1,
         "Deleting a packet with stream index:%d image_index:%d with keyframe:%d, video frames in queue:%d max: %d, queuesize:%zu",
-        packet->packet.stream_index,
+        packet->packet->stream_index,
         packet->image_index,
         packet->keyframe,
         packet_counts[video_stream_id],
         pre_event_video_packet_count,
         pktQueue.size());
-    packet_counts[packet->packet.stream_index] -= 1;
+    packet_counts[packet->packet->stream_index] -= 1;
     pktQueue.pop_front();
     delete lp;
   }
@@ -529,7 +529,7 @@ bool PacketQueue::increment_it(packetqueue_iterator *it, int stream_id) {
   std::unique_lock<std::mutex> lck(mutex);
   do {
     ++(*it);
-  } while ( (*it != pktQueue.end()) and ( (*(*it))->packet.stream_index != stream_id) );
+  } while ( (*it != pktQueue.end()) and ( (*(*it))->packet->stream_index != stream_id) );
 
   if ( *it != pktQueue.end() ) {
     Debug(2, "Incrementing %p, still not at end, so incrementing", it);
@@ -558,10 +558,10 @@ packetqueue_iterator *PacketQueue::get_event_start_packet_it(
       packet = *(*it);
       /*
       Debug(1, "Previous packet pre_event_count %d stream_index %d keyframe %d score %d",
-          pre_event_count, packet->packet.stream_index, packet->keyframe, packet->score);
+          pre_event_count, packet->packet->stream_index, packet->keyframe, packet->score);
       ZM_DUMP_PACKET(packet->packet, "");
       */
-      if (packet->packet.stream_index == video_stream_id) {
+      if (packet->packet->stream_index == video_stream_id) {
         pre_event_count --;
         if (!pre_event_count)
           break;
@@ -589,7 +589,7 @@ packetqueue_iterator *PacketQueue::get_event_start_packet_it(
   while ((*it) != pktQueue.begin()) {
     packet = *(*it);
     //ZM_DUMP_PACKET(packet->packet, "No keyframe");
-    if ((packet->packet.stream_index == video_stream_id) and packet->keyframe)
+    if ((packet->packet->stream_index == video_stream_id) and packet->keyframe)
       return it; // Success
     --(*it);
   }
@@ -638,8 +638,8 @@ packetqueue_iterator * PacketQueue::get_video_it(bool wait) {
       return nullptr;
     }
     Debug(1, "Packet keyframe %d for stream %d, so returning the it to it",
-        zm_packet->keyframe, zm_packet->packet.stream_index);
-    if (zm_packet->keyframe and ( zm_packet->packet.stream_index == video_stream_id )) {
+        zm_packet->keyframe, zm_packet->packet->stream_index);
+    if (zm_packet->keyframe and ( zm_packet->packet->stream_index == video_stream_id )) {
       Debug(1, "Found a keyframe for stream %d, so returning the it to it", video_stream_id);
       return it;
     }

--- a/src/zm_remote_camera_http.cpp
+++ b/src/zm_remote_camera_http.cpp
@@ -1099,7 +1099,7 @@ int RemoteCameraHttp::Capture(std::shared_ptr<ZMPacket> &packet) {
   Image *image = packet->image;
   packet->keyframe = 1;
   packet->codec_type = AVMEDIA_TYPE_VIDEO;
-  packet->packet.stream_index = mVideoStreamId;
+  packet->packet->stream_index = mVideoStreamId;
   packet->stream = mVideoStream;
 
   switch (format) {

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -216,7 +216,7 @@ int RemoteCameraRtsp::PreCapture() {
 
 int RemoteCameraRtsp::Capture(std::shared_ptr<ZMPacket> &zm_packet) {
   int frameComplete = false;
-  AVPacket *packet = &zm_packet->packet;
+  AVPacket *packet = zm_packet->packet.get();
 
   while (!frameComplete) {
     buffer.clear();

--- a/src/zm_rtsp_server_device_source.cpp
+++ b/src/zm_rtsp_server_device_source.cpp
@@ -141,7 +141,7 @@ int ZoneMinderDeviceSource::getNextFrame() {
     m_packetqueue_it = m_packetqueue->get_video_it(true);
   }
   ZMPacket *zm_packet = m_packetqueue->get_packet(m_packetqueue_it);
-  while ( zm_packet and (zm_packet->packet.stream_index != m_stream->index) ) {
+  while ( zm_packet and (zm_packet->packet->stream_index != m_stream->index) ) {
     zm_packet->unlock();
     // We want our stream to start at the same it as the video
     // but if this is an audio stream we need to increment past that first packet

--- a/src/zm_swscale.cpp
+++ b/src/zm_swscale.cpp
@@ -25,8 +25,6 @@
 SWScale::SWScale() :
   gotdefaults(false),
   swscale_ctx(nullptr),
-  input_avframe(nullptr),
-  output_avframe(nullptr),
   default_width(0),
   default_height(0)
 {
@@ -34,13 +32,13 @@ SWScale::SWScale() :
 }
 
 bool SWScale::init() {
-  input_avframe = av_frame_alloc();
+  input_avframe = av_frame_ptr{zm_av_frame_alloc()};
   if (!input_avframe) {
     Error("Failed allocating AVFrame for the input");
     return false;
   }
 
-  output_avframe = av_frame_alloc();
+  output_avframe = av_frame_ptr{zm_av_frame_alloc()};
   if (!output_avframe) {
     Error("Failed allocating AVFrame for the output");
     return false;
@@ -51,12 +49,6 @@ bool SWScale::init() {
 SWScale::~SWScale() {
 
   /* Free up everything */
-  if ( input_avframe )
-    av_frame_free(&input_avframe);
-
-  if ( output_avframe )
-    av_frame_free(&output_avframe);
-
   if ( swscale_ctx ) {
     sws_freeContext(swscale_ctx);
     swscale_ctx = nullptr;

--- a/src/zm_swscale.h
+++ b/src/zm_swscale.h
@@ -24,8 +24,8 @@ class SWScale {
   protected:
     bool gotdefaults;
     struct SwsContext* swscale_ctx;
-    AVFrame* input_avframe;
-    AVFrame* output_avframe;
+    av_frame_ptr input_avframe;
+    av_frame_ptr output_avframe;
     enum _AVPIXELFORMAT default_input_pf;
     enum _AVPIXELFORMAT default_output_pf;
     unsigned int default_width;

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -110,7 +110,7 @@ VideoStore::VideoStore(
 {
   FFMPEGInit();
   swscale.init();
-  opkt = new AVPacket;
+  opkt = av_packet_ptr{av_packet_alloc()};
 }  // VideoStore::VideoStore
 
 bool VideoStore::open() {
@@ -575,21 +575,17 @@ bool VideoStore::open() {
 void VideoStore::flush_codecs() {
   // The codec queues data.  We need to send a flush command and out
   // whatever we get. Failures are not fatal.
-  AVPacket pkt;
-  // Without these we seg fault becuse av_init_packet doesn't init them
-  pkt.data = nullptr;
-  pkt.size = 0;
-  av_init_packet(&pkt);
+  av_packet_ptr pkt{av_packet_alloc()};
 
   // I got crashes if the codec didn't do DELAY, so let's test for it.
   if (video_out_ctx && video_out_ctx->codec && (video_out_ctx->codec->capabilities & AV_CODEC_CAP_DELAY)) {
     // Put encoder into flushing mode
-    while ((zm_send_frame_receive_packet(video_out_ctx, nullptr, pkt)) > 0) {
-      av_packet_rescale_ts(&pkt,
+    while ((zm_send_frame_receive_packet(video_out_ctx, nullptr, *pkt)) > 0) {
+      av_packet_rescale_ts(pkt.get(),
           video_out_ctx->time_base,
           video_out_stream->time_base);
-      write_packet(&pkt, video_out_stream);
-      zm_av_packet_unref(&pkt);
+      write_packet(pkt.get(), video_out_stream);
+      zm_av_packet_unref(pkt.get());
     } // while have buffered frames
     Debug(1, "Done writing buffered video.");
   } // end if have delay capability
@@ -608,12 +604,12 @@ void VideoStore::flush_codecs() {
       if (zm_add_samples_to_fifo(fifo, out_frame)) {
         // Should probably set the frame size to what is reported FIXME
         if (zm_get_samples_from_fifo(fifo, out_frame)) {
-          if (zm_send_frame_receive_packet(audio_out_ctx, out_frame, pkt) > 0) {
-            av_packet_rescale_ts(&pkt,
+          if (zm_send_frame_receive_packet(audio_out_ctx, out_frame, *pkt) > 0) {
+            av_packet_rescale_ts(pkt.get(),
                 audio_out_ctx->time_base,
                 audio_out_stream->time_base);
-            write_packet(&pkt, audio_out_stream);
-            zm_av_packet_unref(&pkt);
+            write_packet(pkt.get(), audio_out_stream);
+            zm_av_packet_unref(pkt.get());
           }
         }  // end if data returned from fifo
       }
@@ -629,14 +625,14 @@ void VideoStore::flush_codecs() {
 
       // SHould probably set the frame size to what is reported FIXME
       if (av_audio_fifo_read(fifo, (void **)out_frame->data, frame_size)) {
-        if (zm_send_frame_receive_packet(audio_out_ctx, out_frame, pkt)) {
-          pkt.stream_index = audio_out_stream->index;
+        if (zm_send_frame_receive_packet(audio_out_ctx, out_frame, *pkt)) {
+          pkt->stream_index = audio_out_stream->index;
 
-          av_packet_rescale_ts(&pkt,
+          av_packet_rescale_ts(pkt.get(),
               audio_out_ctx->time_base,
               audio_out_stream->time_base);
-          write_packet(&pkt, audio_out_stream);
-          zm_av_packet_unref(&pkt);
+          write_packet(pkt.get(), audio_out_stream);
+          zm_av_packet_unref(pkt.get());
         }
       }  // end if data returned from fifo
     }  // end while still data in the fifo
@@ -645,16 +641,16 @@ void VideoStore::flush_codecs() {
       avcodec_send_frame(audio_out_ctx, nullptr);
 
     while (true) {
-      if (0 >= zm_receive_packet(audio_out_ctx, pkt)) {
+      if (0 >= zm_receive_packet(audio_out_ctx, *pkt)) {
         Debug(1, "No more packets");
         break;
       }
 
       ZM_DUMP_PACKET(pkt, "raw from encoder");
-      av_packet_rescale_ts(&pkt, audio_out_ctx->time_base, audio_out_stream->time_base);
+      av_packet_rescale_ts(pkt.get(), audio_out_ctx->time_base, audio_out_stream->time_base);
       ZM_DUMP_STREAM_PACKET(audio_out_stream, pkt, "writing flushed packet");
-      write_packet(&pkt, audio_out_stream);
-      zm_av_packet_unref(&pkt);
+      write_packet(pkt.get(), audio_out_stream);
+      zm_av_packet_unref(pkt.get());
     }  // while have buffered frames
   }  // end if audio_out_codec
 }  // end flush_codecs
@@ -977,13 +973,13 @@ int VideoStore::writePacket(const std::shared_ptr<ZMPacket> &zm_pkt) {
   auto &queue = reorder_queues[stream_index];
   Debug(1, "Queue size for %d is %zu", stream_index, queue.size());
 
-  AVPacket *av_pkt = &zm_pkt->packet;
+  AVPacket *av_pkt = zm_pkt->packet.get();
   // queue the packet
   bool have_out_of_order = false;
   auto rit = queue.rbegin();
   // Find the previous packet for the stream, and check dts
   while (rit != queue.rend()) {
-    AVPacket *p = &((*rit)->packet);
+    AVPacket *p = ((*rit)->packet).get();
     if (p->dts <= av_pkt->dts) {
       Debug(1, "Found in order packet");
       // packets are in order, everything is fine
@@ -1052,7 +1048,7 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
             );
       } else if (!zm_packet->in_frame) {
         Debug(4, "Have no in_frame");
-        if (zm_packet->packet.size and !zm_packet->decoded) {
+        if (zm_packet->packet->size and !zm_packet->decoded) {
           Debug(4, "Decoding");
           if (!zm_packet->decode(video_in_ctx)) {
             Debug(2, "unable to decode yet.");
@@ -1131,10 +1127,6 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
             video_out_ctx->time_base.den);
     }
 
-    av_init_packet(opkt);
-    opkt->data = nullptr;
-    opkt->size = 0;
-
     int ret = zm_send_frame_receive_packet(video_out_ctx, frame, *opkt);
     if (ret <= 0) {
       if (ret < 0) {
@@ -1142,7 +1134,7 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
       }
       return ret;
     }
-    ZM_DUMP_PACKET((*opkt), "packet returned by codec");
+    ZM_DUMP_PACKET(opkt, "packet returned by codec");
 
     // Need to adjust pts/dts values from codec time to stream time
     if (opkt->pts != AV_NOPTS_VALUE)
@@ -1193,11 +1185,10 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
     }  // end if in_frmae
     opkt->duration = duration;
   } else { // Passthrough
-    AVPacket *ipkt = &zm_packet->packet;
-    ZM_DUMP_STREAM_PACKET(video_in_stream, (*ipkt), "Doing passthrough, just copy packet");
+    AVPacket *ipkt = zm_packet->packet.get();
+    ZM_DUMP_STREAM_PACKET(video_in_stream, ipkt, "Doing passthrough, just copy packet");
     // Just copy it because the codec is the same
-    av_init_packet(opkt);
-    av_packet_ref(opkt, ipkt);
+    av_packet_ref(opkt.get(), ipkt);
 
     if (ipkt->dts != AV_NOPTS_VALUE) {
       if (video_first_dts == AV_NOPTS_VALUE) {
@@ -1213,19 +1204,19 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
       opkt->pts = ipkt->pts - video_first_dts;
     }
 
-    av_packet_rescale_ts(opkt, video_in_stream->time_base, video_out_stream->time_base);
+    av_packet_rescale_ts(opkt.get(), video_in_stream->time_base, video_out_stream->time_base);
   }  // end if codec matches
 
-  write_packet(opkt, video_out_stream);
-  zm_av_packet_unref(opkt);
+  write_packet(opkt.get(), video_out_stream);
+  zm_av_packet_unref(opkt.get());
   if (hw_frame) av_frame_free(&hw_frame);
 
   return 1;
 }  // end int VideoStore::writeVideoFramePacket( AVPacket *ipkt )
 
 int VideoStore::writeAudioFramePacket(const std::shared_ptr<ZMPacket> &zm_packet) {
-  AVPacket *ipkt = &zm_packet->packet;
-  ZM_DUMP_STREAM_PACKET(audio_in_stream, (*ipkt), "input packet");
+  AVPacket *ipkt = zm_packet->packet.get();
+  ZM_DUMP_STREAM_PACKET(audio_in_stream, ipkt, "input packet");
 
   if (audio_first_dts == AV_NOPTS_VALUE) {
     audio_first_dts = ipkt->dts;
@@ -1262,17 +1253,16 @@ int VideoStore::writeAudioFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
 
       zm_dump_frame(out_frame, "Out frame after resample");
 
-      av_init_packet(opkt);
       if (zm_send_frame_receive_packet(audio_out_ctx, out_frame, *opkt) <= 0)
         break;
 
       // Scale the PTS of the outgoing packet to be the correct time base
-      av_packet_rescale_ts(opkt,
+      av_packet_rescale_ts(opkt.get(),
           audio_out_ctx->time_base,
           audio_out_stream->time_base);
 
-      write_packet(opkt, audio_out_stream);
-      zm_av_packet_unref(opkt);
+      write_packet(opkt.get(), audio_out_stream);
+      zm_av_packet_unref(opkt.get());
 
       if (zm_resample_get_delay(resample_ctx, out_frame->sample_rate) < out_frame->nb_samples)
         break;
@@ -1280,7 +1270,6 @@ int VideoStore::writeAudioFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
       input_frame = nullptr;
     }  // end while there is data in the resampler
   } else {
-    av_init_packet(opkt);
     opkt->data = ipkt->data;
     opkt->size = ipkt->size;
     opkt->flags = ipkt->flags;
@@ -1293,12 +1282,12 @@ int VideoStore::writeAudioFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
       opkt->dts = ipkt->dts;
     }
 
-    ZM_DUMP_STREAM_PACKET(audio_in_stream, (*ipkt), "after pts adjustment");
-    av_packet_rescale_ts(opkt, audio_in_stream->time_base, audio_out_stream->time_base);
-    ZM_DUMP_STREAM_PACKET(audio_out_stream, (*opkt), "after stream pts adjustment");
-    write_packet(opkt, audio_out_stream);
+    ZM_DUMP_STREAM_PACKET(audio_in_stream, ipkt, "after pts adjustment");
+    av_packet_rescale_ts(opkt.get(), audio_in_stream->time_base, audio_out_stream->time_base);
+    ZM_DUMP_STREAM_PACKET(audio_out_stream, opkt, "after stream pts adjustment");
+    write_packet(opkt.get(), audio_out_stream);
 
-    zm_av_packet_unref(opkt);
+    zm_av_packet_unref(opkt.get());
   }  // end if encoding or copying
 
   return 0;
@@ -1337,7 +1326,7 @@ int VideoStore::write_packet(AVPacket *pkt, AVStream *stream) {
     pkt->pts = pkt->dts;
   }
 
-  ZM_DUMP_STREAM_PACKET(stream, (*pkt), "finished pkt");
+  ZM_DUMP_STREAM_PACKET(stream, pkt, "finished pkt");
   Debug(3, "next_dts for stream %d has become %" PRId64 " last_dts %" PRId64,
       stream->index, next_dts[stream->index], last_dts[stream->index]);
 

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -59,10 +59,8 @@ class VideoStore {
     // Move this into the object so that we aren't constantly allocating/deallocating it on the stack
     av_packet_ptr opkt;
 
-    AVFrame *video_in_frame;
-    AVFrame *in_frame;
-    AVFrame *out_frame;
-    AVFrame *hw_frame;
+    av_frame_ptr in_frame;
+    av_frame_ptr out_frame;
 
     SWScale swscale;
     unsigned int packets_written;

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -57,7 +57,7 @@ class VideoStore {
     const AVCodec *audio_out_codec;
     AVCodecContext *audio_out_ctx;
     // Move this into the object so that we aren't constantly allocating/deallocating it on the stack
-    AVPacket *opkt;
+    av_packet_ptr opkt;
 
     AVFrame *video_in_frame;
     AVFrame *in_frame;


### PR DESCRIPTION
Remove all uses of deprecated av_init_packet() and switch any stack
based AVPackets to unique_ptrs allocated with av_packet_alloc().

Ensure that all code paths call av_packet_unref() after use to reset
before next usage.

---

- This API has been available since v3.0 so that covers all the supported systems.
- I checked that it properly initializes all fields so can drop the setting of packet.size & packet.data
- Debating creating an exit_guard to handle cleanup

Thoughts?