### PR TITLE
Fix usage of unset variable

### DIFF
--- a/web/api/app/Controller/HostController.php
+++ b/web/api/app/Controller/HostController.php
@@ -7,6 +7,7 @@ class HostController extends AppController {
 
   public function daemonCheck($daemon=false, $args=false) {
     # To try to prevent abuse here, we are only going to allow certain characters in the daemon and args.
+    $count = 0;
     $safe_daemon = $daemon ? preg_replace('/[^A-Za-z0-9\- \.]/', '', $daemon, -1, $count) : false;
     if ($count) Error("Invalid characters found in daemon string ($daemon). Potential attack?");
     $safe_args = $args ? preg_replace('/[^A-Za-z0-9\- \.]/', '', $args, -1, $count) : false;


### PR DESCRIPTION
If daemon or args are unset the preg_replace is never called which can result in count not having a value when referenced in the if statement. This generates a warning in error.log.