### PR TITLE
Set default cookie time to Jan 2038

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -279,10 +279,10 @@ if ( currentView != 'none' && currentView != 'login' ) {
       const flip = $j("#flip");
       if ( flip.html() == 'keyboard_arrow_up' ) {
         flip.html('keyboard_arrow_down');
-        setCookie('zmHeaderFlip', 'down', 3600);
+        setCookie('zmHeaderFlip', 'down');
       } else {
         flip.html('keyboard_arrow_up');
-        setCookie('zmHeaderFlip', 'up', 3600);
+        setCookie('zmHeaderFlip', 'up');
       }
     });
     // Manage the web console filter bar minimize chevron
@@ -291,10 +291,10 @@ if ( currentView != 'none' && currentView != 'login' ) {
       var fbflip = $j("#fbflip");
       if ( fbflip.html() == 'keyboard_arrow_up' ) {
         fbflip.html('keyboard_arrow_down');
-        setCookie('zmFilterBarFlip', 'down', 3600);
+        setCookie('zmFilterBarFlip', 'down');
       } else {
         fbflip.html('keyboard_arrow_up');
-        setCookie('zmFilterBarFlip', 'up', 3600);
+        setCookie('zmFilterBarFlip', 'up');
         $j('.chosen').chosen("destroy");
         $j('.chosen').chosen();
       }
@@ -306,10 +306,10 @@ if ( currentView != 'none' && currentView != 'login' ) {
       var mfbflip = $j("#mfbflip");
       if ( mfbflip.html() == 'keyboard_arrow_up' ) {
         mfbflip.html('keyboard_arrow_down');
-        setCookie('zmMonitorFilterBarFlip', 'up', 3600);
+        setCookie('zmMonitorFilterBarFlip', 'up');
       } else {
         mfbflip.html('keyboard_arrow_up');
-        setCookie('zmMonitorFilterBarFlip', 'down', 3600);
+        setCookie('zmMonitorFilterBarFlip', 'down');
         $j('.chosen').chosen("destroy");
         $j('.chosen').chosen();
       }
@@ -656,6 +656,9 @@ function setCookie(name, value, seconds) {
     const date = new Date();
     date.setTime(date.getTime() + (seconds*1000));
     expires = "; expires=" + date.toUTCString();
+  } else {
+    // 2147483647 is 2^31 - 1 which is January of 2038 to avoid the 32bit integer overflow bug.
+    expires = "; expires=2147483647";
   }
   document.cookie = name + "=" + (value || "") + expires + "; path=/; samesite=strict";
 }
@@ -678,7 +681,7 @@ function delCookie(name) {
 function bwClickFunction() {
   $j('.bwselect').click(function() {
     var bwval = $j(this).data('pdsa-dropdown-val');
-    setCookie("zmBandwidth", bwval, 3600);
+    setCookie("zmBandwidth", bwval);
     getNavBar();
   });
 }

--- a/web/skins/classic/views/js/cycle.js
+++ b/web/skins/classic/views/js/cycle.js
@@ -73,9 +73,9 @@ function changeSize() {
   if (scale <= 0) scale = 100;
 
   $j('#scale').val('0');
-  setCookie('zmCycleScale', '0', 3600);
-  setCookie('zmCycleWidth', width, 3600);
-  setCookie('zmCycleHeight', height, 3600);
+  setCookie('zmCycleScale', '0');
+  setCookie('zmCycleWidth', width);
+  setCookie('zmCycleHeight', height);
   applyScale();
   monitor.setStreamScale(scale);
 } // end function changeSize()
@@ -84,9 +84,9 @@ function changeScale() {
   var scale = $j('#scale').val();
   $j('#width').val('auto');
   $j('#height').val('auto');
-  setCookie('zmCycleScale', scale, 3600);
-  setCookie('zmCycleWidth', 'auto', 3600);
-  setCookie('zmCycleHeight', 'auto', 3600);
+  setCookie('zmCycleScale', scale);
+  setCookie('zmCycleWidth', 'auto');
+  setCookie('zmCycleHeight', 'auto');
   applyScale();
 } // end function changeScale()
 

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -283,8 +283,7 @@ function changeScale() {
     //just re-render alarmCues.  skip ajax call
     alarmCue.html(renderAlarmCues(eventViewer));
   }
-  // 63072000 seconds is 2 years
-  setCookie('zmEventScale'+eventData.MonitorId, scale, 63072000);
+  setCookie('zmEventScale'+eventData.MonitorId, scale);
 
   // After a resize, check if we still have room to display the event stats table
   onStatsResize(newWidth);
@@ -951,7 +950,7 @@ function getEvtStatsCookie() {
 
   if (!stats) {
     stats = 'on';
-    setCookie(cookie, stats, 10*365);
+    setCookie(cookie, stats);
   }
   return stats;
 }
@@ -1070,7 +1069,7 @@ function initPage() {
       handleClick(event);
     });
     vid.on('volumechange', function() {
-      setCookie('volume', vid.volume(), 3600);
+      setCookie('volume', vid.volume());
     });
     const cookie = getCookie('volume');
     if (cookie) vid.volume(cookie);
@@ -1081,7 +1080,7 @@ function initPage() {
     vid.on('ratechange', function() {
       rate = vid.playbackRate() * 100;
       $j('select[name="rate"]').val(rate);
-      setCookie('zmEventRate', rate, 3600);
+      setCookie('zmEventRate', rate);
     });
 
     // rate is in % so 100 would be 1x
@@ -1218,10 +1217,10 @@ function initPage() {
 
     // Toggle the visiblity of the stats table and write an appropriate cookie
     if (table.is(':visible')) {
-      setCookie(cookie, 'off', 10*365);
+      setCookie(cookie, 'off');
       table.toggle(false);
     } else {
-      setCookie(cookie, 'on', 10*365);
+      setCookie(cookie, 'on');
       table.toggle(true);
     }
   });
@@ -1301,12 +1300,12 @@ function toggleZones(e) {
       zones.hide();
       button.setAttribute('title', showZonesString);
       $j('#toggleZonesButton .material-icons').text('layers');
-      setCookie('zmEventShowZones'+eventData.MonitorId, '0', 3600);
+      setCookie('zmEventShowZones'+eventData.MonitorId, '0');
     } else {
       zones.show();
       button.setAttribute('title', hideZonesString);
       $j('#toggleZonesButton .material-icons').text('layers_clear');
-      setCookie('zmEventShowZones'+eventData.MonitorId, '1', 3600);
+      setCookie('zmEventShowZones'+eventData.MonitorId, '1');
     }
   } else {
     console.error("Zones svg not found");

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -99,12 +99,12 @@ function selectLayout(new_layout_id) {
       }
     } // end if specific monitor style
   } // end foreach monitor
-  setCookie('zmMontageLayout', layout_id, 3600);
+  setCookie('zmMontageLayout', layout_id);
   if (layouts[layout_id].Name != 'Freeform') { // 'montage_freeform.css' ) {
     // For freeform, we don't touch the width/height/scale settings, but we may need to update sizing and scales
-    setCookie('zmMontageScale', '0', 3600);
-    setCookie('zmMontageWidth', 'auto', 3600);
-    //setCookie('zmMontageHeight', 'auto', 3600);
+    setCookie('zmMontageScale', '0');
+    setCookie('zmMontageWidth', 'auto');
+    //setCookie('zmMontageHeight', 'auto');
     $j('#scale').val('0');
     $j('#width').val('auto');
     //$j('#height').val('auto');
@@ -116,11 +116,11 @@ function selectLayout(new_layout_id) {
 } // end function selectLayout(element)
 
 function changeHeight() {
-  const height = $j('#height').val();
-  setCookie('zmMontageHeight', height, 3600);
-  for (let i = 0, length = monitors.length; i < length; i++) {
-    const monitor = monitors[i];
-    const monitor_frame = $j('#monitor'+monitor.id + " .monitorStream");
+  var height = $j('#height').val();
+  setCookie('zmMontageHeight', height);
+  for (var i = 0, length = monitors.length; i < length; i++) {
+    var monitor = monitors[i];
+    monitor_frame = $j('#monitor'+monitor.id + " .monitorStream");
     monitor_frame.css('height', height);
   }
 }
@@ -140,9 +140,9 @@ function changeWidth() {
     monitors[i].setScale('0', width, height);
   }
   $j('#scale').val('0');
-  setCookie('zmMontageScale', '0', 3600);
-  setCookie('zmMontageWidth', width, 3600);
-  setCookie('zmMontageHeight', height, 3600);
+  setCookie('zmMontageScale', '0');
+  setCookie('zmMontageWidth', width);
+  setCookie('zmMontageHeight', height);
 } // end function changeSize()
 
 /**
@@ -152,9 +152,9 @@ function changeScale() {
   const scale = $j('#scale').val();
   selectLayout(freeform_layout_id); // Will also clear width and height
   $j('#scale').val(scale);
-  setCookie('zmMontageScale', scale, 3600);
-  setCookie('zmMontageWidth', 'auto', 3600);
-  setCookie('zmMontageHeight', 'auto', 3600);
+  setCookie('zmMontageScale', scale);
+  setCookie('zmMontageWidth', 'auto');
+  setCookie('zmMontageHeight', 'auto');
   $j('#width').val('auto');
   $j('#height').val('auto');
 
@@ -282,7 +282,7 @@ function initPage() {
   $j("#hdrbutton").click(function() {
     $j("#flipMontageHeader").slideToggle("slow");
     $j("#hdrbutton").toggleClass('glyphicon-menu-down').toggleClass('glyphicon-menu-up');
-    setCookie('zmMontageHeaderFlip', $j('#hdrbutton').hasClass('glyphicon-menu-up') ? 'up' : 'down', 3600);
+    setCookie('zmMontageHeaderFlip', $j('#hdrbutton').hasClass('glyphicon-menu-up') ? 'up' : 'down');
   });
   if (getCookie('zmMontageHeaderFlip') == 'down') {
     // The chosen dropdowns require the selects to be visible, so once chosen has initialized, we can hide the header

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -96,19 +96,19 @@ function changeSize() {
 
   monitorStream.setScale('0', width, height);
   $j('#scale').val('0');
-  setCookie('zmWatchScale', '0', 3600);
-  setCookie('zmWatchWidth', width, 3600);
-  setCookie('zmWatchHeight', height, 3600);
+  setCookie('zmWatchScale', '0');
+  setCookie('zmWatchWidth', width);
+  setCookie('zmWatchHeight', height);
 } // end function changeSize()
 
 function changeScale() {
   var scale = $j('#scale').val();
-  setCookie('zmWatchScale'+monitorId, scale, 3600);
+  setCookie('zmWatchScale'+monitorId, scale);
   $j('#width').val('auto');
   $j('#height').val('auto');
-  setCookie('zmCycleScale', scale, 3600);
-  setCookie('zmWatchWidth', 'auto', 3600);
-  setCookie('zmWatchHeight', 'auto', 3600);
+  setCookie('zmCycleScale', scale);
+  setCookie('zmWatchWidth', 'auto');
+  setCookie('zmWatchHeight', 'auto');
 
   setScale();
 }
@@ -942,17 +942,17 @@ function cyclePrev() {
 function cyclePeriodChange() {
   const cyclePeriodSelect = $j('#cyclePeriod');
   secondsToCycle = cyclePeriodSelect.val();
-  setCookie('zmCyclePeriod', secondsToCycle, 3600);
+  setCookie('zmCyclePeriod', secondsToCycle);
 }
 function cycleToggle(e) {
   sidebar = $j('#sidebar');
   button = $j('#cycleToggle');
   if (sidebar.is(":visible")) {
     sidebar.hide();
-    setCookie('zmCycleShow', false, 3600);
+    setCookie('zmCycleShow', false);
   } else {
     sidebar.show();
-    setCookie('zmCycleShow', true, 3600);
+    setCookie('zmCycleShow', true);
   }
   button.toggleClass('btn-secondary');
   button.toggleClass('btn-primary');
@@ -974,7 +974,7 @@ function changeRate(e) {
       streamImage.attr('src', oldsrc.replace(/maxfps=\d+/i, 'maxfps='+newvalue));
     }
   }
-  setCookie('zmWatchRate', newvalue, 3600);
+  setCookie('zmWatchRate', newvalue);
 }
 
 // Kick everything off


### PR DESCRIPTION
This sets the default cookie timeout to the current maximum of January 2038

Key change is at line 659 of skin.js:
```
} else {
    // 2147483647 is 2^31 - 1 which is January of 2038 to avoid the 32bit integer overflow bug.
    expires = "; expires=2147483647";
```

Other changes just enable this default for cookies by removing explicit values.