### PR TITLE
Update ZM version in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,17 +2,14 @@
 
 ## Supported Versions
 
-Time and computers move on. We do not have the resources to support every ancient version of everything
-(unless you'd like to pay us to do so.)  We ONLY support the latest stable release and development releases.
+Time and computers move on. We do not have the resources to support every ancient version of everything (unless you'd like to pay us to do so). We ONLY support the latest stable release and development releases. ZoneMinder uses Semantic Versioning with even minor versions being stable and odd being development. 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.34.x   | :white_check_mark: |
-| 1.35.x   | :white_check_mark: |
-| < 1.34.x   | :x:                |
+| 1.36.x   | :white_check_mark: |
+| 1.37.x   | :white_check_mark: |
+| < 1.36.x   | :x:                |
 
 ## Reporting a Vulnerability
 
-Since sometimes security vulnerabilities can be sensitive, you can just email me at isaac@zoneminder.com.
-If it's not such a big deal, by all means, create an issue here on github
-
+Since sometimes security vulnerabilities can be sensitive, you can just email me at isaac@zoneminder.com. If it's not such a big deal, by all means, create an issue here on GitHub.


### PR DESCRIPTION
Updated stable and development versions to 1.36 and 1.37 respectively. Clarified that SemVer is used and that even minor versions are stable and odd are development.