### PR TITLE
Introducing a new ZM_DB_SSL_VERIFY_SERVER_CERT configuration option t…

### DIFF
--- a/cmakecacheimport.sh
+++ b/cmakecacheimport.sh
@@ -58,6 +58,7 @@ echo "Database password          : Not shown"
 echo "Database SSL CA Cert       : $ZM_DB_SSL_CA_CERT"
 echo "Database SSL Client Key    : $ZM_DB_SSL_CLIENT_KEY"
 echo "Database SSL Client Cert   : $ZM_DB_SSL_CLIENT_CERT"
+echo "Verify database SSL Cert : $ZM_DB_SSL_VERIFY_SERVER_CERT"
 
 
 CMPATH="CACHE PATH \"Imported by cmakecacheimport.sh\" FORCE"
@@ -78,6 +79,7 @@ echo "set(ZM_DB_PASS \"$ZM_DB_PASS\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CA_CERT \"$ZM_DB_SSL_CA_CERT\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CLIENT_KEY \"$ZM_DB_SSL_CLIENT_KEY\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CLIENT_CERT \"$ZM_DB_SSL_CLIENT_CERT\" $CMSTRING)">>zm_conf.cmake
+echo "set(ZM_DB_SSL_VERIFY_SERVER_CERT \"$ZM_DB_SSL_VERIFY_SERVER_CERT\" $CMSTRING)">>zm_conf.cmake
 
 echo ""
 echo "Wrote zm_conf.cmake"

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -102,7 +102,8 @@ sub zmDbConnect {
           'mysql_ssl=1',
           'mysql_ssl_ca_file='.$ZoneMinder::Config::Config{ZM_DB_SSL_CA_CERT},
           'mysql_ssl_client_key='.$ZoneMinder::Config::Config{ZM_DB_SSL_CLIENT_KEY},
-          'mysql_ssl_client_cert='.$ZoneMinder::Config::Config{ZM_DB_SSL_CLIENT_CERT}
+          'mysql_ssl_client_cert='.$ZoneMinder::Config::Config{ZM_DB_SSL_CLIENT_CERT},
+          'mysql_ssl_verify_server_cert='.$ZoneMinder::Config::Config{ZM_DB_SSL_VERIFY_SERVER_CERT}
           );
     }
 

--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -170,6 +170,8 @@ void process_configfile(char const *configFile) {
       staticConfig.DB_SSL_CLIENT_KEY = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_DB_SSL_CLIENT_CERT") == 0 )
       staticConfig.DB_SSL_CLIENT_CERT = std::string(val_ptr);
+    else if ( strcasecmp(name_ptr, "ZM_DB_SSL_VERIFY_SERVER_CERT") == 0 )
+      staticConfig.DB_SSL_VERIFY_SERVER_CERT = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_PATH_WEB") == 0 )
       staticConfig.PATH_WEB = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_SERVER_HOST") == 0 )

--- a/src/zm_config.h
+++ b/src/zm_config.h
@@ -53,6 +53,7 @@ struct StaticConfig {
   std::string DB_SSL_CA_CERT;
   std::string DB_SSL_CLIENT_KEY;
   std::string DB_SSL_CLIENT_CERT;
+  std::string DB_SSL_VERIFY_SERVER_CERT;
   std::string PATH_WEB;
   std::string SERVER_NAME;
   unsigned int SERVER_ID;

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -46,6 +46,7 @@ bool zmDbConnect() {
     mysql_options(&dbconn, MYSQL_OPT_SSL_KEY,    staticConfig.DB_SSL_CLIENT_KEY.c_str());
     mysql_options(&dbconn, MYSQL_OPT_SSL_CERT,   staticConfig.DB_SSL_CLIENT_CERT.c_str());
     mysql_options(&dbconn, MYSQL_OPT_SSL_CA,     staticConfig.DB_SSL_CA_CERT.c_str());
+    mysql_options(&dbconn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT,     staticConfig.DB_SSL_VERIFY_SERVER_CERT.c_str());
   }
 
   std::string::size_type colonIndex = staticConfig.DB_HOST.find(":");

--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -73,6 +73,7 @@ class DATABASE_CONFIG {
 		'ssl_ca' => ZM_DB_SSL_CA_CERT,
 		'ssl_key' => ZM_DB_SSL_CLIENT_KEY,
 		'ssl_cert' => ZM_DB_SSL_CLIENT_CERT,
+		'ssl_verify_server_cert' => ZM_DB_SSL_VERIFY_SERVER_CERT,
 		'prefix' => '',
 		'encoding' => 'utf8',
 	);

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -55,6 +55,7 @@ function dbConnect() {
         PDO::MYSQL_ATTR_SSL_CA   => ZM_DB_SSL_CA_CERT,
         PDO::MYSQL_ATTR_SSL_KEY  => ZM_DB_SSL_CLIENT_KEY,
         PDO::MYSQL_ATTR_SSL_CERT => ZM_DB_SSL_CLIENT_CERT,
+        PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => ZM_DB_SSL_VERIFY_SERVER_CERT,
       );
       $dbConn = new PDO($dsn, ZM_DB_USER, ZM_DB_PASS, $dbOptions);
     } else {

--- a/zm.conf.in
+++ b/zm.conf.in
@@ -59,6 +59,9 @@ ZM_DB_SSL_CLIENT_KEY=@ZM_DB_SSL_CLIENT_KEY@
 # SSL client cert for ZoneMinder database
 ZM_DB_SSL_CLIENT_CERT=@ZM_DB_SSL_CLIENT_CERT@
 
+# Verify database SSL Cert
+ZM_DB_SSL_VERIFY_SERVER_CERT=@ZM_DB_SSL_VERIFY_SERVER_CERT@
+
 # Do NOT set ZM_SERVER_HOST if you are not using Multi-Server
 # You have been warned
 #


### PR DESCRIPTION
…o allow

deployments to specify whether they wish to verify their database server's certificate or not, mapped to PHP's PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT attribute.

Resolves 3816.