### PR TITLE
chore(): Update .gitignore to remove node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ misc/zoneminder-tmpfiles.conf
 misc/zoneminder.service
 missing
 mkinstalldirs
+node_modules/
 onvif/CMakeFiles/
 onvif/cmake_install.cmake
 onvif/modules/CMakeFiles/
@@ -52,6 +53,8 @@ onvif/proxy/output/
 onvif/proxy/pm_to_blib
 onvif/scripts/CMakeFiles/
 onvif/scripts/cmake_install.cmake
+package.json
+package-lock.json
 scripts/CMakeFiles/
 scripts/ZoneMinder/CMakeFiles/
 scripts/ZoneMinder/MYMETA.json


### PR DESCRIPTION
I'm using the following in a package.json file to check for eslint issues, but these don't need to be part of the product:

```
{
  "devDependencies": {
    "eslint": "^8.42.0",
    "eslint-config-google": "^0.14.0",
    "eslint-plugin-html": "^7.1.0",
    "eslint-plugin-php-markup": "^6.0.0"
  }
}
```