### PR TITLE
fix(alarmSound): Use Audio.play() for alarm sound

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -334,13 +334,10 @@ function MonitorStream(monitorData) {
 
     if (newAlarm) {
       if (ZM_WEB_SOUND_ON_ALARM) {
-        // Enable the alarm sound
-        const isIE = window.document.documentMode ? true : false;
-        if (!isIE) {
-          $j('#alarmSound').removeClass('hidden');
-        } else {
-          $j('#MediaPlayer').trigger('play');
-        }
+        console.log('Attempting to play alarm sound');
+        var soundFile = ZM_DIR_SOUNDS+'/'+ZM_WEB_ALARM_SOUND;
+        var sound = new Audio(soundFile);
+        sound.play();
       }
       if (ZM_WEB_POPUP_ON_ALARM) {
         window.focus();
@@ -350,15 +347,6 @@ function MonitorStream(monitorData) {
       }
     }
     if (oldAlarm) { // done with an event do a refresh
-      if (ZM_WEB_SOUND_ON_ALARM) {
-        // Disable alarm sound
-        const isIE = window.document.documentMode ? true : false;
-        if (!isIE) {
-          $j('#alarmSound').addClass('hidden');
-        } else {
-          $j('#MediaPlayer').trigger('pause');
-        }
-      }
       if (this.onalarm) {
         this.onalarm();
       }

--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -14,6 +14,7 @@
 // Import constants
 //
 
+var ZM_DIR_SOUNDS = "<?php echo ZM_DIR_SOUNDS ?>";
 var POPUP_ON_ALARM = <?php echo ZM_WEB_POPUP_ON_ALARM ?>;
 var LIST_THUMBS = <?php echo ZM_WEB_LIST_THUMBS?'true':'false' ?>;
 

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -407,41 +407,6 @@ if ( canView('Events') && ($monitor->Type() != 'WebSite') ) {
     </div>
 <?php
 }
-if ( ZM_WEB_SOUND_ON_ALARM ) {
-    $soundSrc = ZM_DIR_SOUNDS.'/'.ZM_WEB_ALARM_SOUND;
-?>
-      <div id="alarmSound" class="hidden">
-<?php
-    if ( ZM_WEB_USE_OBJECT_TAGS && isWindows() ) {
-?>
-        <object id="MediaPlayer" width="0" height="0"
-          classid="CLSID:22D6F312-B0F6-11D0-94AB-0080C74C7E95"
-          codebase="http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,0,02,902">
-          <param name="FileName" value="<?php echo $soundSrc ?>"/>
-          <param name="autoStart" value="0"/>
-          <param name="loop" value="1"/>
-          <param name="hidden" value="1"/>
-          <param name="showControls" value="0"/>
-          <embed src="<?php echo $soundSrc ?>"
-            autostart="true"
-            loop="true"
-            hidden="true">
-          </embed>
-        </object>
-<?php
-    } else {
-?>
-        <embed src="<?php echo $soundSrc ?>"
-          autostart="true"
-          loop="true"
-          hidden="true">
-        </embed>
-<?php
-    }
-?>
-      </div>
-<?php
-}
 ?>
     </div>
   </div>


### PR DESCRIPTION
I reworked the alarm sound when viewing a monitor.  The old implementation seemed to be more complicated broken.  (At least I couldn't get it to work.)

I also removed the specific Internet Explorer (IE) checks since IE has not been supported by Microsoft for quite a while now.

Once the monitor view is open, the user has to interact with it (click anywhere on the page) and then the alarm sound will activate when a new alarm is triggered.  (See [this page](https://developer.chrome.com/blog/autoplay/) for details.)