### PR TITLE
On Options -> System , show languages with names not codes/filenames

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -993,9 +993,5 @@ None: No frames will be decoded, live view and thumbnails will not be available~
 //        'Help' => "This is some new help for this option which will be displayed in the window when the ? is clicked"
 //    ),
 );
-// language translations
-$LLANG = array(
-//    'es_la' => 'Español Latam',
-);
 
 ?>

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -651,6 +651,31 @@ $SLANG = array(
     'ZoneExtendAlarmFrames' => 'Extend Alarm Frame Count',
     'ZoomIn'                => 'Zoom In',
     'ZoomOut'               => 'Zoom Out',
+// language names translation
+    'es_la' => 'Spanish Latam',
+    'es_CR' => 'Spanish Costa Rica',
+    'es_ar' => 'Spanish Argentina',
+    'es_es' => 'Spanish Spain',
+    'en_gb' => 'British English',
+    'en_us' => 'Us English',
+    'fr_fr' => 'French',
+    'cs_cz' => 'Czech',
+    'zh_cn' => 'Simplified Chinese',
+    'zh_tw' => 'Traditional Chinese',
+    'de_de' => 'German',
+    'it_it' => 'Italian',
+    'ja_jp' => 'Japanese',
+    'hu_hu' => 'Hungarian',
+    'pl_pl' => 'Polish',
+    'pt_br' => 'Portuguese Brazil',
+    'ru_ru' => 'Russian',
+    'nl_nl' => 'Dutch',
+    'se_se' => 'Sami',
+    'et_ee' => 'Estonian',
+    'he_il' => 'Hebrew',
+    'dk_dk' => 'Danish',
+    'ro_ro' => 'Romanian',
+
 );
 
 // Complex replacements with formatting and/or placements, must be passed through sprintf
@@ -967,6 +992,10 @@ None: No frames will be decoded, live view and thumbnails will not be available~
 //        'Prompt' => "This is a new prompt for this option",
 //        'Help' => "This is some new help for this option which will be displayed in the window when the ? is clicked"
 //    ),
+);
+// language translations
+$LLANG = array(
+//    'es_la' => 'Español Latam',
 );
 
 ?>

--- a/web/lang/es_la.php
+++ b/web/lang/es_la.php
@@ -908,6 +908,30 @@ $SLANG = array(
     'ConfirmDeleteTitle'   => 'Borrar Seleccionados',
     'Continuous'           => 'Continuo',
     'ONVIF_Alarm_Text'      => 'Texto Alarma ONVIF', //added 18/07/2022
+// language names translation
+    'es_la' => 'Español Latam',
+    'es_CR' => 'Español Costa Rica',
+    'es_ar' => 'Español Argentina',
+    'es_es' => 'Español España',
+    'en_gb' => 'Ingles Britanico',
+    'en_us' => 'Ingles Estados Unidos',
+    'fr_fr' => 'Frances',
+    'cs_cz' => 'Checo',
+    'zh_cn' => 'Chino Simplificado',
+    'zh_tw' => 'Chino Tradicional',
+    'de_de' => 'Aleman',
+    'it_it' => 'Italiano',
+    'ja_jp' => 'Japones',
+    'hu_hu' => 'Hungaro',
+    'pl_pl' => 'Polaco',
+    'pt_br' => 'Portugues Brasil',
+    'ru_ru' => 'Ruso',
+    'nl_nl' => 'Holandes',
+    'se_se' => 'Sueco',
+    'et_ee' => 'Estonio',
+    'he_il' => 'Hebreo',
+    'dk_dk' => 'Danes',
+    'ro_ro' => 'Rumano',
 
 );
 

--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -297,10 +297,21 @@ foreach (array_map('basename', glob('skins/'.$skin.'/css/*', GLOB_ONLYDIR)) as $
       'watch' => 'Watch',
     ];
   } else if ($tab == 'system') {
-    $configCats[$tab]['ZM_LANG_DEFAULT']['Hint'] = join('|', getLanguages());
+//    $configCats[$tab]['ZM_LANG_DEFAULT']['Hint'] = join('|', getLanguages());
     $configCats[$tab]['ZM_SKIN_DEFAULT']['Hint'] = join('|', array_map('basename', glob('skins/*',GLOB_ONLYDIR)));
     $configCats[$tab]['ZM_CSS_DEFAULT']['Hint'] = join('|', array_map ( 'basename', glob('skins/'.ZM_SKIN_DEFAULT.'/css/*',GLOB_ONLYDIR) ));
     $configCats[$tab]['ZM_BANDWIDTH_DEFAULT']['Hint'] = $bandwidth_options;
+
+// create new multidim array for languages (code1|translation)
+    $languagecodess=join('|', getLanguages());
+    $languagecodelist=explode('|',$languagecodess);
+    $languageslist = array();
+    foreach ($languagecodelist as $language){
+        $languageslist[$language] = translate($language);
+       }
+
+    $configCats[$tab]['ZM_LANG_DEFAULT']['Hint'] = $languageslist;
+
 
     function timezone_list() {
       static $timezones = null;
@@ -334,7 +345,6 @@ foreach (array_map('basename', glob('skins/'.$skin.'/css/*', GLOB_ONLYDIR)) as $
       return $name;
     }
     $configCats[$tab]['ZM_TIMEZONE']['Hint'] = array(''=> translate('TZUnset')) + timezone_list();
-
     $configCats[$tab]['ZM_LOCALE_DEFAULT']['Hint'] = array(''=> translate('System Default'));
     $locales = ResourceBundle::getLocales('');
     if ($locales) {
@@ -387,7 +397,7 @@ foreach (array_map('basename', glob('skins/'.$skin.'/css/*', GLOB_ONLYDIR)) as $
                 $attributes = ['id'=>$name, 'class'=>'form-control-sm'.(count($html_options)>10?' chosen':'')];
                 if (!$optionCanEdit) $attributes['disabled']='disabled';
                 echo htmlSelect("newConfig[$name]", $html_options, $value['Value'], $attributes);
-              } else {
+              } else { 
                 foreach ($options as $option) {
                   if (preg_match('/^([^=]+)=(.+)$/', $option)) {
                     $optionLabel = $matches[1];


### PR DESCRIPTION
On Options -> System , show languages with names not codes/filenames
Possible implementation for open issue https://github.com/ZoneMinder/zoneminder/issues/3694