### PR TITLE
fix(php8): AllowDynamicProperties

### DIFF
--- a/web/includes/Object.php
+++ b/web/includes/Object.php
@@ -4,6 +4,12 @@ require_once('database.php');
 
 $object_cache = array();
 
+/**
+ * Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute on "MyClass" WILL NOT WORK.
+ */
+use \AllowDynamicProperties;
+
+#[AllowDynamicProperties]
 class ZM_Object {
   protected $_last_error;
 


### PR DESCRIPTION
This fixes a problem that was introduced in PHP 8 which deprecated the use of dynamic properties.

The problem can be seen in the [zoneminder-containers/zoneminder-base](https://github.com/zoneminder-containers/zoneminder-base) after [pull request 56.](https://github.com/zoneminder-containers/zoneminder-base/pull/56)

Symptom:
When you click on any of the monitor names from the Console view, you will get a 502 Bad Gateway message when running with nginx.

nginx log files show the following message many times:
`PHP message: PHP Deprecated:  Creation of dynamic property <property name> is deprecated in <file name>`