### PR TITLE
Fixed eslint checks

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -302,7 +302,9 @@ if ( currentView != 'none' && currentView != 'login' ) {
 
     // Manage the web console filter bar minimize chevron
     $j("#mfbflip").click(function() {
-      $j("#mfbpanel").slideToggle("slow", function() { changeScale(); });
+      $j("#mfbpanel").slideToggle("slow", function() {
+        changeScale();
+      });
       var mfbflip = $j("#mfbflip");
       if ( mfbflip.html() == 'keyboard_arrow_up' ) {
         mfbflip.html('keyboard_arrow_down');


### PR DESCRIPTION
Corrected format so `eslint` tests pass.

eslitnt actions was failing:

```
Run npx eslint --ext .php,.js .
  npx eslint --ext .php,.js .
  shell: /usr/bin/bash -e {0}

/home/runner/work/zoneminder/zoneminder/web/skins/classic/js/skin.js
  305:54  error  Statement inside of curly braces should be on next line                                                        brace-style
  305:55  error  Unexpected space(s) after '{'                                                                                  block-spacing
  305:70  error  Unexpected space(s) before '}'                                                                                 block-spacing
  305:71  error  Closing curly brace should be on the same line as opening curly brace or on the line after the previous block  brace-style

✖ 4 problems (4 errors, 0 warnings)
  4 errors and 0 warnings potentially fixable with the `--fix` option.

Error: Process completed with exit code 1.
```
