### PR TITLE
docs: debian 12 install needs a2enmod cgi

### DIFF
--- a/docs/installationguide/debian.rst
+++ b/docs/installationguide/debian.rst
@@ -98,6 +98,7 @@ To make sure zoneminder can read the configuration file, run the following comma
 ::
 
     sudo a2enconf zoneminder
+    sudo a2enmod cgi
     sudo systemctl reload apache2.service
     sudo systemctl restart zoneminder.service
     sudo systemctl status zoneminder.service


### PR DESCRIPTION
I just did a brand new install of 1.36.33 on a brand new install of Raspberry Pi OS 12 (bookworm). Initially, live view does not work at all. As described in [this forum thread](https://forums.zoneminder.com/viewtopic.php?t=32596), Debian 12 (bookworm) needs the apache2 CGI module to be enabled; this fixes live view.