### PR TITLE
(fix): Montage 2 wide is stable on Chrome during alert

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -365,6 +365,7 @@ body.sticky #content {
 }
 .alert, .warnText, .warning, .disabledText {
     color: #ffa801;
+    padding: 0;
 }
 
 


### PR DESCRIPTION
bootstrap has in internal css class called .alert that interferes with ZoneMinder's .alert class.

This fix overrides the bootstrap class and sets padding to 0.

This fixes #3711 