### PR TITLE
PHP 8.3 deprecated get_class method call without argument

### DIFF
--- a/web/includes/Control.php
+++ b/web/includes/Control.php
@@ -108,11 +108,11 @@ class Control extends ZM_Object {
     );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function commands() {

--- a/web/includes/Event.php
+++ b/web/includes/Event.php
@@ -45,18 +45,18 @@ class Event extends ZM_Object {
     'Locked' => 0,
 );
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public static function clear_cache() {
-    return ZM_Object::_clear_cache(get_class());
+    return ZM_Object::_clear_cache(self::class);
   }
   public function remove_from_cache() {
-    return ZM_Object::_remove_from_cache(get_class(), $this);
+    return ZM_Object::_remove_from_cache(self::class, $this);
   }
 
   public function Storage( $new = null ) {

--- a/web/includes/Event_Data.php
+++ b/web/includes/Event_Data.php
@@ -17,11 +17,11 @@ class Event_Data extends ZM_Object {
   private $Event = null;
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Event() {

--- a/web/includes/Event_Tag.php
+++ b/web/includes/Event_Tag.php
@@ -23,11 +23,11 @@ class Event_Tag extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Event() {

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -217,11 +217,11 @@ class Filter extends ZM_Object {
   }
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function terms() {

--- a/web/includes/Frame.php
+++ b/web/includes/Frame.php
@@ -17,11 +17,11 @@ class Frame extends ZM_Object {
   );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Storage() {

--- a/web/includes/Group.php
+++ b/web/includes/Group.php
@@ -12,11 +12,11 @@ class Group extends ZM_Object {
   protected static $monitor_ids_cache = array();
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function delete() {

--- a/web/includes/Group_Monitor.php
+++ b/web/includes/Group_Monitor.php
@@ -10,11 +10,11 @@ class Group_Monitor extends ZM_Object {
       );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Group_Monitor
 ?>

--- a/web/includes/Group_Permission.php
+++ b/web/includes/Group_Permission.php
@@ -20,11 +20,11 @@ class Group_Permission extends ZM_Object {
   private $Monitors;
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function MonitorPermission($mid) {

--- a/web/includes/Manufacturer.php
+++ b/web/includes/Manufacturer.php
@@ -13,11 +13,11 @@ class Manufacturer extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Manufacturer
 ?>

--- a/web/includes/Model.php
+++ b/web/includes/Model.php
@@ -13,11 +13,11 @@ class Model extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Model
 ?>

--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -534,11 +534,11 @@ public static function getStatuses() {
   } // end function SignalCheckColour
 
   public static function find($parameters = array(), $options = array()) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one($parameters = array(), $options = array()) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   function zmcControl($mode=false) {

--- a/web/includes/Monitor_Permission.php
+++ b/web/includes/Monitor_Permission.php
@@ -19,11 +19,11 @@ class Monitor_Permission extends ZM_Object {
   private $User;
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Monitor($new=null) {

--- a/web/includes/MontageLayout.php
+++ b/web/includes/MontageLayout.php
@@ -12,11 +12,11 @@ class MontageLayout extends ZM_Object {
   );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
 } // end class MontageLayout

--- a/web/includes/Object.php
+++ b/web/includes/Object.php
@@ -127,7 +127,7 @@ class ZM_Object {
           $sql .= ' LIMIT '.$options['limit'];
         } else {
           $backTrace = debug_backtrace();
-          Error('Invalid value for limit('.$options['limit'].') passed to '.get_class()."::find from ".print_r($backTrace,true));
+          Error('Invalid value for limit('.$options['limit'].') passed to '.self::class."::find from ".print_r($backTrace,true));
           return array();
         }
       }
@@ -460,7 +460,7 @@ class ZM_Object {
     }
   }
   public function remove_from_cache() {
-    return ZM_Object::_remove_from_cache(get_class(), $this);
+    return ZM_Object::_remove_from_cache(self::class, $this);
   }
   public function get_last_error() {
     return $this->_last_error;

--- a/web/includes/Report.php
+++ b/web/includes/Report.php
@@ -16,11 +16,11 @@ class Report extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Report
 ?>

--- a/web/includes/Server.php
+++ b/web/includes/Server.php
@@ -22,11 +22,11 @@ class Server extends ZM_Object {
   );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Hostname($new = null) {

--- a/web/includes/Snapshot.php
+++ b/web/includes/Snapshot.php
@@ -15,11 +15,11 @@ class Snapshot extends ZM_Object {
   );
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Event() {
@@ -56,11 +56,11 @@ class Snapshot_Event extends ZM_Object {
     'SnapshotId' => 0,
   );
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Snapshot_Event
 ?>

--- a/web/includes/Storage.php
+++ b/web/includes/Storage.php
@@ -31,11 +31,11 @@ class Storage extends ZM_Object {
     'Enabled'   => 1,
   );
   public static function find($parameters = array(), $options = array()) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one($parameters = array(), $options = array()) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Path($new=null) {

--- a/web/includes/Tag.php
+++ b/web/includes/Tag.php
@@ -16,11 +16,11 @@ class Tag extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 } # end class Tag
 ?>

--- a/web/includes/User.php
+++ b/web/includes/User.php
@@ -60,11 +60,11 @@ class User extends ZM_Object {
   private $Preferences;
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function Name($new=null) {

--- a/web/includes/User_Preference.php
+++ b/web/includes/User_Preference.php
@@ -15,11 +15,11 @@ class User_Preference extends ZM_Object {
   private $User = null;
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
 
   public function User() {

--- a/web/includes/Zone.php
+++ b/web/includes/Zone.php
@@ -35,11 +35,11 @@ class Zone extends ZM_Object {
 			);
 
   public static function find( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find(get_class(), $parameters, $options);
+    return ZM_Object::_find(self::class, $parameters, $options);
   }
 
   public static function find_one( $parameters = array(), $options = array() ) {
-    return ZM_Object::_find_one(get_class(), $parameters, $options);
+    return ZM_Object::_find_one(self::class, $parameters, $options);
   }
   public function Monitor() {
     if ( isset($this->{'MonitorId'}) ) {


### PR DESCRIPTION
Hi,

In this PR, I replaced get_class with `self:class` due to new deprecations in PHP 8.3, which you can read about it [here](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#:~:text=has%20been%20closed.-,get_class()%20and%20get_parent_class(),-get_class()%20currently)