### PR TITLE
Fix(event): Consistent cookie timeframe

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -283,7 +283,8 @@ function changeScale() {
     //just re-render alarmCues.  skip ajax call
     alarmCue.html(renderAlarmCues(eventViewer));
   }
-  setCookie('zmEventScale'+eventData.MonitorId, scale, 3600);
+  // 63072000 seconds is 2 years
+  setCookie('zmEventScale'+eventData.MonitorId, scale, 63072000);
 
   // After a resize, check if we still have room to display the event stats table
   onStatsResize(newWidth);


### PR DESCRIPTION
Sets cookie timeframe from one hour to two years (consistent with other cookie settings).