### PR TITLE
fix(events): Dark background for table while loading

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -141,6 +141,10 @@ fieldset {
     background-color: #070707;
 }
 
+.fixed-table-loading {
+  background-color: #333333 !important;
+}
+
 #header {
     border-bottom: 1px solid #000000;
 }


### PR DESCRIPTION
When using the dark theme css, as the events table is loaded, the background is a dark grey instead of white.

Previously, the "loading" background color was white which was very jarring for the user as the screen flashes from dark grey to white and then back to dark grey.