### PR TITLE
views/monitor.php: Add back h264 NVMPI decoder

### DIFF
--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -825,6 +825,7 @@ $decoders = array(
   'libx264' => 'libx264',
   'h264' => 'h264',
   'h264_cuvid' => 'h264_cuvid',
+  'h264_nvmpi' => 'h264_nvmpi',
   'h264_mmal'   => 'h264_mmal',
   'h264_omx' => 'h264_omx',
   'h264_qsv' => 'h264_qsv',


### PR DESCRIPTION
While moving decoder selection to be configuration based, the NVMPI based H264 decoder was missed: add it back.

Fixes: 5027bf207 ("add h264_mmal as a decoder option")