### PR TITLE
Fix Horizontal scroll bar in live view

### DIFF
--- a/web/skins/classic/css/base/views/watch.css
+++ b/web/skins/classic/css/base/views/watch.css
@@ -5,6 +5,12 @@
 /*  padding-left: 0;
   padding-right: 0;*/
 }
+
+#wrapperMonitor {
+  width: 100%;
+  overflow-x: auto;
+}
+
 #wrapperMonitor .buttons {
   display: inline-block;
 }


### PR DESCRIPTION
When scaling videos larger than the screen size, the horizontal bar was not visible.