### PR TITLE
Added a link to live viewing from monitor event viewer

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -582,6 +582,7 @@ body.sticky #page {
 
 #content table input[type=submit], #content table input[type=button], #content table button, #content table .btn-primary {
     margin-top: 1px;
+    margin-right: 4px;
 }
 
 #contentButtons {

--- a/web/skins/classic/css/base/views/event.css
+++ b/web/skins/classic/css/base/views/event.css
@@ -104,10 +104,10 @@ height: 100%;
 #eventStatsTable {
 }
 #eventVideo {
-  width: 100%; /* flex will make it fill the available space */
+  /* width: 100%; *//* flex will make it fill the available space */
 }
 .eventStats {
-  margin-right: 5px;
+  /* margin-right: 5px; */
 }
 
 #videoFeed {

--- a/web/skins/classic/css/classic/skin.css
+++ b/web/skins/classic/css/classic/skin.css
@@ -416,6 +416,7 @@ th.table-th-sort-rev span.table-th-sort-span {
 #content table button,
 #content table .btn-primary {
     margin-top: 0;
+    margin-right: 4px;
 }
 
 #contentButtons {

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -68,8 +68,8 @@ height: 100%;
 }
 
 #eventVideo {
-   display: inline-block;
-   position: relative;
+   /* display: inline-block;
+   position: relative; */
 }
 
 #imageFeed {

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -68,7 +68,7 @@ height: 100%;
 }
 
 #eventVideo {
-    display: inline-block;
+    /* display: inline-block; */
 }
 
 #imageFeed {

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -613,14 +613,20 @@ function scaleToFit(baseWidth, baseHeight, scaleEl, bottomEl, container) {
   let newHeight = viewPort.height() - (bottomLoc - scaleEl.outerHeight(true));
   console.log("newHeight = " + viewPort.height() +" - " + bottomLoc + ' - ' + scaleEl.outerHeight(true)+'='+newHeight);
   let newWidth = ratio * newHeight;
+  
+  // Let's recalculate everything and reduce the height a little. Necessary if "padding" is specified for "wrapperEventVideo"
+  padding = parseInt(container.css("padding-left")) + parseInt(container.css("padding-right"));
+  newWidth -= padding;
+  newHeight = newWidth / ratio ;
+  
   console.log("newWidth = ", newWidth, "container width:", container.innerWidth());
 
   if (newHeight < 0) {
     // Doesn't fit on screen anyways?
-    newWidth = container.innerWidth();
+    newWidth = container.innerWidth()-padding;
     newHeight = newWidth / ratio;
   } else if (newWidth > container.innerWidth()) {
-    newWidth = container.innerWidth();
+    newWidth = container.innerWidth()-padding;
     newHeight = newWidth / ratio;
   }
   console.log("newWidth = " + newWidth);

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -240,20 +240,22 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
 <!-- BEGIN VIDEO CONTENT ROW -->
     <div id="inner-content">
       <div class="d-flex flex-row px-3">
-        <div class="eventStats">
-          <!-- VIDEO STATISTICS TABLE -->
-          <table id="eventStatsTable" class="table-sm table-borderless">
-            <!-- EVENT STATISTICS POPULATED BY JAVASCRIPT -->
-          </table>
+        <div class="container-fluid">
+          <div class="row row-cols-1 row-cols-sm-2">
+            <div id = "eventStats" class="col col-sm-4 eventStats">
+              <!-- VIDEO STATISTICS TABLE -->
+              <table id="eventStatsTable" class="table-sm table-borderless">
+                <!-- EVENT STATISTICS POPULATED BY JAVASCRIPT -->
+              </table>
 <?php
 if (defined('ZM_OPT_USE_GEOLOCATION') and ZM_OPT_USE_GEOLOCATION) {
 ?>
-          <div id="LocationMap"></div>
+              <div id="LocationMap"></div>
 <?php
 }
 ?>
 
-      <div id="frames">
+              <div id="frames">
 <?php 
 if (file_exists($Event->Path().'/alarm.jpg')) {
   echo '
@@ -277,34 +279,35 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
 ';
 }
 ?>
-      </div>
-        </div>
-        <div id="eventVideo">
-        <!-- VIDEO CONTENT -->
-          <div id="videoFeed">
+              </div><!-- id="frames" -->
+            </div><!-- id="eventStats" -->
+            <div id="wrapperEventVideo" class="col col-sm-8 pl-0 pr-0">
+              <div id="eventVideo">
+              <!-- VIDEO CONTENT -->
+                <div id="videoFeed">
 <?php
 if ($video_tag) {
 ?>
-          <video autoplay id="videoobj" class="video-js vjs-default-skin"
-            style="transform: matrix(1, 0, 0, 1, 0, 0);"
-           <?php echo $scale ? 'width="'.reScale($Event->Width(), $scale).'"' : '' ?>
-           <?php echo $scale ? 'height="'.reScale($Event->Height(), $scale).'"' : '' ?>
-            data-setup='{ "controls": true, "autoplay": true, "preload": "auto", "playbackRates": [ <?php echo implode(',',
-              array_map(function($r){return $r/100;},
-                array_filter(
-                  array_keys($rates),
-                  function($r){return $r >= 0 ? true : false;}
-                ))) ?>], "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'
-          >
-          <source src="<?php echo $Event->getStreamSrc(array('mode'=>'mpeg','format'=>'h264'),'&amp;'); ?>" type="video/mp4">
-          <track id="monitorCaption" kind="captions" label="English" srclang="en" src='data:plain/text;charset=utf-8,"WEBVTT\n\n 00:00:00.000 --> 00:00:01.000 ZoneMinder"' default/>
-          Your browser does not support the video tag.
-          </video>
-        <div id="progressBar" style="width: 100%;">
-          <div id="alarmCues" style="width: 100%;"></div>
-          <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
-          <div id="indicator" style="display: none;"></div>
-        </div><!--progressBar-->
+                  <video autoplay id="videoobj" class="video-js vjs-default-skin"
+                    style="transform: matrix(1, 0, 0, 1, 0, 0);"
+                   <?php echo $scale ? 'width="'.reScale($Event->Width(), $scale).'"' : '' ?>
+                   <?php echo $scale ? 'height="'.reScale($Event->Height(), $scale).'"' : '' ?>
+                    data-setup='{ "controls": true, "autoplay": true, "preload": "auto", "playbackRates": [ <?php echo implode(',',
+                      array_map(function($r){return $r/100;},
+                        array_filter(
+                          array_keys($rates),
+                          function($r){return $r >= 0 ? true : false;}
+                        ))) ?>], "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'
+                  >
+                  <source src="<?php echo $Event->getStreamSrc(array('mode'=>'mpeg','format'=>'h264'),'&amp;'); ?>" type="video/mp4">
+                  <track id="monitorCaption" kind="captions" label="English" srclang="en" src='data:plain/text;charset=utf-8,"WEBVTT\n\n 00:00:00.000 --> 00:00:01.000 ZoneMinder"' default/>
+                  Your browser does not support the video tag.
+                  </video>
+                  <div id="progressBar" style="width: 100%;">
+                    <div id="alarmCues" style="width: 100%;"></div>
+                    <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
+                    <div id="indicator" style="display: none;"></div>
+                  </div><!--progressBar-->
 <?php
 } else {
 if ( (ZM_WEB_STREAM_METHOD == 'mpeg') && ZM_MPEG_LIVE_FORMAT ) {
@@ -321,79 +324,85 @@ if ( (ZM_WEB_STREAM_METHOD == 'mpeg') && ZM_MPEG_LIVE_FORMAT ) {
     validHtmlStr($Event->Name()));
 } // end if stream method
 ?>
-        <div id="progressBar" style="width: 100%;">
-          <div id="alarmCues" style="width: 100%;"></div>
-          <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
-          <div id="indicator" style="display: none;"></div>
-        </div><!--progressBar-->
+                  <div id="progressBar" style="width: 100%;">
+                    <div id="alarmCues" style="width: 100%;"></div>
+                    <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
+                    <div id="indicator" style="display: none;"></div>
+                  </div><!--progressBar-->
 <?php
 } /*end if !DefaultVideo*/
 ?>
-<svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="display:<?php echo $showZones ? 'block' : 'none'; ?>" viewBox="0 0 <?php echo $monitor->ViewWidth().' '.$monitor->ViewHeight() ?>" preserveAspectRatio="none">
+                  <svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="display:<?php echo $showZones ? 'block' : 'none'; ?>" viewBox="0 0 <?php echo $monitor->ViewWidth().' '.$monitor->ViewHeight() ?>" preserveAspectRatio="none">
 <?php
     foreach (ZM\Zone::find(array('MonitorId'=>$monitor->Id()), array('order'=>'Area DESC')) as $zone) {
       echo $zone->svg_polygon();
     } // end foreach zone
 ?>
   Sorry, your browser does not support inline SVG
-</svg>
-        </div><!--videoFeed-->
-        <p id="dvrControls">
-          <button type="button" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" data-on-click-true="streamPrev">
-          <i class="material-icons md-18">skip_previous</i>
-          </button>
-          <button type="button" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" data-on-click-true="streamFastRev">
-          <i class="material-icons md-18">fast_rewind</i>
-          </button>
-          <button type="button" id="slowRevBtn" title="<?php echo translate('StepBack') ?>" class="unavail" disabled="disabled" data-on-click-true="streamSlowRev">
-          <i class="material-icons md-18">chevron_left</i>
-          </button>
-          <button type="button" id="pauseBtn" title="<?php echo translate('Pause') ?>" class="inactive" data-on-click="pauseClicked">
-          <i class="material-icons md-18">pause</i>
-          </button>
-          <button type="button" id="playBtn" title="<?php echo translate('Play') ?>" class="active" disabled="disabled" data-on-click="playClicked">
-          <i class="material-icons md-18">play_arrow</i>
-          </button>
-          <button type="button" id="slowFwdBtn" title="<?php echo translate('StepForward') ?>" class="unavail" disabled="disabled" data-on-click-true="streamSlowFwd">
-          <i class="material-icons md-18">chevron_right</i>
-          </button>
-          <button type="button" id="fastFwdBtn" title="<?php echo translate('FastForward') ?>" class="inactive" data-on-click-true="streamFastFwd">
-          <i class="material-icons md-18">fast_forward</i>
-          </button>
-          <button type="button" id="zoomOutBtn" title="<?php echo translate('ZoomOut') ?>" class="unavail" disabled="disabled" data-on-click="clickZoomOut">
-          <i class="material-icons md-18">zoom_out</i>
-          </button>
-          <button type="button" id="fullscreenBtn" title="<?php echo translate('Fullscreen') ?>" class="avail" data-on-click="fullscreenClicked">
-            <i class="material-icons md-18">fullscreen</i>
-            </button>
-          <button type="button" id="nextBtn" title="<?php echo translate('Next') ?>" class="inactive" data-on-click-true="streamNext">
-          <i class="material-icons md-18">skip_next</i>
-          </button>
-        </p>
-        <div id="replayStatus">
-          <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">Replay</span></span>
-          <span id="rate"><?php echo translate('Rate') ?>: 
+                  </svg>
+                </div><!--videoFeed-->
+                <div class="monitorStatus">
+                  <span class="MonitorName"><?php echo $monitor->Name() . " (". translate('ID'). "=" . $monitor->Id() . ")"; ?>  </span>
+                </div>
+                <p id="dvrControls">
+                  <button type="button" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" data-on-click-true="streamPrev">
+                  <i class="material-icons md-18">skip_previous</i>
+                  </button>
+                  <button type="button" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" data-on-click-true="streamFastRev">
+                  <i class="material-icons md-18">fast_rewind</i>
+                  </button>
+                  <button type="button" id="slowRevBtn" title="<?php echo translate('StepBack') ?>" class="unavail" disabled="disabled" data-on-click-true="streamSlowRev">
+                  <i class="material-icons md-18">chevron_left</i>
+                  </button>
+                  <button type="button" id="pauseBtn" title="<?php echo translate('Pause') ?>" class="inactive" data-on-click="pauseClicked">
+                  <i class="material-icons md-18">pause</i>
+                  </button>
+                  <button type="button" id="playBtn" title="<?php echo translate('Play') ?>" class="active" disabled="disabled" data-on-click="playClicked">
+                  <i class="material-icons md-18">play_arrow</i>
+                  </button>
+                  <button type="button" id="slowFwdBtn" title="<?php echo translate('StepForward') ?>" class="unavail" disabled="disabled" data-on-click-true="streamSlowFwd">
+                  <i class="material-icons md-18">chevron_right</i>
+                  </button>
+                  <button type="button" id="fastFwdBtn" title="<?php echo translate('FastForward') ?>" class="inactive" data-on-click-true="streamFastFwd">
+                  <i class="material-icons md-18">fast_forward</i>
+                  </button>
+                  <button type="button" id="zoomOutBtn" title="<?php echo translate('ZoomOut') ?>" class="unavail" disabled="disabled" data-on-click="clickZoomOut">
+                  <i class="material-icons md-18">zoom_out</i>
+                  </button>
+                  <button type="button" id="fullscreenBtn" title="<?php echo translate('Fullscreen') ?>" class="avail" data-on-click="fullscreenClicked">
+                  <i class="material-icons md-18">fullscreen</i>
+                  </button>
+                  <button type="button" id="nextBtn" title="<?php echo translate('Next') ?>" class="inactive" data-on-click-true="streamNext">
+                  <i class="material-icons md-18">skip_next</i>
+                  </button>
+                </p>
+                <div id="replayStatus">
+                  <span id="mode"><?php echo translate('Mode') ?>: <span id="modeValue">Replay</span></span>
+                  <span id="rate"><?php echo translate('Rate') ?>: 
 <?php 
   #rates are defined in skins/classic/includes/config.php
   echo htmlSelect('rate', $rates, intval($rate), array('id'=>'rateValue'));
 ?>
-          <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
-          <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
-        </div>
-      </div><!--eventVideo-->
-      <div id="EventData" class="EventData">
-      <?php
-        $data = ZM\Event_Data::find(['EventId'=>$Event->Id()]);
-        if (count($data)) {
-          echo '<table class="table table-striped table-hover table-condensed"><thead><tr><th>'.translate('Timestamp').'</th><th>'.translate('Data').'</th></tr></thead><tbody>'.PHP_EOL;
-          foreach ($data as $d) {
-            echo '<tr><td class="Timestamp">'.$d->Timestamp().'</td><td class="Data">'.strip_tags($d->Data()).'</td></tr>'.PHP_EOL;
+                  <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
+                  <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
+                </div>
+              </div><!--eventVideo-->
+            </div><!--wrapperEventVideo-->
+          </div><!-- class="row" -->
+        </div><!-- class="container-fluid" -->
+        <div id="EventData" class="EventData">
+        <?php
+          $data = ZM\Event_Data::find(['EventId'=>$Event->Id()]);
+          if (count($data)) {
+            echo '<table class="table table-striped table-hover table-condensed"><thead><tr><th>'.translate('Timestamp').'</th><th>'.translate('Data').'</th></tr></thead><tbody>'.PHP_EOL;
+            foreach ($data as $d) {
+              echo '<tr><td class="Timestamp">'.$d->Timestamp().'</td><td class="Data">'.strip_tags($d->Data()).'</td></tr>'.PHP_EOL;
+            }
+            echo '</tbody></table>';
           }
-          echo '</tbody></table>';
-        }
-      ?>
-      </div><!--EventData-->
-</div>
+        ?>
+        </div><!--EventData-->
+      </div>
 <?php
 } // end if Event exists
 ?>

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -817,6 +817,10 @@ function eventEdit() {
   window.location.assign("?view=monitor&amp;mid='+eventData.MonitorId+'");
 }
 
+function viewAllEvents() {
+  window.location.assign("?view=events&page=1&filter%5BQuery%5D%5Bterms%5D%5B0%5D%5Battr%5D=Monitor&filter%5BQuery%5D%5Bterms%5D%5B0%5D%5Bop%5D=%3D&filter%5BQuery%5D%5Bterms%5D%5B0%5D%5Bval%5D="+eventData.MonitorId+"&filter%5BQuery%5D%5Bsort_asc%5D=1&filter%5BQuery%5D%5Bsort_field%5D=StartDateTime&filter%5BQuery%5D%5Bskip_locked%5D=&filter%5BQuery%5D%5Blimit%5D=0");
+}
+
 // Called on each event load because each event can be a different width
 function drawProgressBar() {
   var barWidth = $j('#evtStream').width();
@@ -981,9 +985,10 @@ function getStat() {
       case 'MonitorName':
         if (canView["Monitors"]) {
           tdString = '('+ eventData.MonitorId +') '+ eventData.MonitorName+ '&nbsp';
-          tdString += '<div style="display:inline-block">' + '<button id="eventLiveBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="'+translate["Live"]+'" ><i class="fa fa-television"></i></button>';
+          tdString += '<div style="display:inline-block">';
+          tdString += '<button id="eventLiveBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="'+translate["Live"]+'" ><i class="fa fa-television"></i></button>';
           tdString += '<button id="eventEditBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="'+translate["Edit"]+'" ><i class="fa fa-edit"></i></button>';
-          tdString += '<button id="eventEditBtn000" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="'+translate["Edit"]+'" ><i class="fa fa-film"></i></button>';
+          tdString += '<button id="eventAllEvents" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="'+translate["All Events"]+'" ><i class="fa fa-film"></i></button>';
           tdString += '</div>';
         } else {
           tdString = eventData[key];
@@ -1208,17 +1213,22 @@ function initPage() {
   });
 
   // Manage the generate Live button
-  bindButton('#eventLiveBtn', 'click', null, function onVideoClick(evt) {
+  bindButton('#eventLiveBtn', 'click', null, function onLiveClick(evt) {
     evt.preventDefault();
     eventLive();
   });
 
   // Manage the generate Edit button
-  bindButton('#eventEditBtn', 'click', null, function onVideoClick(evt) {
+  bindButton('#eventEditBtn', 'click', null, function onEditClick(evt) {
     evt.preventDefault();
     eventEdit();
   });
 
+  // Manage the generate All Events button
+  bindButton('#eventAllEvents', 'click', null, function onAllEventsClick(evt) {
+    evt.preventDefault();
+    viewAllEvents();
+  });
   // Manage the Event STATISTICS Button
   bindButton('#statsBtn', 'click', null, function onStatsClick(evt) {
     evt.preventDefault();

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -967,7 +967,7 @@ function getStat() {
         break;
       case 'MonitorName':
         if (canView["Monitors"]) {
-          tdString = '<a href="?view=monitor&amp;mid='+eventData.MonitorId+'">'+eventData.MonitorName+'</a>';
+          tdString = '<a href="?view=watch&amp;mid='+eventData.MonitorId+'">'+translate["Live"]+" \""+eventData.MonitorName+'\"</a>';
         } else {
           tdString = eventData[key];
         }

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -110,4 +110,5 @@ var translate = {
   "seconds": "<?php echo translate('seconds') ?>",
   "Fullscreen": "<?php echo translate('Fullscreen') ?>",
   "Exit Fullscreen": "<?php echo translate('Exit Fullscreen') ?>",
+  "Live": "<?php echo translate('Live') ?>",
 };

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -111,4 +111,5 @@ var translate = {
   "Fullscreen": "<?php echo translate('Fullscreen') ?>",
   "Exit Fullscreen": "<?php echo translate('Exit Fullscreen') ?>",
   "Live": "<?php echo translate('Live') ?>",
+  "Edit": "<?php echo translate('Edit') ?>",
 };


### PR DESCRIPTION
1. When viewing events, there is no way to go to a live view of the monitor in real time in one click.
2. But, there are two links to go to the monitor settings.

It was decided to replace one of the links with a transition to live viewing.

![P1040680](https://github.com/ZoneMinder/zoneminder/assets/5006170/aa3881e2-9804-4bce-8893-defa0b1099ea)
