### PR TITLE
db: start the processing thread after all fields are initialized

### DIFF
--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -227,9 +227,10 @@ zmDbRow::~zmDbRow() {
 }
 
 zmDbQueue::zmDbQueue() :
-  mThread(&zmDbQueue::process, this),
   mTerminate(false)
-{ }
+{
+  mThread = std::thread(&zmDbQueue::process, this);
+}
 
 zmDbQueue::~zmDbQueue() {
   stop();


### PR DESCRIPTION
Initializing `zmDbQueue::mThread` with initializer list makes the thread
start in the middle of object initialization. This means `zmDbQueue::
process()` could start and reach mCondition.wait(lock); before `std::
wait_condition`'s constructor, which causes deadlock.

To make sure thread won't start before object initialize, move
`mThread`'s initialization to constructor's body.

This _at last_ solves the random zmu deadlock issue that has plagued my
setup for almost a year.