### PR TITLE
Fix Monitor Source Tab Rendering

### DIFF
--- a/web/skins/classic/views/_monitor_source_nvsocket.php
+++ b/web/skins/classic/views/_monitor_source_nvsocket.php
@@ -1,7 +1,8 @@
+<table>
 <input type="hidden" name="newMonitor[Method]" value="<?php echo validHtmlStr($monitor->Method()) ?>"/>
 <tr><td><?php echo translate('HostName') ?></td><td><input type="text" name="newMonitor[Host]" value="<?php echo validHtmlStr($monitor->Host()) ?>" size="36"/></td></tr>
 <tr><td><?php echo translate('Port') ?></td><td><input type="number" name="newMonitor[Port]" value="<?php echo validHtmlStr($monitor->Port()) ?>" size="6"/></td></tr>
-<tr><td><?php echo translate('Path') ?></td><td><input type="hidden" name="newMonitor[Path]" value="<?php echo validHtmlStr($monitor->Path()) ?>" size="36"/></td></tr>
+<tr><td><?php echo translate('Path') ?></td><td><input type="text" name="newMonitor[Path]" value="<?php echo validHtmlStr($monitor->Path()) ?>" size="36"/></td></tr>
 <input type="hidden" name="newMonitor[User]" value="<?php echo validHtmlStr($monitor->User()) ?>"/>
 <input type="hidden" name="newMonitor[Pass]" value="<?php echo validHtmlStr($monitor->Pass()) ?>"/>
 <input type="hidden" name="newMonitor[Options]" value="<?php echo validHtmlStr($monitor->Options()) ?>"/>
@@ -20,3 +21,4 @@
 <tr><td><?php echo translate('Orientation') ?></td><td><?php echo htmlselect( 'newMonitor[Orientation]', $orientations, $monitor->Orientation() );?></td></tr>
 <input type="hidden" name="newMonitor[Deinterlacing]" value="<?php echo validHtmlStr($monitor->Deinterlacing()) ?>"/>
 <input type="hidden" name="newMonitor[RTSPDescribe]" value="<?php echo validHtmlStr($monitor->RTSPDescribe()) ?>"/>
+</table>

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -747,8 +747,8 @@ include('_monitor_source_nvsocket.php');
             <label><?php echo translate('Height') ?> (<?php echo translate('Pixels') ?>)</label>
             <input type="number" name="newMonitor[Height]" value="<?php echo validHtmlStr($monitor->Height()) ?>" min="1" step="1"/>
           </li>
-          <li>
-            <label<?php echo 'Web Site Refresh (Optional)' ?></label>
+	  <li>
+            <label><?php echo 'Web Site Refresh (Optional)' ?></label>
             <input type="number" name="newMonitor[Refresh]" value="<?php echo validHtmlStr($monitor->Refresh()) ?>" min="1" step="1"/>
           </li>
 <?php


### PR DESCRIPTION
Monitor -> Source (for Web Site) was missing the 'Web Site Refresh (Optional)' description label.

Monitor -> Source (for NVSocket) was not rending correctly. Added missing `<table>` tags. Now renders okay but not as clean as other source types due to the use of table formatting. May consider cleaning this up later if NVSocket is to be kept in ZM 1.38.