### PR TITLE
Event table data should be aligned with column headers

### DIFF
--- a/web/skins/classic/css/base/views/events.css
+++ b/web/skins/classic/css/base/views/events.css
@@ -6,7 +6,7 @@
     white-space: nowrap;
 }
 
-#contentTable.major .colId, #contentTable.major .colDuration, #contentTable.major .colFrames, #contentTable.major .colAlarmFrames, #contentTable.major .colTotScore, #contentTable.major .colMaxScore, #contentTable.major .colAvgScore {
+#contentTable.major .colId, #contentTable.major .colDuration, #contentTable.major .colFrames, #contentTable.major .colAlarmFrames, #contentTable.major .colTotScore, #contentTable.major .colMaxScore, #contentTable.major .colAvgScore, #eventTable th, #eventTable td {
     text-align: center;
 }
 


### PR DESCRIPTION
This is more noticeable when some columns of the events table are toggled off, but the column headers were centered and the data in columns were left justified.  This made it difficult to read which column went to which data.

This change centers both the column headers and the data in the columns so that they line up.