### PR TITLE
Fix "overflow-y" for "#monitorList" in console

### DIFF
--- a/web/skins/classic/css/base/views/console.css
+++ b/web/skins/classic/css/base/views/console.css
@@ -118,7 +118,7 @@ form[name="monitorForm"] {
 }
 #monitorList {
   flex: 1 1 auto;
-  overflow-y: scroll;
+/*  overflow-y: scroll; */
 }
 #contentButtons {
   float: none;


### PR DESCRIPTION
For "#monitorList" there is no need to set "overflow-y: scroll;" Otherwise, scrolling will always be displayed.