### PR TITLE
feat(watch): Shift delete with no confirm

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -667,7 +667,15 @@ function getSettingsModal() {
 
 function processClicks(event, field, value, row, $element) {
   if (field == 'Delete') {
-    $j.getJSON(monitorUrl + '?request=modal&modal=delconfirm')
+    if (window.event.shiftKey) {
+      var eid = row.Id.replace(/(<([^>]+)>)/gi, '');
+      $j.getJSON(thisUrl + '?request=events&task=delete&eids[]='+eid)
+        .done(function(data) {
+          table.bootstrapTable('refresh');
+        })
+        .fail(logAjaxFail);
+    } else {
+      $j.getJSON(monitorUrl + '?request=modal&modal=delconfirm')
         .done(function(data) {
           insertModalHtml('deleteConfirm', data.html);
           manageDelConfirmModalBtns();
@@ -675,6 +683,7 @@ function processClicks(event, field, value, row, $element) {
           $j('#deleteConfirm').modal('show');
         })
         .fail(logAjaxFail);
+    }
   }
 }
 


### PR DESCRIPTION
This is an enhancement to the watch (monitor) page.  If the Shift key is held while pressing the delete button for any of the events on the page, the confirmation dialog will not come up and the events will be deleted.