### PR TITLE
Adds Alarm Server support

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -3834,6 +3834,53 @@ our @options = (
     type        => $types{string},
     category    => 'config',
   },
+# Add options for Alarm Server
+  {
+    name        => 'ZM_OPT_USE_ALARMSERVER',
+    default     => 'no',
+    description => 'Enable NETSurveillance WEB Camera ALARM SERVER',
+    help        => q`
+      Alarm Server that works with cameras that use Netsurveillance Web Server, 
+      and has the Alarm Server option it receives alarms sent by this cameras 
+      (once enabled), and pass to Zoneminder the events. 
+      It requires pyzm installed, visit https://pyzm.readthedocs.io/en/latest/
+      for installation instructions.
+      `,
+    type        => $types{boolean},
+    category    => 'system',
+  },
+  {
+    name        => 'ZM_OPT_ALS_LOGENTRY',
+    default     => 'no',
+    description => 'Makes ALARM SERVER create a log entry in ZoneMinder on Human Detected',
+    help        => '',
+    type        => $types{boolean},
+    category    => 'system',
+  },
+  {
+    name        => 'ZM_OPT_ALS_ALARM',
+    default     => 'no',
+    description => 'Send the Human Detected alarm from ALARM SERVER to ZoneMinder, It does not work along with OPT_ALS_TRIGGEREVENT',
+    help        => '',
+    type        => $types{boolean},
+    category    => 'system',
+  },
+  {
+    name        => 'ZM_OPT_ALS_TRIGGEREVENT',
+    default     => 'no',
+    description => 'Trigger an event on Human Detected alarm from ALARM SERVER to ZoneMinder. Requires the zmTrigger option Enabled',
+    help        => '',
+    type        => $types{boolean},
+    category    => 'system',
+  },
+  {
+    name        => 'ZM_OPT_ALS_PORT',
+    default     => '15002',
+    description => 'Port Number to receive alarms from Alarm Server',
+    help        => '',
+    type        => $types{integer},
+    category    => 'system',
+  },
 );
 
 our %options_hash = map { ( $_->{name}, $_ ) } @options;

--- a/scripts/zmalarm-server.py
+++ b/scripts/zmalarm-server.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Adds pyzm support
+import pyzm.api as zmapi
+import pyzm.ZMLog as zmlog
+import pyzm.helpers.utils as utils
+
+import os, sys, struct, json
+from time import sleep
+#import time
+from socket import *
+# from datetime import *
+# telnet
+from telnetlib import Telnet
+# multi threading
+from threading import Thread
+
+def writezmlog(m,s):
+    zmlog.init()
+    zmlog.Info(m+s)
+#    zmlog.close()
+
+def alarm_thread(m, monid,eventlenght):
+    import subprocess
+    print("Monitor " + str(monid)+" entered alarm_thread...")
+    result = subprocess.run(['zmu','-m', str(monid), '-s'] ,stdout=subprocess.PIPE)
+    if result.stdout.decode('utf-8') != '3\n':
+        print('Changing monitor '+ str(monid) + ' status to Alarm...')
+        m.arm()
+        sleep(eventlenght)
+        m.disarm()
+    else:
+        print('Monitor '+ str(monid) + ' already in status Alarm...')
+    print('Finishing thread...')
+
+
+def event_thread(m_id,eventlenght):
+    import subprocess
+    print("Monitor " + str(m_id)+" entered event_thread...")
+    result = subprocess.run(['zmu','-m', str(m_id), '-x'] ,stdout=subprocess.PIPE)
+    if result.stdout.decode('utf-8') == '0\n':
+        print('Firing monitor '+ str(m_id) + ' trigger...')
+        telbuff = str(m_id) + '|on+'+str(eventlenght)+'|1|Human Motion Detected|'
+        with Telnet('localhost', 6802) as tn:
+          tn.write(telbuff.encode('ascii') + alarm_desc.encode('ascii') + b'\n')
+          tn.read_until(b'off')
+    else:
+        print('Monitor '+ str(m_id) + ' already triggered, doing nothing...')
+    print('Finishing thread...')
+
+
+
+def tolog(s):
+    logfile = open(datetime.now().strftime('%Y_%m_%d_') + log, 'a+')
+    logfile.write(s)
+    logfile.close()
+
+
+def GetIP(s):
+    return inet_ntoa(struct.pack('<I', int(s, 16)))
+
+
+# config variables
+eventlenght = 60
+wrzmlog = 'n'
+wrzmevent ='n'
+rsealm = 'n'
+port = '15002'
+
+if len(sys.argv) > 1:
+    keys = ["--log=","-l=","--alarm=","-a=","--port=","-p=","--event=","-e="]
+    for i in range(1,len(sys.argv)):
+        for key in keys:
+            if sys.argv[i].find(key) == 0:
+                if  key == "--log=" or key == "-l=":
+                     wrzmlog=sys.argv[i][len(key):]
+                elif key == "--alarm=" or key == "-a=":
+                     rsealm=sys.argv[i][len(key):]
+                elif key == "--port=" or key == "-p=":
+                     port=sys.argv[i][len(key):]
+                elif key == "--event=" or key == "-e=":
+                     wrzmevent=sys.argv[i][len(key):]
+                break
+
+else:
+    print('Usage: %s [--port|-p=<value> --log|-l=<y/n> --alarm|-a=<y/n> --event|-e=<y/n>]' % os.path.basename(sys.argv[0]))
+    sys.exit() 
+
+print ('Create log entry: ', wrzmlog)
+print ('Trigger event: ', wrzmlog)
+print ('Raise Alarm: ', rsealm)
+
+server = socket(AF_INET, SOCK_STREAM)
+server.bind(('0.0.0.0', int(port)))
+# server.settimeout(0.5)
+server.listen(1)
+
+log = "AlarmServer.log"
+
+conf = utils.read_config('/etc/zm/secrets.ini')
+api_options  = {
+    'apiurl': utils.get(key='ZM_API_PORTAL', section='secrets', conf=conf),
+    'portalurl':utils.get(key='ZM_PORTAL', section='secrets', conf=conf),
+    'user': utils.get(key='ZM_USER', section='secrets', conf=conf),
+    #'disable_ssl_cert_check': True
+}
+
+zmapi = zmapi.ZMApi(options=api_options)
+
+# importing the regex to get ip out of path
+import re
+#define regex pattern for IP addresses
+pattern =re.compile('''((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)''')
+# store the response of URL
+#process monitors create dict of monitors
+list_monit = {}
+zm_monitors = zmapi.monitors()
+for m in zm_monitors.list():
+	ip_v4=pattern.search(m.get()['Path'])
+	list_monit[ip_v4.group()]=m.id()
+
+writezmlog('Listening on port: '+port,' AlarmServer.py')
+print ('Listening on port: '+port)
+#run Alarm Server
+while True:
+    try:
+        conn, addr = server.accept()
+        head, version, session, sequence_number, msgid, len_data = struct.unpack(
+            'BB2xII2xHI', conn.recv(20)
+        )
+        sleep(0.1)  # Just for recive whole packet
+        data = conn.recv(len_data)
+        conn.close()
+        # make the json a Dictionary
+        reply = json.loads(data)
+        # get ip
+        ip_v4 = GetIP(reply.get('Address'))
+        # get alarm_event_desc
+        alarm_desc = reply.get('Event')
+#        print(datetime.now().strftime('[%Y-%m-%d %H:%M:%S]>>>'))
+        print ('Ip Address: ',ip_v4)
+        print ("Alarm Description: ", alarm_desc)
+        print('<<<')
+#        tolog(repr(data) + "\r\n")
+        if alarm_desc == 'HumanDetect':
+            if wrzmlog == 'y':
+               writezmlog(alarm_desc+' in monitor ',str(list_monit[ip_v4]))
+            if rsealm == 'y':
+               print ("Triggering Alarm...")
+               mthread = Thread(target=alarm_thread, args=(zm_monitors.find(list_monit[ip_v4]),list_monit[ip_v4],eventlenght))
+               mthread.start()
+            elif wrzmevent == 'y':
+               print ("Triggering Event Rec on zmtrigger...")
+               mthread = Thread(target=event_thread, args=(list_monit[ip_v4],eventlenght))
+               mthread.start()
+    except (KeyboardInterrupt, SystemExit):
+        break
+server.close()
+# needs to be closed again... otherwise it will crash on exit.
+zmlog.close()
+sys.exit(1)

--- a/scripts/zmdc.pl
+++ b/scripts/zmdc.pl
@@ -1,0 +1,876 @@
+#!/usr/bin/perl -wT
+#
+# ==========================================================================
+#
+# ZoneMinder Daemon Control Script, $Date$, $Revision$
+# Copyright (C) 2001-2008 Philip Coombes
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# ==========================================================================
+
+=head1 NAME
+
+zmdc.pl - ZoneMinder Daemon Control script
+
+=head1 SYNOPSIS
+
+zmdc.pl {command} [daemon [options]]
+
+=head1 DESCRIPTION
+
+This script is the gateway for controlling the various ZoneMinder
+daemons. All starting, stopping and restarting goes through here.
+On the first invocation it starts up a server which subsequently
+records what's running and what's not. Other invocations just
+connect to the server and pass instructions to it.
+
+=head1 OPTIONS
+
+{command}           - One of 'startup|shutdown|status|check|logrot' or
+'start|stop|restart|reload|version'.
+[daemon [options]]  - Daemon name and options, required for second group of commands
+
+=cut
+use strict;
+use warnings;
+use bytes;
+
+# ==========================================================================
+#
+# User config
+#
+# ==========================================================================
+
+# in useconds, not seconds.
+use constant MAX_CONNECT_DELAY => 40;
+
+# ==========================================================================
+#
+# Don't change anything from here on down
+#
+# ==========================================================================
+
+# Include from system perl paths only
+use ZoneMinder;
+use POSIX;
+use Socket;
+use IO::Handle;
+use Time::HiRes qw(usleep);
+
+use autouse 'Pod::Usage'=>qw(pod2usage);
+#use Data::Dumper;
+
+use constant SOCK_FILE => $Config{ZM_PATH_SOCKS}.'/zmdc'.($Config{ZM_SERVER_ID}?$Config{ZM_SERVER_ID}:'').'.sock';
+
+$| = 1;
+
+$ENV{PATH}  = '/bin:/usr/bin:/usr/local/bin';
+$ENV{SHELL} = '/bin/sh' if exists $ENV{SHELL};
+if ( $Config{ZM_LD_PRELOAD} ) {
+  Debug("Adding ENV{LD_PRELOAD} = $Config{ZM_LD_PRELOAD}");
+  $ENV{LD_PRELOAD} = $Config{ZM_LD_PRELOAD};
+  foreach my $lib ( split(/\s+/, $ENV{LD_PRELOAD} ) ) {
+    if ( ! -e $lib ) {
+      Warning("LD_PRELOAD lib $lib does not exist from LD_PRELOAD $ENV{LD_PRELOAD}.");
+    }
+  }
+}
+delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
+
+my @daemons = (
+    'zmc',
+    'zmfilter.pl',
+    'zmaudit.pl',
+    'zmtrigger.pl',
+    'zmx10.pl',
+    'zmwatch.pl',
+    'zmupdate.pl',
+    'zmstats.pl',
+    'zmtrack.pl',
+    'zmcontrol.pl',
+    'zm_rtsp_server',
+    'zmtelemetry.pl',
+    'zmalarm-server.py'
+
+    );
+
+if ( $Config{ZM_OPT_USE_EVENTNOTIFICATION} ) {
+	push @daemons, 'zmeventnotification.pl';
+}
+
+my $command = shift @ARGV;
+if ( !$command ) {
+  print(STDERR "No command given\n");
+  pod2usage(-exitstatus => -1);
+}
+if ( $command eq 'version' ) {
+  print ZoneMinder::Base::ZM_VERSION."\n";
+  exit(0);
+}
+my $needs_daemon = $command !~ /(?:startup|shutdown|status|check|logrot|version)/;
+my $daemon = shift @ARGV;
+if ( $needs_daemon && !$daemon ) {
+  print(STDERR "No daemon given\n");
+  pod2usage(-exitstatus => -1);
+}
+my @args;
+
+my $daemon_patt = '('.join('|', @daemons).')';
+if ( $needs_daemon ) {
+  if ( $daemon =~ /^${daemon_patt}$/ ) {
+    $daemon = $1;
+  } else {
+    print(STDERR "Invalid daemon '$daemon' specified");
+    pod2usage(-exitstatus => -1);
+  }
+}
+
+foreach my $arg ( @ARGV ) {
+# Detaint arguments, if they look ok
+#if ( $arg =~ /^(-{0,2}[\w]+)/ )
+  if ( $arg =~ /^(-{0,2}[\w\/?&=.-]+)$/ ) {
+    push @args, $1;
+  } else {
+    print(STDERR "Bogus argument '$arg' found");
+    exit(-1);
+  }
+}
+
+my $dbh = zmDbConnect();
+
+socket(CLIENT, PF_UNIX, SOCK_STREAM, 0) or Fatal("Can't open socket: $!");
+
+my $saddr = sockaddr_un(SOCK_FILE);
+my $server_up = connect(CLIENT, $saddr);
+
+if ( !$server_up ) {
+  if ( $Config{ZM_SERVER_ID} ) {
+    use Sys::MemInfo qw(totalmem freemem totalswap freeswap);
+    use ZoneMinder::Server qw(CpuLoad);
+    if ( ! defined $dbh->do(q{UPDATE Servers SET Status=?,TotalMem=?,FreeMem=?,TotalSwap=?,FreeSwap=? WHERE Id=?}, undef,
+          'NotRunning', &totalmem, &freemem, &totalswap, &freeswap, $Config{ZM_SERVER_ID} ) ) {
+      Error('Failed Updating status of Server record to Not Running for Id='.$Config{ZM_SERVER_ID}.': '.$dbh->errstr());
+    }
+  }
+# Server is not up.  Some commands can still be handled
+  if ( $command eq 'logrot' ) {
+    # If server is not running, then logrotate doesn't need to do anything.
+    Debug('Server is not running, logrotate doesn\'t need to do anything');
+    exit();
+  }
+  if ( $command eq 'check' ) {
+    print("stopped\n");
+    exit();
+  } elsif ( $command ne 'startup' ) {
+    print('Unable to connect to server using socket at '.SOCK_FILE."\n");
+    exit(-1);
+  }
+
+  # The server isn't there
+  print("Starting server\n");
+  close(CLIENT);
+
+  if ( my $cpid = fork() ) {
+    # Parent process just sleep and fall through
+
+    # I'm still not sure why we need to re-init the logs
+    logInit();
+
+    socket(CLIENT, PF_UNIX, SOCK_STREAM, 0) or Fatal("Can't open socket: $!");
+    my $attempts = 0;
+    while ( !connect(CLIENT, $saddr) ) {
+      $attempts++;
+      Debug('Waiting for zmdc.pl server process at '.SOCK_FILE.', attempt '.$attempts);
+      Fatal('Can\'t connect to zmdc.pl server process at '.SOCK_FILE.': '.$!) if $attempts > MAX_CONNECT_DELAY;
+      usleep(200000);
+    } # end while
+  } elsif ( defined($cpid) ) {
+    ZMServer::run();
+  } else {
+    Fatal("Can't fork: $!");
+  }
+} # end if ! server is up
+
+if ( ($command eq 'check') && !$daemon ) {
+  print("running\n");
+  exit();
+} elsif ( $command eq 'startup' ) {
+  # Our work here is done
+  exit() if !$server_up;
+}
+
+# The server is there, connect to it
+CLIENT->autoflush();
+my $message = join(';', $command, ( $daemon ? $daemon : () ), @args);
+print(CLIENT  $message);
+shutdown(CLIENT, 1);
+while( my $line = <CLIENT> ) {
+  chomp($line);
+  print("$line\n");
+}
+close(CLIENT);
+
+exit;
+
+package ZMServer;
+
+use strict;
+use warnings;
+use bytes;
+
+# Include from system perl paths only
+use ZoneMinder;
+use POSIX;
+use Socket;
+use IO::Handle;
+use Time::HiRes qw(usleep);
+use Sys::MemInfo qw(totalmem freemem totalswap freeswap);
+use ZoneMinder::Server qw(CpuLoad);
+#use Data::Dumper;
+
+use constant KILL_DELAY => 10; # seconds to wait between sending TERM and sending KILL
+
+our %cmd_hash;
+our %pid_hash;
+our %terminating_processes;
+our %pids_to_reap;
+our $zm_terminate = 0;
+
+sub run {
+
+  # Call this first otherwise stdout/stderror redirects to the pidfile = bad
+  if ( open(my $PID, '>', ZM_PID) ) {
+    print($PID $$);
+    close($PID);
+  } else {
+    # Log not initialized at this point so use die instead
+    die 'Can\'t open pid file at '.ZM_PID."\n";
+  }
+
+  my $fd = 0;
+
+  # This also closes dbh and CLIENT and SERVER
+  while ( $fd < POSIX::sysconf(&POSIX::_SC_OPEN_MAX) ) {
+    POSIX::close($fd++);
+  }
+
+  # Sets a process group, so that signals to go this and it's children I think
+  setpgrp();
+
+  # dbh got closed with the rest of the fd's above, so need to reconnect.
+  my $dbh = zmDbConnect(1);
+  logInit();
+
+  dPrint(ZoneMinder::Logger::INFO, 'Server starting at '
+      .strftime('%y/%m/%d %H:%M:%S', localtime())
+      ."\n"
+      );
+
+  # We don't want to leave killall zombies, so ignore SIGCHLD
+  $SIG{CHLD} = 'IGNORE';
+  # Tell any existing processes to die, wait 1 second between TERM and KILL
+  killAll(1);
+
+  dPrint(ZoneMinder::Logger::INFO, 'Socket should be open at ' .main::SOCK_FILE);
+  socket(SERVER, PF_UNIX, SOCK_STREAM, 0) or Fatal("Can't open socket: $!");
+  unlink(main::SOCK_FILE) or Error('Unable to unlink ' . main::SOCK_FILE .". Error message was: $!") if -e main::SOCK_FILE;
+  bind(SERVER, $saddr) or Fatal('Can\'t bind to ' . main::SOCK_FILE . ": $!");
+  listen(SERVER, SOMAXCONN) or Fatal("Can't listen: $!");
+
+  $SIG{CHLD} = \&chld_sig_handler;
+  $SIG{INT} = \&shutdown_sig_handler;
+  $SIG{TERM} = \&shutdown_sig_handler;
+  $SIG{ABRT} = \&shutdown_sig_handler;
+  $SIG{HUP} = \&logrot;
+
+  my $rin = '';
+  vec($rin, fileno(SERVER), 1) = 1;
+  my $win = $rin;
+  my $ein = $win;
+  my $timeout = 1;
+  my $secs_count = 0;
+
+  while ( !$zm_terminate ) {
+    
+    if ( $Config{ZM_SERVER_ID} ) {
+      if ( ! ( $secs_count % 60 ) ) {
+        while ( (!$zm_terminate) and !($dbh and $dbh->ping()) ) {
+          Warning("Not connected to db ($dbh)".($dbh?' ping('.$dbh->ping().')':''). ($DBI::errstr?" errstr($DBI::errstr)":'').' Reconnecting');
+          $dbh = zmDbConnect();
+          sleep 10 if !$dbh;
+        }
+        last if $zm_terminate;
+
+        my @cpuload = CpuLoad();
+        Debug("Updating Server record @cpuload");
+        if ( ! defined $dbh->do('UPDATE Servers SET Status=?,CpuLoad=?,TotalMem=?,FreeMem=?,TotalSwap=?,FreeSwap=? WHERE Id=?', undef,
+            'Running', $cpuload[0], &totalmem, &freemem, &totalswap, &freeswap, $Config{ZM_SERVER_ID} ) ) {
+          Error("Failed Updating status of Server record for Id=$Config{ZM_SERVER_ID} :".$dbh->errstr());
+        }
+      }
+      $secs_count += 1;
+    }
+    my $nfound = select(my $rout = $rin, undef, undef, $timeout);
+    if ( $nfound > 0 ) {
+      if ( vec($rout, fileno(SERVER), 1) ) {
+        my $paddr = accept(CLIENT, SERVER);
+        my $message = <CLIENT>;
+
+        next if !$message;
+
+        my ( $command, $daemon, @args ) = split(';', $message);
+
+        if ( $command eq 'start' ) {
+          start($daemon, @args);
+        } elsif ( $command eq 'stop' ) {
+          stop($daemon, @args);
+        } elsif ( $command eq 'restart' ) {
+          restart($daemon, @args);
+        } elsif ( $command eq 'reload' ) {
+          reload($daemon, @args);
+        } elsif ( $command eq 'startup' ) {
+# Do nothing, this is all we're here for
+          dPrint(ZoneMinder::Logger::WARNING, "Already running, ignoring command '$command'\n");
+        } elsif ( $command eq 'shutdown' ) {
+          # Break out of while loop
+          last;
+        } elsif ( $command eq 'check' ) {
+          check($daemon, @args);
+        } elsif ( $command eq 'status' ) {
+          if ( $daemon ) {
+            status($daemon, @args);
+          } else {
+            status();
+          }
+        } elsif ( $command eq 'logrot' ) {
+          logrot();
+        } else {
+          dPrint(ZoneMinder::Logger::ERROR, "Invalid command '$command'\n");
+        }
+        close(CLIENT);
+      } else {
+        Error('Bogus descriptor');
+      }
+    } elsif ( $nfound < 0 ) {
+      if ( $! == EINTR ) {
+# Dead child, will be reaped
+#print( "Probable dead child\n" );
+# See if it needs to start up again
+      } elsif ( $! == EPIPE ) {
+        Error("Can't select: $!");
+      } else {
+        Fatal("Can't select: $!");
+      }
+    } else {
+#print( "Select timed out\n" );
+    }
+
+    restartPending();
+    check_for_processes_to_kill() if %terminating_processes;
+    reaper() if %pids_to_reap;
+  } # end while
+
+  dPrint(ZoneMinder::Logger::INFO, 'Server exiting at '
+      .strftime('%y/%m/%d %H:%M:%S', localtime())
+      ."\n"
+      );
+  if ( $Config{ZM_SERVER_ID} ) {
+    $dbh = zmDbConnect() if ! ($dbh and $dbh->ping());
+    if ( ! defined $dbh->do(q{UPDATE Servers SET Status='NotRunning' WHERE Id=?}, undef, $Config{ZM_SERVER_ID}) ) {
+      Error("Failed Updating status of Server record for Id=$Config{ZM_SERVER_ID}".$dbh->errstr());
+    }
+  }
+  shutdownAll();
+}
+
+sub cPrint {
+  # One thought here, if no client exists to read these... does it block?
+  if ( fileno(CLIENT) ) {
+    print CLIENT @_
+  }
+}
+
+# I think the purpose of this is to echo the logs to the client process so it can then display them. 
+sub dPrint {
+  my $logLevel = shift;
+  cPrint(@_);
+  if ( $logLevel == ZoneMinder::Logger::DEBUG ) {
+    Debug(@_);
+  } elsif ( $logLevel == ZoneMinder::Logger::INFO ) {
+    Info(@_);
+  } elsif ( $logLevel == ZoneMinder::Logger::WARNING ) {
+    Warning(@_);
+  } elsif ( $logLevel == ZoneMinder::Logger::ERROR ) {
+    Error(@_);
+  } elsif ( $logLevel == ZoneMinder::Logger::FATAL ) {
+    Fatal(@_);
+  }
+}
+
+sub start {
+  my $daemon = shift;
+  my @args = @_;
+
+  my $command = join(' ', $daemon, @args);
+  my $process = $cmd_hash{$command};
+
+  if ( !$process ) {
+# It's not running, or at least it's not been started by us
+    $process = { daemon=>$daemon, args=>\@args, command=>$command, keepalive=>!undef };
+  } elsif ( $process->{pid} && $pid_hash{$process->{pid}} ) {
+    if ($process->{term_sent_at}) {
+      dPrint(ZoneMinder::Logger::INFO, "'$process->{command}' was told to term at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime($process->{term_sent_at}))
+        .", pid = $process->{pid}\n"
+      );
+      $process->{keepalive} = !undef;
+      $process->{delay} = 0;
+      delete $terminating_processes{$command};
+    } else {
+      dPrint(ZoneMinder::Logger::INFO, "'$process->{command}' already running at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime($process->{started}))
+        .", pid = $process->{pid}\n"
+      );
+    }
+    return;
+  }
+
+  # We have to block SIGCHLD during fork to prevent races while we setup our records for it
+  my $sigset = POSIX::SigSet->new;
+  my $blockset = POSIX::SigSet->new(SIGCHLD);
+  sigprocmask(SIG_BLOCK, $blockset, $sigset) or Fatal("Can't block SIGCHLD: $!");
+  # Apparently the child closing the db connection can affect the parent.
+  zmDbDisconnect();
+  if ( my $child_pid = fork() ) {
+
+    $dbh = zmDbConnect(1);
+    # This logReinit is required.  Not sure why.
+    logReinit();
+
+    $process->{pid} = $child_pid;
+    $process->{started} = time();
+    delete $process->{pending};
+
+    dPrint(ZoneMinder::Logger::INFO, "'$command' starting at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime($process->{started}))
+        .", pid = $process->{pid}\n"
+        );
+
+    $cmd_hash{$process->{command}} = $pid_hash{$child_pid} = $process;
+    sigprocmask(SIG_SETMASK, $sigset) or Fatal("Can't restore SIGCHLD: $!");
+  } elsif ( defined($child_pid) ) {
+    # Child process
+    
+    # Force reconnection to the db. $dbh got copied, but isn't really valid anymore.
+    $dbh = zmDbConnect(1);
+    logReinit();
+
+    dPrint(ZoneMinder::Logger::INFO, "'$command' started at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime())
+        ."\n"
+        );
+
+    if ( $daemon =~ /^${daemon_patt}$/ ) {
+      $daemon = $Config{ZM_PATH_BIN}.'/'.$1;
+    } else {
+      Fatal("Invalid daemon '$daemon' specified");
+    }
+
+    my @good_args;
+    foreach my $arg ( @args ) {
+      # Detaint arguments, if they look ok
+      if ( $arg =~ /^(-{0,2}[\w\/?&=.-]+)$/ ) {
+        push @good_args, $1;
+      } else {
+        Fatal("Bogus argument '$arg' found");
+      }
+    }
+
+    logTerm();
+    zmDbDisconnect();
+
+    my $fd = 3; # leave stdin,stdout,stderr open.  Closing them causes problems with libx264
+    while ( $fd < POSIX::sysconf(&POSIX::_SC_OPEN_MAX) ) {
+      POSIX::close($fd++);
+    }
+
+    $SIG{CHLD} = 'DEFAULT';
+    $SIG{HUP} = 'DEFAULT';
+    $SIG{INT} = 'DEFAULT';
+    $SIG{TERM} = 'DEFAULT';
+    $SIG{ABRT} = 'DEFAULT';
+
+    exec($daemon, @good_args) or Fatal("Can't exec: $!");
+  } else {
+    Fatal("Can't fork: $!");
+  }
+} # end sub start
+
+# Sends the stop signal, without waiting around to see if the process died.
+sub send_stop {
+  my ( $final, $process ) = @_;
+
+  my $sigset = POSIX::SigSet->new;
+  my $blockset = POSIX::SigSet->new(SIGCHLD);
+  sigprocmask(SIG_BLOCK, $blockset, $sigset) or die "dying at block...\n";
+
+  my $command = $process->{command};
+  if ( $process->{pending} ) {
+    delete $cmd_hash{$command};
+    dPrint(ZoneMinder::Logger::INFO, "Command '$command' removed from pending list at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime())
+        ."\n"
+        );
+    sigprocmask(SIG_UNBLOCK, $blockset) or die "dying at unblock...\n";
+    return ();
+  }
+
+  my $pid = $process->{pid};
+  if ( !$pid ) {
+    dPrint(ZoneMinder::Logger::ERROR, "No process with command of '$command' is running\n");
+    sigprocmask(SIG_UNBLOCK, $blockset) or die "dying at unblock...\n";
+    return();
+  }
+  if ( !$pid_hash{$pid} ) {
+    dPrint(ZoneMinder::Logger::ERROR, "No process with command of '$command' pid $pid is running\n");
+    sigprocmask(SIG_UNBLOCK, $blockset) or die "dying at unblock...\n";
+    return();
+  }
+
+  dPrint(ZoneMinder::Logger::INFO, "'$command' sending stop to pid $pid at "
+      .strftime('%y/%m/%d %H:%M:%S', localtime())
+      ."\n"
+      );
+  $process->{keepalive} = !$final;
+  $process->{term_sent_at} = time if ! $process->{term_sent_at};
+  $process->{pending} = 0;
+  $terminating_processes{$command} = $process;
+
+  kill('TERM', $pid);
+  sigprocmask(SIG_UNBLOCK, $blockset) or die "dying at unblock...\n";
+  return $pid;
+} # end sub send_stop
+
+sub check_for_processes_to_kill {
+  # Turn off SIGCHLD
+  my $sigset = POSIX::SigSet->new;
+  my $blockset = POSIX::SigSet->new(SIGCHLD);
+  sigprocmask(SIG_BLOCK, $blockset, $sigset) or die "dying at block...\n";
+  foreach my $command ( keys %terminating_processes ) {
+    my $process = $cmd_hash{$command};
+    if ( ! $process ) {
+      Debug("No process found for $command");
+      delete $terminating_processes{$command};
+      next;
+    }
+    if ( ! $$process{pid} ) {
+      Warning("Have no pid for $command.");
+      delete $terminating_processes{$command};
+      next;
+    }
+    my $now = time;
+    Debug("Have process $command at pid $$process{pid} $now - $$process{term_sent_at} = " . ( $now - $$process{term_sent_at} ));
+    if ( $$process{term_sent_at} and ( $now - $$process{term_sent_at} > KILL_DELAY ) ) {
+      dPrint(ZoneMinder::Logger::WARNING, "'$$process{command}' has not stopped at "
+        .strftime('%y/%m/%d %H:%M:%S', localtime())
+        .' after ' . KILL_DELAY . ' seconds.'
+        ." Sending KILL to pid $$process{pid}\n"
+      );
+      kill('KILL', $$process{pid});
+      delete $terminating_processes{$command};
+    }
+  }
+  sigprocmask(SIG_UNBLOCK, $blockset) or die "dying at unblock...\n";
+} # end sub check_for_processess_to_kill
+
+sub stop {
+  my ( $daemon, @args ) = @_;
+  my $command = join(' ', $daemon, @args);
+  my $process = $cmd_hash{$command};
+  if ( !$process ) {
+    dPrint(ZoneMinder::Logger::WARNING, "Can't find process with command of '$command'");
+    return;
+  }
+
+  send_stop(1, $process);
+}
+
+# restart is the same as stop, except that we flag the processes for restarting once it dies
+# One difference is that if we don't know about the process, then we start it.
+sub restart {
+  my ( $daemon, @args ) = @_;
+
+  my $command = join(' ', $daemon, @args);
+  dPrint(ZoneMinder::Logger::DEBUG, "Restarting $command\n");
+  my $process = $cmd_hash{$command};
+  if ( !$process ) {
+    dPrint(ZoneMinder::Logger::WARNING, "Can't find process with command of '$command'\n");
+    start($daemon, @args);
+    return;
+  }
+  # Start will be handled by the reaper...
+  # unless it was already pending in which case send_stop will return () so we should start it
+  if ( !send_stop(0, $process) ) {
+    dPrint(ZoneMinder::Logger::DEBUG, "!send_stop so starting '$command'\n");
+    start($daemon, @args);
+  }
+  return;
+}
+
+sub reload {
+  my $daemon = shift;
+  my @args = @_;
+
+  my $command = join(' ', $daemon, @args);
+  my $process = $cmd_hash{$command};
+  if ( $process ) {
+    if ( $process->{pid} ) {
+      kill('HUP', $process->{pid});
+    }
+  }
+}
+
+sub logrot {
+  logReinit();
+  foreach my $process ( values %pid_hash ) {
+    if ( $process->{pid} ) {
+      Debug("Hupping $$process{command} at $$process{pid}");
+      # && $process->{command} =~ /^zm.*\.pl/ ) {
+      kill('HUP', $process->{pid});
+    } else {
+      Debug("Not Hupping $$process{command}");
+    }
+  }
+}
+
+sub shutdown_sig_handler {
+  $zm_terminate = 1;
+}
+
+sub chld_sig_handler {
+  my $saved_status = $!;
+
+  # Wait for a child to terminate
+  while ( (my $cpid = waitpid(-1, WNOHANG)) > 0 ) {
+    $pids_to_reap{$cpid} = { status=>$?, stopped=>time() };
+  } # end while waitpid
+  $SIG{CHLD} = \&chld_sig_handler;
+  $! = $saved_status;
+}
+
+sub reaper {
+  foreach my $cpid ( keys %pids_to_reap ) {
+    my $process = $pid_hash{$cpid};
+    delete $pid_hash{$cpid};
+    my $reap_info = $pids_to_reap{$cpid};
+    my ( $status, $stopped ) = @$reap_info{'status','stopped'};
+    delete $pids_to_reap{$cpid};
+
+    if ( !$process ) {
+      dPrint(ZoneMinder::Logger::INFO, "Can't find child with pid of '$cpid'\n");
+      next;
+    }
+    delete $terminating_processes{$$process{command}};
+    delete $$process{term_sent_at};
+
+    $process->{stopped} = $stopped;
+    $process->{runtime} = ($process->{stopped}-$process->{started});
+    delete $process->{pid};
+
+    my $exit_status = $status>>8;
+    my $exit_signal = $status&0xfe;
+    my $core_dumped = $status&0x01;
+
+    my $out_str = "'$process->{command}' ";
+    if ( $exit_signal ) {
+      # 15 == TERM, 14 == ALARM
+      if ( $exit_signal == 15 || $exit_signal == 14 ) {
+        $out_str .= 'exited';
+      } else {
+        $out_str .= 'crashed';
+      }
+      $out_str .= ", signal $exit_signal";
+    } else {
+      $out_str .= 'exited ';
+      if ( $exit_status ) {
+        $out_str .= "abnormally, exit status $exit_status";
+      } else {
+        $out_str .= 'normally';
+      }
+    }
+#print( ", core dumped" ) if ( $core_dumped );
+    $out_str .= "\n";
+
+    if ( $exit_status == 0 ) {
+      Info($out_str);
+    } else {
+      Error($out_str);
+    }
+
+    if ( $process->{keepalive} ) {
+# Schedule for immediate restart
+      $cmd_hash{$process->{command}} = $process;
+      if ( !$process->{delay} || ($process->{runtime} > $Config{ZM_MAX_RESTART_DELAY} ) ) {
+#start( $process->{daemon}, @{$process->{args}} );
+        $process->{pending} = $process->{stopped};
+        $process->{delay} = 5;
+      } else {
+        $process->{pending} = $process->{stopped}+$process->{delay};
+        $process->{delay} *= 2;
+# Limit the start delay to 15 minutes max
+        if ( $process->{delay} > $Config{ZM_MAX_RESTART_DELAY} ) {
+          $process->{delay} = $Config{ZM_MAX_RESTART_DELAY};
+        }
+      }
+      #Debug("Delay for $$process{command} is now $$process{delay}");
+    } else {
+      delete $cmd_hash{$$process{command}};
+    }
+  } # end foreach pid_to_reap
+} # end sub reaper
+
+sub restartPending {
+# Restart any pending processes, we list them first because cmd_hash may change in foreach
+  my @processes =  values %cmd_hash;
+  foreach my $process ( @processes ) {
+    if ( $process->{pending} && $process->{pending} <= time() ) {
+      dPrint(ZoneMinder::Logger::INFO, "Starting pending process, $process->{command}\n");
+      start($process->{daemon}, @{$process->{args}});
+    }
+  }
+}
+
+sub shutdownAll {
+  foreach my $pid ( keys %pid_hash ) {
+# This is a quick fix because a SIGCHLD can happen and alter pid_hash while we are in here.
+    next if ! $pid_hash{$pid};
+    send_stop(1, $pid_hash{$pid});
+  }
+  while ( keys %terminating_processes ) {
+
+    reaper() if %pids_to_reap;
+    check_for_processes_to_kill();
+    if ( %terminating_processes ) {
+      Debug("Still " .  %terminating_processes . ' to die. sleeping');
+      sleep(1);
+    }
+  }
+  dPrint(ZoneMinder::Logger::INFO, 'Server shutdown at '
+    .strftime('%y/%m/%d %H:%M:%S', localtime())
+    ."\n"
+  );
+  unlink(main::SOCK_FILE) or Error("Unable to unlink " . main::SOCK_FILE .". Error message was: $!") if ( -e main::SOCK_FILE );
+  unlink(ZM_PID) or Error("Unable to unlink " . ZM_PID .". Error message was: $!") if ( -e ZM_PID );
+  close(CLIENT);
+  close(SERVER);
+  exit();
+}
+
+sub check {
+  my $daemon = shift;
+  my @args = @_;
+
+  my $command = join(' ', $daemon, @args);
+  my $process = $cmd_hash{$command};
+  if ( !$process ) {
+    cPrint("unknown\n");
+  } elsif ( $process->{pending} ) {
+    cPrint("pending\n");
+  } else {
+    my $cpid = $process->{pid};
+    if ( ! $pid_hash{$cpid} ) {
+      cPrint("stopped\n");
+    } else {
+      cPrint("running\n");
+    }
+  }
+}
+
+sub status {
+  my $daemon = shift;
+  my @args = @_;
+
+  if ( defined($daemon) ) {
+    my $command = join(' ', $daemon, @args);
+    my $process = $cmd_hash{$command};
+    if ( ! $process ) {
+      dPrint(ZoneMinder::Logger::DEBUG, "'$command' not running\n");
+      return;
+    }
+
+    if ( $process->{pending} ) {
+      dPrint(ZoneMinder::Logger::DEBUG, "'$command' pending at "
+          .strftime('%y/%m/%d %H:%M:%S', localtime($process->{pending}))
+          ."\n"
+          );
+    } else {
+      my $pid = $process->{pid};
+      if ( ! $pid_hash{$pid} ) {
+        dPrint(ZoneMinder::Logger::DEBUG, "'$command' not running\n");
+        return;
+      }
+    }
+    dPrint(ZoneMinder::Logger::DEBUG, "'$command' running since "
+        .strftime('%y/%m/%d %H:%M:%S', localtime($process->{started}))
+        .", pid = $process->{pid}"
+        );
+  } else {
+    foreach my $process ( values %pid_hash ) {
+      my $out_str = "'$process->{command}' running since "
+        .strftime('%y/%m/%d %H:%M:%S', localtime($process->{started}))
+        .", pid = $process->{pid}"
+        ;
+      $out_str .= ", valid" if ( kill(0, $process->{pid}) );
+      $out_str .= "\n";
+      dPrint(ZoneMinder::Logger::DEBUG, $out_str);
+    }
+    foreach my $process ( values %cmd_hash ) {
+      if ( $process->{pending} ) {
+        dPrint(ZoneMinder::Logger::DEBUG, "'$process->{command}' pending at "
+            .strftime('%y/%m/%d %H:%M:%S', localtime($process->{pending}))
+            ."\n"
+            );
+      }
+    } # end foreach process
+  }
+} # end sub status
+
+sub killAll {
+  my $delay = shift;
+  # Why sleep before sending term?
+  #sleep( $delay );
+  my $killall;
+  if ( 'linux' eq 'BSD' ) {
+    $killall = 'killall -q -';
+  } elsif ( 'linux' eq 'solaris' ) {
+    $killall = 'pkill -';
+  } else {
+    $killall = 'killall -q -s ';
+  }
+  foreach my $daemon ( @daemons ) {
+    my $cmd = $killall ."TERM $daemon";
+    Debug($cmd);
+    qx($cmd);
+  }
+  sleep($delay);
+  foreach my $daemon ( @daemons ) {
+    my $cmd = $killall."KILL $daemon";
+    Debug($cmd);
+    qx($cmd);
+  }
+}
+1;
+__END__

--- a/scripts/zmpkg.pl
+++ b/scripts/zmpkg.pl
@@ -1,0 +1,418 @@
+#!/usr/bin/perl -wT
+#
+# ==========================================================================
+#
+# ZoneMinder Package Control Script, $Date$, $Revision$
+# Copyright (C) 2001-2008 Philip Coombes
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# ==========================================================================
+
+use strict;
+use bytes;
+
+# ==========================================================================
+#
+# Don't change anything below here
+#
+# ==========================================================================
+
+# Include from system perl paths only
+use ZoneMinder;
+use ZoneMinder::Monitor;
+use ZoneMinder::State;
+use ZoneMinder::Filter;
+use DBI;
+use POSIX;
+use Time::HiRes qw/gettimeofday/;
+use autouse 'Pod::Usage'=>qw(pod2usage);
+
+# Detaint our environment
+$ENV{PATH}  = '/bin:/usr/bin:/usr/local/bin';
+$ENV{SHELL} = '/bin/sh' if exists $ENV{SHELL};
+delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
+my $store_state=''; # PP - will remember state name passed
+
+logInit();
+
+my $command = $ARGV[0]||'';
+if ( $command eq 'version' ) {
+  print ZoneMinder::Base::ZM_VERSION . "\n";
+  exit(0);
+}
+
+my $state;
+
+my $dbh = zmDbConnect();
+Debug("Command: $command");
+if ( $command and ( $command !~ /^(?:start|stop|restart|status|logrot|version)$/ ) ) {
+  # Check to see if it's a valid run state
+  if ($state = ZoneMinder::State->find_one(Name=>$command)) {
+    $state->{Definitions} = [];
+    foreach (split(',', $state->{Definition})) {
+      my @state = split(':', $_);
+      my ($id, $capturing, $analysing, $recording);
+      if (@state == 3) {
+        ($id, my $function, my $enabled) = @state;
+        if (!$enabled) {
+          ($capturing, $analysing, $recording) = ('None','None','None');
+        } elsif ($function eq 'None') {
+          ($capturing, $analysing, $recording) = ('None','None','None');
+        } elsif ($function eq 'Monitor') {
+          ($capturing, $analysing, $recording) = ('Always','None','None');
+        } elsif ($function eq 'Modect') {
+          ($capturing, $analysing, $recording) = ('Always','Always','OnMotion');
+        } elsif ($function eq 'Mocord') {
+          ($capturing, $analysing, $recording) = ('Always','Always','OnMotion');
+        } elsif ($function eq 'Record') {
+          ($capturing, $analysing, $recording) = ('Always','Always','Always');
+        } else {
+          Error("Unknown function $function, defaulting to Mocord"); 
+        }
+      } elsif (@state == 4) {
+        ($id, $capturing, $analysing, $recording) = @state;
+      } else {
+        Error("Unknown state in @state");
+      }
+      push @{$state->{Definitions}}, {Id=>$id, Capturing=>$capturing, Analysing=>$analysing, Recording=>$recording};
+    } # end foreach state definition
+    $store_state = $command; # PP - Remember the name that was passed to search in DB
+    $command = 'state';
+  } else {
+    $command = undef;
+  }
+} # end if not one of the usual commands
+
+if ( !$command ) {
+  pod2usage(-exitstatus => -1);
+}
+
+# PP - Sane state check
+isActiveSanityCheck();
+
+# Move to the right place
+chdir($Config{ZM_PATH_WEB}) or Fatal("Can't chdir to $Config{ZM_PATH_WEB}: $!");
+
+my $dbg_id = '';
+
+Info("Command: $command");
+
+my $retval = 0;
+
+if ( $command eq 'state' ) {
+  Info("Updating DB: $state->{Name}");
+  foreach my $monitor (ZoneMinder::Monitor->find(
+        ($Config{ZM_SERVER_ID} ? (ServerId=>$Config{ZM_SERVER_ID}) : () ), order=>'Id ASC')
+      ) {
+    foreach my $definition ( @{$state->{Definitions}} ) {
+# FIXME WHY a REGEXP
+      if ( $monitor->{Id} =~ /^$definition->{Id}$/ ) {
+        $monitor->{NewFunction} = $definition->{Function};
+        $monitor->{NewEnabled} = $definition->{Enabled};
+        if (
+            ($monitor->{Capturing} ne $definition->{Capturing})
+            or
+            ($monitor->{Analysing} ne $definition->{Analysing})
+            or 
+            ($monitor->{Recording} ne $definition->{Recording})
+            ) {
+              $monitor->save({ map { $_ => $$definition{$_} } qw(Capturing Analysing Recording) });
+              last; # definition
+        } # end if
+      } # end if
+    } # end foreach definition
+  } # end foreach monitor
+
+  # PP - Now mark a specific state as active
+  resetStates();
+  Info("Marking $store_state as Enabled");
+  $state->save({IsActive=>1});
+
+  # PP - zero out other states isActive
+  $command = 'restart';
+} # end if command = state
+
+# Check if we are running systemd and if we have been called by the system
+if ( $command =~ /^(start|stop|restart)$/ ) {
+# We have to detaint to keep perl from complaining
+  $command = $1;
+
+  if ( systemdRunning() && !calledBysystem() ) {
+    qx(/usr/local/bin/zmsystemctl.pl $command);
+    $command = '';
+  }
+}
+
+if ( $command =~ /^(?:stop|restart)$/ ) {
+  my $status = runCommand('zmdc.pl check');
+  Debug("zmdc.pl check = $status");
+
+  if ( $status eq 'running' ) {
+    runCommand('zmdc.pl shutdown');
+    zmMemTidy();
+  } else {
+    $retval = 1;
+  }
+}
+
+if ( $command =~ /^(?:start|restart)$/ ) {
+  my $status = runCommand('zmdc.pl check');
+  Debug("zmdc.pl check = $status");
+
+  if ( $status eq 'stopped' ) {
+    if ( $Config{ZM_DYN_DB_VERSION}
+        and ( $Config{ZM_DYN_DB_VERSION} ne ZM_VERSION )
+       ) {
+         my ( $db_major, $db_minor, $db_micro ) = split(/\./, $Config{ZM_DYN_DB_VERSION});
+         my ( $major, $minor, $micro ) = split(/\./, ZM_VERSION);
+         if ( $db_major != $major or $db_minor != $minor ) {
+           Fatal('Version mismatch, system is version '.ZM_VERSION
+             .', database is '.$Config{ZM_DYN_DB_VERSION}
+             .', please run zmupdate.pl to update.'
+           );
+           exit(-1);
+         } else {
+           Error('Version mismatch, system is version '.ZM_VERSION
+             .', database is '.$Config{ZM_DYN_DB_VERSION}
+             .', please run zmupdate.pl to update.'
+           );
+         }
+    } # end if version mismatch
+
+# Recreate the temporary directory if it's been wiped
+    verifyFolder('/var/tmp/zm');
+
+# Recreate the run directory if it's been wiped
+    verifyFolder('/var/run/zm');
+
+# Recreate the sock directory if it's been wiped
+    verifyFolder('/var/run/zm');
+
+    zmMemTidy();
+    runCommand('zmdc.pl startup');
+
+    my $Server = undef;
+    my @monitors;
+    if ( $Config{ZM_SERVER_ID} ) {
+      require ZoneMinder::Server;
+      Info("Multi-server configuration detected. Starting up services for server $Config{ZM_SERVER_ID}");
+      $Server = new ZoneMinder::Server($Config{ZM_SERVER_ID});
+      @monitors = ZoneMinder::Monitor->find(ServerId=>$Config{ZM_SERVER_ID});
+    } else {
+      Info('Single server configuration detected. Starting up services.');
+      @monitors = ZoneMinder::Monitor->find();
+    }
+
+    foreach my $monitor (@monitors) {
+      if (($monitor->{Capturing} ne 'None') and ($monitor->{Type} ne 'WebSite')) {
+        if ( $monitor->{Type} eq 'Local' ) {
+          runCommand("zmdc.pl start zmc -d $monitor->{Device}");
+        } else {
+          runCommand("zmdc.pl start zmc -m $monitor->{Id}");
+        }
+        if ( $Config{ZM_OPT_CONTROL} ) {
+          if ( $monitor->{Controllable} ) {
+            runCommand("zmdc.pl start zmcontrol.pl --id $monitor->{Id}");
+            if ( $monitor->{TrackMotion} ) {
+              if ($monitor->{Analysing} ne 'None') {
+                runCommand("zmdc.pl start zmtrack.pl -m $monitor->{Id}");
+              } else {
+                Warning('Monitor is set to track motion, but does not have motion detection enabled.');
+              } # end if Has motion enabled
+            } # end if track motion
+          } # end if controllable
+        } # end if ZM_OPT_CONTROL        
+      } else {
+        Debug("Not running process for Monitor $$monitor{Id} Because Capturing($$monitor{Capturing})== None or Type($$monitor{Type})==Website");
+      } # end if capturing is not none or Website
+    } # end foreach monitor
+
+    my @filters = ZoneMinder::Filter->find(Background=>1);
+    if (@filters) {
+      foreach my $filter (@filters) {
+        runCommand("zmdc.pl start zmfilter.pl --filter_id=$$filter{Id} --daemon");
+      }
+    } else {
+      runCommand('zmdc.pl start zmfilter.pl');
+    }
+
+    if ( $Config{ZM_RUN_AUDIT} ) {
+      if ( $Server and exists $$Server{zmaudit} and ! $$Server{zmaudit} ) {
+        Debug('Not running zmaudit.pl because it is turned off for this server.');
+      } else {
+        runCommand('zmdc.pl start zmaudit.pl -c');
+      }
+    }
+    if ( $Config{ZM_OPT_TRIGGERS} ) {
+      if ( $Server and exists $$Server{zmtrigger} and ! $$Server{zmtrigger} ) {
+        Debug('Not running zmtrigger.pl because it is turned off for this server.');
+      } else {
+        runCommand('zmdc.pl start zmtrigger.pl');
+      }
+    }
+    if ( $Config{ZM_OPT_X10} ) {
+      runCommand('zmdc.pl start zmx10.pl -c start');
+    }
+    runCommand('zmdc.pl start zmwatch.pl');
+    if ( $Config{ZM_CHECK_FOR_UPDATES} ) {
+      runCommand('zmdc.pl start zmupdate.pl -c');
+    }
+    if ( $Config{ZM_TELEMETRY_DATA} ) {
+      runCommand('zmdc.pl start zmtelemetry.pl');
+    }
+    if ($Config{ZM_OPT_USE_EVENTNOTIFICATION} ) {
+      if ( $Server and exists $$Server{zmeventnotification} and ! $$Server{zmeventnotification} ) {
+        Debug('Not running zmnotification.pl because it is turned off for this server.');
+      } else {
+        runCommand('zmdc.pl start zmeventnotification.pl');
+      }
+    }
+    if ( $Server and exists $$Server{zmstats} and ! $$Server{zmstats} ) {
+      Debug('Not running zmstats.pl because it is turned off for this server.');
+    } else {
+      runCommand('zmdc.pl start zmstats.pl');
+    }
+    if ( $Config{ZM_MIN_RTSP_PORT} ) {
+      runCommand('zmdc.pl start zm_rtsp_server');
+    }
+    # run and pass parameters to AlarmServer.py
+    if ($Config{ZM_OPT_USE_ALARMSERVER} ) {
+       my $cmd='zmdc.pl start zmalarm-server.py '. $Config{ZM_OPT_ALS_PORT};
+       if ($Config{ZM_OPT_ALS_LOGENTRY} ) {
+             $cmd = $cmd . ' --log=y';
+           }
+       else {
+             $cmd = $cmd . ' --log=n';
+           }
+       if ($Config{ZM_OPT_ALS_TRIGGEREVENT} ) {
+             $cmd = $cmd . ' --event=y';
+           }
+       else {
+             $cmd = $cmd . ' --event=n';
+           }
+
+       if ($Config{ZM_OPT_ALS_ALARM} ) {
+             $cmd = $cmd . ' --alarm=y';
+           }
+       else {
+             $cmd = $cmd . ' --alarm=n';
+          }
+       runCommand($cmd);
+    }
+  } else {
+    $retval = 1;
+  }
+} # end if command is start or restart
+
+if ($command eq 'status') {
+  my $status = runCommand('zmdc.pl check');
+
+  print(STDOUT $status."\n");
+} elsif ($command eq 'logrot') {
+  runCommand('zmdc.pl logrot');
+}
+
+exit($retval);
+
+# PP - Make sure isActive is on and only one
+sub isActiveSanityCheck {
+  Info('Sanity checking States table...');
+  $dbh = zmDbConnect() if ! $dbh;
+
+# PP - First, make sure default exists and there is only one
+  my @states = ZoneMinder::State->find(Name=>'default', order=>'Id ASC');
+# PP - no row, or too many rows. Either case is an error
+
+  my $default_state;
+  while (@states > 1) {
+    my $state = shift @states;
+    $state->delete();
+  }
+  if (!@states) {
+    $default_state = new ZoneMinder::State();
+    $default_state->save({Name=>'default', Definition=>'', IsActive=>1});
+  } else {
+    $default_state = shift @states;
+  }
+
+  @states = ZoneMinder::State->find(IsActive=>1);
+  if (@states != 1) {
+    Info('Fixing States table so only one run state is active');
+    resetStates();
+    $default_state->save({IsActive=>1});
+  }
+} # end sub isActiveSanityCheck
+
+# PP - zeroes out isActive for all states
+sub resetStates {
+  $dbh = zmDbConnect() if ! $dbh;
+  $dbh->do('UPDATE `States` SET `IsActive`=0')
+    or Fatal("Can't execute: ".$dbh->errstr());
+}
+
+sub systemdRunning {
+  my $output = qx(ps -o comm="" -p 1);
+  return scalar ( $output =~ /systemd/ );
+}
+
+sub calledBysystem {
+  my $ppid = getppid();
+
+  my $output = qx(ps -o comm="" -p $ppid);
+  #chomp( $output );
+
+  return ($output =~ /^(?:systemd|init)$/);
+}
+
+sub verifyFolder {
+  my $folder = shift;
+
+  # Recreate the temporary directory if it's been wiped
+  if ( !-e $folder ) {
+    Debug("Recreating directory '$folder'");
+    mkdir($folder, 0774)
+      or Fatal( "Can't create missing temporary directory '$folder': $!" );
+    my ( $runName ) = getpwuid($>);
+    if ( $runName ne $Config{ZM_WEB_USER} ) {
+      # Not running as web user, so should be root in which case
+      # chown the directory
+      my ( $webName, $webPass, $webUid, $webGid ) = getpwnam($Config{ZM_WEB_USER})
+        or Fatal("Can't get details for web user '$Config{ZM_WEB_USER}': $!");
+      chown($webUid, $webGid, $folder)
+        or Fatal("Can't change ownership of '$folder' to '"
+            .$Config{ZM_WEB_USER}.':'.$Config{ZM_WEB_GROUP}."': $!"
+            );
+    } # end if runName ne ZM_WEB_USER
+  } # end if folder doesn't exist
+} # end sub verifyFolder
+
+1;
+__END__
+
+=head1 NAME
+
+zmpkg.pl - ZoneMinder Package Control Script
+
+=head1 SYNOPSIS
+
+zmpkg.pl {start|stop|restart|status|logrot|state|version}
+
+=head1 DESCRIPTION
+
+  This script is used to start and stop the ZoneMinder package primarily to
+allow command line control for automatic restart on reboot (see zm script)
+
+=cut


### PR DESCRIPTION
Adds support for Alarm Server feature, when using cameras with Netsurveillance Web software
and Alarm Server option (zmalarm-server.py).

Is controlled by zm as an internal service (zmdc.pl/zmpkg.pl)

Configured using UI from Zoneminder (ConfigData.pm.in)

Requires pyzm package installed to run, and zmtrigger to receive trigger events if configured.