### PR TITLE
Add zmDbReconnect, and more!

### DIFF
--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -21,6 +21,7 @@
 #include "zm_logger.h"
 #include "zm_signal.h"
 #include <cstdlib>
+#include <unistd.h>
 
 MYSQL dbconn;
 std::mutex db_mutex;
@@ -94,7 +95,7 @@ bool zmDbConnect() {
     mysql_close(&dbconn);
     return false;
   }
-  if ( mysql_query(&dbconn, "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED") ) {
+  if (mysql_query(&dbconn, "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")) {
     Error("Can't set isolation level: %s", mysql_error(&dbconn));
   }
   mysql_set_character_set(&dbconn, "utf8");

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -103,10 +103,11 @@ bool zmDbConnect() {
   return zmDbConnected;
 }
 
+/* Calls to zmDbReconnect must have the lock. */
 int zmDbReconnect() {
   if (zmDbConnected) {
-    zmDbConnected = false;
     mysql_close(&dbconn);
+    zmDbConnected = false;
   }
   if (zmDbConnect()) {
     Debug(1, "Reconnected to db...");

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -104,7 +104,7 @@ bool zmDbConnect() {
 }
 
 /* Calls to zmDbReconnect must have the lock. */
-int zmDbReconnect() {
+bool zmDbReconnect() {
   if (zmDbConnected) {
     mysql_close(&dbconn);
     zmDbConnected = false;
@@ -114,6 +114,7 @@ int zmDbReconnect() {
   } else {
     Debug(1, "Failed to reconnect to db");
   }
+  return zmDbConnected;
 }
 
 void zmDbClose() {

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -32,12 +32,12 @@ bool zmDbConnected = false;
 bool zmDbConnect() {
   // For some reason having these lines causes memory corruption and crashing on newer debian/ubuntu
 	// But they really need to be here in order to prevent a double open of mysql
-  if ( zmDbConnected )  {
+  if (zmDbConnected)  {
     //Warning("Calling zmDbConnect when already connected");
     return true;
   }
 
-  if ( !mysql_init(&dbconn) ) {
+  if (!mysql_init(&dbconn)) {
     Error("Can't initialise database connection: %s", mysql_error(&dbconn));
     return false;
   }
@@ -104,8 +104,10 @@ bool zmDbConnect() {
 }
 
 int zmDbReconnect() {
-  zmDbConnected = false;
-  mysql_close(&dbconn);
+  if (zmDbConnected) {
+    zmDbConnected = false;
+    mysql_close(&dbconn);
+  }
   if (zmDbConnect()) {
     Debug(1, "Reconnected to db...");
   } else {


### PR DESCRIPTION
Add zmDbReconnect, which closes the connection before trying to reconnect, in an attempt to prevent mem leak.  This adds a 1 sec sleep if we fail to connect. This also removes the disabling of db logging before doing logging... because we are going to assume (possibly incorrectly) that the logging code is correct and generating well-formed sql, and hence the error is external. This might be a bad idea.