### PR TITLE
Refresh table on show

### DIFF
--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -420,6 +420,11 @@ function initPage() {
     }
   });
 
+  window.onpageshow = function(evt) {
+    console.log('Refreshing table');
+    table.bootstrapTable('refresh');
+  };
+
   table.bootstrapTable('resetSearch');
   // The table is initially given a hidden style, so now that we are done rendering, show it
   table.show();


### PR DESCRIPTION
After opening an event from the events table and editing some properties, returning back to the events table would show the cached version of the table without the new values.  

This change will refresh the events table each time it's shown. 

It is a bit of a performance hit, but it's more important to show accurate information after a quick delay than to show bad/inaccurate information fast.