### PR TITLE
fix(event): Honor the Alt key with left/right arrow

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -45,9 +45,9 @@ $j(document).on("keydown", "", function(e) {
       console.log('Modal is visible: key not implemented: ', e.key, '  keyCode: ', e.keyCode);
     }
   } else {
-    if (e.key === "ArrowLeft") {
+    if (e.key === "ArrowLeft" && !e.altKey) {
       prevEvent();
-    } else if (e.key === "ArrowRight") {
+    } else if (e.key === "ArrowRight" && !e.altKey) {
       nextEvent();
     } else if (e.key === "Delete") {
       if ( $j("#deleteBtn").is(":disabled") == false ) {


### PR DESCRIPTION
Fixes a race condition when using Alt-LeftArrow to go back to the previous page (standard browser behavior).

Sometimes it would go the previous event and sometimes it would go to the previous page.  Now it will consistently go to the previous page when the alt key is pressed with the left arrow.