### PR TITLE
fix(cookies): Use max-age instead of expires

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -658,7 +658,7 @@ function setCookie(name, value, seconds) {
     expires = "; expires=" + date.toUTCString();
   } else {
     // 2147483647 is 2^31 - 1 which is January of 2038 to avoid the 32bit integer overflow bug.
-    expires = "; expires=2147483647";
+    expires = "; max-age=2147483647";
   }
   document.cookie = name + "=" + (value || "") + expires + "; path=/; samesite=strict";
 }

--- a/web/skins/classic/views/add_monitors.php
+++ b/web/skins/classic/views/add_monitors.php
@@ -104,7 +104,7 @@ getBodyTopHTML();
         data-search="true"
         data-cookie="true"
         data-cookie-id-table="AddMonitorsTable"
-        data-cookie-expire="86400s"
+        data-cookie-expire="2y"
         data-click-to-select="true"
         data-remember-order="false"
         data-show-columns="true"

--- a/web/skins/classic/views/js/frame.js
+++ b/web/skins/classic/views/js/frame.js
@@ -28,7 +28,7 @@ function changeScale() {
     img.css('width', newWidth + 'px');
     img.css('height', newHeight + 'px');
   }
-  setCookie('zmWatchScale', scale, 3600);
+  setCookie('zmWatchScale', scale);
   $j.each(controlsLinks, function(k, anchor) { // Make frames respect scale choices
     if (anchor) {
       anchor.prop('href', anchor.prop('href').replace(/scale=.*&/, 'scale=' + scale + '&'));


### PR DESCRIPTION
Since Internet Explorer is no longer supported by Microsoft, there is no reason to consider it.