### PR TITLE
Set web backend DB connection to UTF8

### DIFF
--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -46,7 +46,7 @@ function dbConnect() {
   } else {
     $dsn .= ':host=localhost;';
   }
-  $dsn .= 'dbname='.ZM_DB_NAME;
+  $dsn .= 'dbname='.ZM_DB_NAME.';charset=utf8';
 
   try {
     $dbOptions = null;


### PR DESCRIPTION


Issue
=====

PHP web backend is encoding data fetched from the DB to JSON using function `json_encode` in multiple locations. When data contains non-UTF8 characters, the conversion fails (with `json_last_error()` = `JSON_ERROR_UTF8` = `5`), and `json_encode` will return an empty string instead of valid JSON. This leads to a lot of errors in JSON delivered to the UI, which even renders UIs to be unusable.

Example: [Lines 107 to 108 in `web/skins/classic/views/js/montagereview.js.php`](https://github.com/ZoneMinder/zoneminder/blob/bfaf8c8b5399b4d9485bbcc5a9d2a637c4c2c782/web/skins/classic/views/js/montagereview.js.php#L107-L108)

```
    $event_json = json_encode($event, JSON_PRETTY_PRINT|JSON_NUMERIC_CHECK);
    echo " $event_id : $event_json,\n";
```

The code there is generating an element of a JSON array. If conversion with `json_encode` fails, an empty string is returned in `$event_json`. This leads to a generated JSON with syntax errors that is delivered to the UI, and causes the UI to fail (neither rendering properly, nor providing any sensible functionality to the user).


Suggested Fix
=============

The issue can easily be avoided by setting the charater encoding of the DB connection to UTF8. After that, all data returned from DB queries will be proper UTF8, and all the JSON encodings with `json_encode` will work without problems.

All it takes to set the proper character encoding, is adding the desired character encoding to the connection string when opening the DB connection. This can easily be done by adding `;charset=utf8` at the end of the connection string.

Suggested fix is to do this in function `dbConnect` [line 49 of `web/includes/database.php`](https://github.com/ZoneMinder/zoneminder/blob/bfaf8c8b5399b4d9485bbcc5a9d2a637c4c2c782/web/includes/database.php#L49) by changing the line from

	`$dsn .= 'dbname='.ZM_DB_NAME;`

to

	`$dsn .= 'dbname='.ZM_DB_NAME.';charset=utf8';`

That's it. After that, all `json_encode` operations will succeed and the UI doesn't break anymore (even if non-UTF8 characters find their way somehow into the DB, e.g. by externally triggered events and their custom descriptions).


Tested
======

Using Ubuntu 22.04 (Jammy), installed ZoneMinder via the [`iconnor` PPA](http://ppa.launchpad.net/iconnor/zoneminder-1.36/ubuntu/dists/jammy/) for Jammy. Issue existed after installation. By changing the single line in the code (as suggested above), all issues were gone.
