### PR TITLE
Eliminate event progress bar overlap for classic and dark.  (consistent with base)

### DIFF
--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -139,10 +139,14 @@ height: 100%;
 
 #progressBar {
     position: relative;
+    /*
     top: -1.25em;
+    */
     height: 1.25em;
+    /*
     margin: 0 auto -1.25em auto;
-}
+      */
+ }
 
 #progressBar .progressBox {
     transition: width .1s;

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -141,12 +141,12 @@ height: 100%;
     position: relative;
     /*
     top: -1.25em;
-    */
+     */
     height: 1.25em;
     /*
     margin: 0 auto -1.25em auto;
-      */
- }
+     */
+}
 
 #progressBar .progressBox {
     transition: width .1s;

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -140,12 +140,12 @@ height: 100%;
     position: relative;
     /*
     top: -1.25em;
-    */
+     */
     height: 1.25em;
     /*
     margin: 0 auto -1.25em auto;
-      */
- }
+     */
+}
 
 #progressBar .progressBox {
     transition: width .1s;

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -138,10 +138,14 @@ height: 100%;
 
 #progressBar {
     position: relative;
+    /*
     top: -1.25em;
+    */
     height: 1.25em;
+    /*
     margin: 0 auto -1.25em auto;
-}
+      */
+ }
 
 #progressBar .progressBox {
     transition: width .1s;


### PR DESCRIPTION
Keeps the progressBar from overlapping the videojs control on the event view.  This was already done for the base.  This change just updates classic and dark.