### PR TITLE
use libv4l2  (https://github.com/philips/libv4l) for local USB cameras .

### DIFF
--- a/src/zm_local_camera.cpp
+++ b/src/zm_local_camera.cpp
@@ -1186,7 +1186,6 @@ int LocalCamera::Control(int vid_id, int newvalue) {
         Warning("Given control value (%d) may be out-of-range", newvalue);
       }
     }
-    v4l2_close( vid_fd );
   }
   return vid_control.value;
 }


### PR DESCRIPTION
This allows very simple/primitive cameras to work out of the box . (like USB cameras using the gspca driver )

simple/primitive  USB cameras ( for example using the gspsa driver ) do not work properly with ZoneMinder (zmc keeps crashing ) 

for example : 0c45:6005 Microdia Sweex Mini Webcam , 

I propose a fix for that (patch against  zm 37.40 / master dev ) 
This uses libv4l2 (https://github.com/philips/libv4l) for local USB cameras .

This allows very simple/primitive cameras to work out of the box .
(like for example USB cameras using the gspca driver )

A pull Request has just been made  (sletteland/zoneminder  branch libv4l2 ) 
