### PR TITLE
Fix: Logging levels coloring for languages other than English

### DIFF
--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -114,7 +114,7 @@ function initPage() {
   // Assign inf, err, fat, dbg color classes to the rows in the table
   table.on('post-body.bs.table', function(data) {
     var lvl_ndx = $j('#logTable tr th').filter(function() {
-      return $j(this).text().trim() == 'Level';
+      return $j(this).attr('data-field') == "Code";
     }).index();
 
     $j('#logTable tr').each(function(ndx, row) {


### PR DESCRIPTION
When getting the index, you cannot use text(), because there may be different meaning depending on the language! If the value is different from 'Level', lvl_ndx will not be found and coloring will not work.