### PR TITLE
ConfigData: default to not checking for updated versions of ZoneMinder

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -2647,9 +2647,9 @@ our @options = (
       website to determine the most recent release. These checks are
       infrequent, about once per week, and no personal or system
       information is transmitted other than your current version
-      number. If you do not wish these checks to take place or your
-      ZoneMinder system has no internet access you can switch these
-      check off with this configuration variable
+      number. If you wish these checks to take place and your
+      ZoneMinder system has internet access you can switch these
+      checks on with this configuration variable
       `,
     type        => $types{boolean},
     category    => 'system',

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -2638,7 +2638,7 @@ our @options = (
   },
   {
     name        => 'ZM_CHECK_FOR_UPDATES',
-    default     => 'yes',
+    default     => 'no',
     description => 'Check with zoneminder.com for updated versions',
     help        => q`
       From ZoneMinder version 1.17.0 onwards new versions are


### PR DESCRIPTION
Users should get updates through the package.
Also prevents "phoning home" to zoneminder.com.