### PR TITLE
feat(events): Shift delete with no confirm

### DIFF
--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -381,7 +381,12 @@ function initPage() {
     }
 
     evt.preventDefault();
-    $j('#deleteConfirm').modal('show');
+    if (evt.shiftKey) {
+      const selections = getIdSelections();
+      deleteEvents(selections);
+    } else {
+      $j('#deleteConfirm').modal('show');
+    }
   });
 
   // Update table links each time after new data is loaded


### PR DESCRIPTION
This is an enhancement to the events page.  Multiple events can be selected and if the Shift key is held while pressing the delete button on the page, the confirmation dialog will not come up and the events will be deleted.