### PR TITLE
Fix zmc Segfault on 1.36.20

### DIFF
--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -1039,6 +1039,11 @@ int VideoStore::writePacket(const std::shared_ptr<ZMPacket> &zm_pkt) {
   if (zm_pkt->codec_type == AVMEDIA_TYPE_VIDEO) {
     stream_index = video_out_stream->index;
   } else if (zm_pkt->codec_type == AVMEDIA_TYPE_AUDIO) {
+    if (!audio_out_stream) {
+      Debug(1, "Called writeAudioFramePacket when no audio_out_stream");
+      return 0;
+      // FIXME -ve return codes do not free packet in ffmpeg_camera at the moment
+    }
     stream_index = audio_out_stream->index;
   } else {
     Error("Unknown stream type in packet (%d)", zm_pkt->codec_type);
@@ -1301,12 +1306,6 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
 }  // end int VideoStore::writeVideoFramePacket( AVPacket *ipkt )
 
 int VideoStore::writeAudioFramePacket(const std::shared_ptr<ZMPacket> &zm_packet) {
-  if (!audio_out_stream) {
-    Debug(1, "Called writeAudioFramePacket when no audio_out_stream");
-    return 0;
-    // FIXME -ve return codes do not free packet in ffmpeg_camera at the moment
-  }
-
   AVPacket *ipkt = &zm_packet->packet;
   int ret;
   ZM_DUMP_STREAM_PACKET(audio_in_stream, (*ipkt), "input packet");

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -1275,10 +1275,6 @@ int VideoStore::writeVideoFramePacket(const std::shared_ptr<ZMPacket> &zm_packet
     ZM_DUMP_STREAM_PACKET(video_in_stream, (*ipkt), "Doing passthrough, just copy packet");
     // Just copy it because the codec is the same
     av_init_packet(opkt);
-    opkt->data = ipkt->data;
-    opkt->size = ipkt->size;
-    opkt->flags = ipkt->flags;
-    opkt->duration = ipkt->duration;
     av_packet_ref(opkt, ipkt);
 
     if (ipkt->dts != AV_NOPTS_VALUE) {


### PR DESCRIPTION
Wasn't able to reproduce but based on the stacktrace and logs this looks likely.

1.36.20 added packet reordering and attempts to get the stream_index without checking if there actually is an audio_out_stream.

Fixes: #3533
