### PR TITLE
feat(event): Shift delete with no confirm

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1193,18 +1193,26 @@ function initPage() {
     }
 
     evt.preventDefault();
-    if (!$j('#deleteConfirm').length) {
-      // Load the delete confirmation modal into the DOM
-      $j.getJSON(thisUrl + '?request=modal&modal=delconfirm')
-          .done(function(data) {
-            insertModalHtml('deleteConfirm', data.html);
-            manageDelConfirmModalBtns();
-            $j('#deleteConfirm').modal('show');
-          })
-          .fail(logAjaxFail);
-      return;
+    if (window.event.shiftKey) {
+      $j.getJSON(thisUrl + '?request=event&action=delete&id='+eventData.Id)
+        .done(function(data) {
+          streamNext(true);
+        })
+        .fail(logAjaxFail);
+    } else {
+      if (!$j('#deleteConfirm').length) {
+        // Load the delete confirmation modal into the DOM
+        $j.getJSON(thisUrl + '?request=modal&modal=delconfirm')
+            .done(function(data) {
+              insertModalHtml('deleteConfirm', data.html);
+              manageDelConfirmModalBtns();
+              $j('#deleteConfirm').modal('show');
+            })
+            .fail(logAjaxFail);
+        return;
+      }
+      $j('#deleteConfirm').modal('show');
     }
-    $j('#deleteConfirm').modal('show');
   });
   document.addEventListener('fullscreenchange', fullscreenChangeEvent);
 } // end initPage

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -381,7 +381,12 @@ function initPage() {
     }
 
     evt.preventDefault();
-    $j('#deleteConfirm').modal('show');
+    if (evt.shiftKey) {
+      const selections = getIdSelections();
+      deleteEvents(selections);
+    } else {
+      $j('#deleteConfirm').modal('show');
+    }
   });
 
   // Update table links each time after new data is loaded


### PR DESCRIPTION
This is an enhancement to the event page. If the Shift key is held while pressing the delete button on the page, the confirmation dialog will not come up and the events will be deleted.