### PR TITLE
distros/ubuntu2004: Update libgsoap dependency for Debian 12

### DIFF
--- a/distros/ubuntu2004/control
+++ b/distros/ubuntu2004/control
@@ -82,7 +82,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
         ,libdata-entropy-perl
         ,libvncclient1|libvncclient0
         ,libjwt-gnutls0|libjwt0
-        ,libgsoap-2.8.117|libgsoap-2.8.104|libgsoap-2.8.91|libgsoap-2.8.75|libgsoap-2.8.60|libgsoap10
+        ,libgsoap-2.8.124|libgsoap-2.8.117|libgsoap-2.8.104|libgsoap-2.8.91|libgsoap-2.8.75|libgsoap-2.8.60|libgsoap10
         ,libmosquittopp1
 Recommends: ${misc:Recommends}
            ,libapache2-mod-php | php-fpm


### PR DESCRIPTION
Allow libgsoap-2.8.124, as that is what is shipped with Debian 12. This fixes do_debian_package.sh on Debian 12.