### PR TITLE
Add vertical table scroll on Options page

### DIFF
--- a/web/skins/classic/css/base/views/groups.css
+++ b/web/skins/classic/css/base/views/groups.css
@@ -1,5 +1,5 @@
 #contentTable .colSelect {
-    text-align: center;
+  text-align: center;
 }
 
 #contentTable .colSelect input {
@@ -10,5 +10,40 @@
 }
 
 form {
-    padding-top: 2rem;
+  /* padding-top: 2rem; */
 }
+
+/* +++ temporarily, for the best, you probably need to connect options.css and review layers.*/
+:root {
+  --height-block-before-table: 62px; /* Distance from top border of block where table is located to top border of table itself */
+  --indent-bootstrap-row: 15px; /* Adjusting bootstrap class "row" */
+}
+
+body.sticky #options {
+  height: calc(100% - 50px); /* It's bad, but it's temporary */
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+#options {
+  width: 100%;
+}
+
+#optionsContainer {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-top: 15px;
+}
+
+.wrapper-scroll-table {
+  position: absolute;
+  margin-right: calc(var(--indent-bootstrap-row) * -1);
+  margin-left: calc(var(--indent-bootstrap-row) * -1);
+  padding-right: var(--indent-bootstrap-row);
+  padding-left: var(--indent-bootstrap-row);
+  width: 100%;
+  height: calc(100% - var(--height-block-before-table));
+  overflow-x: hidden; 
+  overflow-y: auto; 
+}
+/* --- */

--- a/web/skins/classic/css/base/views/options.css
+++ b/web/skins/classic/css/base/views/options.css
@@ -1,3 +1,8 @@
+:root {
+  --height-block-before-table: 62px; /* Distance from the top border of the block where the table is located to the top border of the table itself */
+  --indent-bootstrap-row: 15px; /* Adjusting bootstrap class "row" */
+}
+
 .chosen-container-single .chosen-single {
   height: calc(1.5em + 0.5rem + 2px);
   line-height: calc(1.5em + 0.5rem + 2px);
@@ -35,6 +40,9 @@ input.large {
 }
 
 #optionsContainer {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-top: 15px;
 }
 
 #options {
@@ -111,7 +119,7 @@ form {
 /*  display: flex;*/
 /*  flex-direction: column;*/
   height: 100%;
-  padding-top: 2rem;
+/*  padding-top: 2rem; */
 }
 
 @media screen and (max-width:767px) {
@@ -153,4 +161,16 @@ input[name="config[dhcp-range][expires]"] {
 }
 textarea.form-control-sm {
   min-height: 3rem;
+}
+
+.wrapper-scroll-table {
+  position: absolute;
+  margin-right: calc(var(--indent-bootstrap-row) * -1);
+  margin-left: calc(var(--indent-bootstrap-row) * -1);
+  padding-right: var(--indent-bootstrap-row);
+  padding-left: var(--indent-bootstrap-row);
+  width: 100%;
+  height: calc(100% - var(--height-block-before-table));
+  overflow-x: hidden; 
+  overflow-y: auto; 
 }

--- a/web/skins/classic/views/_options_servers.php
+++ b/web/skins/classic/views/_options_servers.php
@@ -1,84 +1,88 @@
 <form name="serversForm" method="post" action="?">
-  <div class="row">
-    <div class="col">
-      <table id="contentTable" class="table table-striped"
-          data-click-to-select="true"
-          data-check-on-init="true"
-          data-mobile-responsive="true"
-          data-min-width="562"
-          data-show-export="true"
-          data-show-columns="true"
-          data-uncheckAll="true"
-            data-cookie="true"
-            data-cookie-same-site="Strict"
-            data-cookie-id-table="zmServersTable"
-            data-cookie-expire="2y"
-            data-remember-order="false"
-      >
-        <thead class="thead-highlight">
-          <tr>
-            <th class="colMark"><?php echo translate('Mark') ?></th>
-            <th data-sortable="true" class="colId"><?php echo translate('Id') ?></th>
-            <th data-sortable="true" class="colName"><?php echo translate('Name') ?></th>
-            <th data-sortable="true" class="colUrl"><?php echo translate('Url') ?></th>
-            <th data-sortable="true" class="colPathToIndex"><?php echo translate('PathToIndex') ?></th>
-            <th data-sortable="true" class="colPathToZMS"><?php echo translate('PathToZMS') ?></th>
-            <th data-sortable="true" class="colPathToAPI"><?php echo translate('PathToApi') ?></th>
-            <th data-sortable="true" class="colStatus"><?php echo translate('Status') ?></th>
-            <th data-sortable="true" class="colMonitorCount"><?php echo translate('Monitors') ?></th>
-            <th data-sortable="true" class="colCpuLoad"><?php echo translate('CpuLoad') ?></th>
-            <th data-sortable="true" class="colMemory"><?php echo translate('Free').'/'.translate('Total') . ' ' . translate('Memory') ?></th>
-            <th data-sortable="true" class="colSwap"><?php echo translate('Free').'/'.translate('Total') . ' ' . translate('Swap') ?></th>
-            <th data-sortable="true" class="colStats"><?php echo translate('RunStats') ?></th>
-            <th data-sortable="true" class="colAudit"><?php echo translate('RunAudit') ?></th>
-            <th data-sortable="true" class="colTrigger"><?php echo translate('RunTrigger') ?></th>
-           <th data-sortable="true" class="colEventNotification"><?php echo translate('RunEventNotification') ?></th>
-          </tr>
-        </thead>
-        <tbody>
+  <div id="options">
+    <div class="row">
+      <input type="hidden" name="view" value="<?php echo $view ?>"/>
+      <input type="hidden" name="tab" value="<?php echo $tab ?>"/>
+      <input type="hidden" name="action" value="delete"/>
+      <input type="hidden" name="object" value="server"/>
+      <div class="col">
+        <div id="contentButtons">
+          <button type="button" id="NewServerBtn" value="<?php echo translate('AddNewServer') ?>" disabled="disabled"><?php echo translate('AddNewServer') ?></button>
+          <button type="submit" class="btn-danger" name="deleteBtn" value="Delete" disabled="disabled"><?php echo translate('Delete') ?></button>
+        </div>
+      </div> <!-- .col -->
+    </div> <!-- .row -->
+    <div class="wrapper-scroll-table">
+      <div class="row">
+        <div class="col">
+          <table id="contentTable" class="table table-striped"
+              data-click-to-select="true"
+              data-check-on-init="true"
+              data-mobile-responsive="true"
+              data-min-width="562"
+              data-show-export="true"
+              data-show-columns="true"
+              data-uncheckAll="true"
+              data-cookie="true"
+              data-cookie-same-site="Strict"
+              data-cookie-id-table="zmServersTable"
+              data-cookie-expire="2y"
+              data-remember-order="false"
+          >
+            <thead class="thead-highlight">
+              <tr>
+                <th class="colMark"><?php echo translate('Mark') ?></th>
+                <th data-sortable="true" class="colId"><?php echo translate('Id') ?></th>
+                <th data-sortable="true" class="colName"><?php echo translate('Name') ?></th>
+                <th data-sortable="true" class="colUrl"><?php echo translate('Url') ?></th>
+                <th data-sortable="true" class="colPathToIndex"><?php echo translate('PathToIndex') ?></th>
+                <th data-sortable="true" class="colPathToZMS"><?php echo translate('PathToZMS') ?></th>
+                <th data-sortable="true" class="colPathToAPI"><?php echo translate('PathToApi') ?></th>
+                <th data-sortable="true" class="colStatus"><?php echo translate('Status') ?></th>
+                <th data-sortable="true" class="colMonitorCount"><?php echo translate('Monitors') ?></th>
+                <th data-sortable="true" class="colCpuLoad"><?php echo translate('CpuLoad') ?></th>
+                <th data-sortable="true" class="colMemory"><?php echo translate('Free').'/'.translate('Total') . ' ' . translate('Memory') ?></th>
+                <th data-sortable="true" class="colSwap"><?php echo translate('Free').'/'.translate('Total') . ' ' . translate('Swap') ?></th>
+                <th data-sortable="true" class="colStats"><?php echo translate('RunStats') ?></th>
+                <th data-sortable="true" class="colAudit"><?php echo translate('RunAudit') ?></th>
+                <th data-sortable="true" class="colTrigger"><?php echo translate('RunTrigger') ?></th>
+               <th data-sortable="true" class="colEventNotification"><?php echo translate('RunEventNotification') ?></th>
+              </tr>
+            </thead>
+            <tbody>
 <?php
 $monitor_counts = dbFetchAssoc('SELECT Id,(SELECT COUNT(Id) FROM Monitors WHERE Deleted!=1 AND ServerId=Servers.Id) AS MonitorCount FROM Servers', 'Id', 'MonitorCount');
 foreach (ZM\Server::find() as $Server) {
   $svr_opt = 'class="serverCol" data-sid="'.$Server->Id().'"';
   ?>
-          <tr>
-            <td class="colMark"><input type="checkbox" name="markIds[]" value="<?php echo $Server->Id() ?>" data-on-click-this="configureDeleteButton"<?php if ( !$canEdit ) { ?> disabled="disabled"<?php } ?>/></td>
-            <td class="colId"><?php echo makeLink('#', $Server->Id(), $canEdit, $svr_opt ) ?></td>
-            <td class="colName"><?php echo makeLink('#', validHtmlStr($Server->Name()), $canEdit, $svr_opt ) ?></td>
-            <td class="colUrl"><?php echo makeLink('#', validHtmlStr($Server->Url()), $canEdit, $svr_opt ) ?></td>
-            <td class="colPathToIndex"><?php echo makeLink('#', validHtmlStr($Server->PathToIndex()), $canEdit, $svr_opt ) ?></td>
-            <td class="colPathToZMS"><?php echo makeLink('#', validHtmlStr($Server->PathToZMS()), $canEdit, $svr_opt ) ?></td>
-            <td class="colPathToAPI"><?php echo makeLink('#', validHtmlStr($Server->PathToAPI()), $canEdit, $svr_opt ) ?></td>
-            <td class="colStatus <?php if ( $Server->Status() == 'NotRunning' ) { echo 'danger'; } ?>">
-                <?php echo makeLink('#', validHtmlStr($Server->Status()), $canEdit, $svr_opt) ?></td>
-            <td class="colMonitorCount"><?php echo makeLink('#', validHtmlStr($monitor_counts[$Server->Id()]), $canEdit, $svr_opt) ?></td>
-            <td class="colCpuLoad <?php if ( $Server->CpuLoad() > 5 ) { echo 'danger'; } ?>"><?php echo makeLink('#', $Server->CpuLoad(), $canEdit, $svr_opt) ?></td>
-            <td class="colMemory <?php if ( (!$Server->TotalMem()) or ($Server->FreeMem()/$Server->TotalMem() < .1) ) { echo 'danger'; } ?>">
-                <?php echo makeLink('#', human_filesize($Server->FreeMem()) . ' / ' . human_filesize($Server->TotalMem()), $canEdit, $svr_opt) ?></td>
-            <td class="colSwap <?php if ( (!$Server->TotalSwap()) or ($Server->FreeSwap()/$Server->TotalSwap() < .1) ) { echo 'danger'; } ?>">
-                <?php echo makeLink('#', human_filesize($Server->FreeSwap()) . ' / ' . human_filesize($Server->TotalSwap()) , $canEdit, $svr_opt) ?></td>
-            <td class="colStats"><?php echo makeLink('#', $Server->zmstats() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
-            <td class="colAudit"><?php echo makeLink('#', $Server->zmaudit() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
-            <td class="colTrigger"><?php echo makeLink('#', $Server->zmtrigger() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
-            <td class="colEventNotification"><?php echo makeLink('#', $Server->zmeventnotification() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
-          </tr>
+              <tr>
+                <td class="colMark"><input type="checkbox" name="markIds[]" value="<?php echo $Server->Id() ?>" data-on-click-this="configureDeleteButton"<?php if ( !$canEdit ) { ?> disabled="disabled"<?php } ?>/></td>
+                <td class="colId"><?php echo makeLink('#', $Server->Id(), $canEdit, $svr_opt ) ?></td>
+                <td class="colName"><?php echo makeLink('#', validHtmlStr($Server->Name()), $canEdit, $svr_opt ) ?></td>
+                <td class="colUrl"><?php echo makeLink('#', validHtmlStr($Server->Url()), $canEdit, $svr_opt ) ?></td>
+                <td class="colPathToIndex"><?php echo makeLink('#', validHtmlStr($Server->PathToIndex()), $canEdit, $svr_opt ) ?></td>
+                <td class="colPathToZMS"><?php echo makeLink('#', validHtmlStr($Server->PathToZMS()), $canEdit, $svr_opt ) ?></td>
+                <td class="colPathToAPI"><?php echo makeLink('#', validHtmlStr($Server->PathToAPI()), $canEdit, $svr_opt ) ?></td>
+                <td class="colStatus <?php if ( $Server->Status() == 'NotRunning' ) { echo 'danger'; } ?>">
+                    <?php echo makeLink('#', validHtmlStr($Server->Status()), $canEdit, $svr_opt) ?></td>
+                <td class="colMonitorCount"><?php echo makeLink('#', validHtmlStr($monitor_counts[$Server->Id()]), $canEdit, $svr_opt) ?></td>
+                <td class="colCpuLoad <?php if ( $Server->CpuLoad() > 5 ) { echo 'danger'; } ?>"><?php echo makeLink('#', $Server->CpuLoad(), $canEdit, $svr_opt) ?></td>
+                <td class="colMemory <?php if ( (!$Server->TotalMem()) or ($Server->FreeMem()/$Server->TotalMem() < .1) ) { echo 'danger'; } ?>">
+                    <?php echo makeLink('#', human_filesize($Server->FreeMem()) . ' / ' . human_filesize($Server->TotalMem()), $canEdit, $svr_opt) ?></td>
+                <td class="colSwap <?php if ( (!$Server->TotalSwap()) or ($Server->FreeSwap()/$Server->TotalSwap() < .1) ) { echo 'danger'; } ?>">
+                    <?php echo makeLink('#', human_filesize($Server->FreeSwap()) . ' / ' . human_filesize($Server->TotalSwap()) , $canEdit, $svr_opt) ?></td>
+                <td class="colStats"><?php echo makeLink('#', $Server->zmstats() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
+                <td class="colAudit"><?php echo makeLink('#', $Server->zmaudit() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
+                <td class="colTrigger"><?php echo makeLink('#', $Server->zmtrigger() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
+                <td class="colEventNotification"><?php echo makeLink('#', $Server->zmeventnotification() ? 'yes' : 'no', $canEdit, $svr_opt) ?></td>
+              </tr>
 <?php } #end foreach Server ?>
-        </tbody>
-      </table>
-    </div> <!-- .col -->
-  </div> <!-- .row -->
-  <div class="row">
-    <input type="hidden" name="view" value="<?php echo $view ?>"/>
-    <input type="hidden" name="tab" value="<?php echo $tab ?>"/>
-    <input type="hidden" name="action" value="delete"/>
-    <input type="hidden" name="object" value="server"/>
-    <div class="col">
-      <div id="contentButtons">
-        <button type="button" id="NewServerBtn" value="<?php echo translate('AddNewServer') ?>" disabled="disabled"><?php echo translate('AddNewServer') ?></button>
-        <button type="submit" class="btn-danger" name="deleteBtn" value="Delete" disabled="disabled"><?php echo translate('Delete') ?></button>
-      </div>
-    </div> <!-- .col -->
-  </div> <!-- .row -->
+           </tbody>
+          </table>
+        </div> <!-- .col -->
+      </div> <!-- .row -->
+    </div> <!-- .wrapper-scroll-table -->
+  </div> <!-- .options -->
 </form>
 <script nonce="<?php echo $cspNonce ?>">
 window.addEventListener("DOMContentLoaded",

--- a/web/skins/classic/views/_options_storage.php
+++ b/web/skins/classic/views/_options_storage.php
@@ -1,0 +1,72 @@
+<form name="storageForm" method="post" action="?">
+  <div id="options">
+    <input type="hidden" name="view" value="<?php echo $view ?>"/>
+    <input type="hidden" name="tab" value="<?php echo $tab ?>"/>
+    <input type="hidden" name="action" value="delete"/>
+    <input type="hidden" name="object" value="storage"/>
+    <div class="row">
+      <div class="col">
+        <div id="contentButtons">
+          <button type="button" id="NewStorageBtn" value="<?php echo translate('AddNewStorage') ?>" disabled="disabled"><?php echo translate('AddNewStorage') ?></button>
+          <button type="submit" class="btn-danger" name="deleteBtn" value="Delete" disabled="disabled"><?php echo translate('Delete') ?></button>
+        </div>
+      </div>
+    </div> <!-- .row -->
+    <div class="wrapper-scroll-table">
+      <div class="row">
+        <div class="col overflow-auto">
+          <table id="contentTable" class="table table-striped">
+            <thead class="thead-highlight">
+              <tr>
+                <th class="colId"><?php echo translate('Id') ?></th>
+                <th class="colName"><?php echo translate('Name') ?></th>
+                <th class="colPath"><?php echo translate('Path') ?></th>
+                <th class="colType"><?php echo translate('Type') ?></th>
+                <th class="colScheme"><?php echo translate('StorageScheme') ?></th>
+                <th class="colServer"><?php echo translate('Server') ?></th>
+                <th class="colDiskSpace"><?php echo translate('DiskSpace') ?></th>
+                <th class="colEvents"><?php echo translate('Events') ?></th>
+                <th class="colMark"><?php echo translate('Mark') ?></th>
+              </tr>
+            </thead>
+            <tbody>
+<?php
+  foreach (ZM\Storage::find(null, array('order'=>'lower(Name)')) as $Storage) { 
+    $filter = new ZM\Filter();
+    $filter->addTerm(array('attr'=>'StorageId','op'=>'=','val'=>$Storage->Id()));
+    if (count($user->unviewableMonitorIds())) {
+      $filter = $filter->addTerm(array('cnj'=>'and', 'attr'=>'MonitorId', 'op'=>'IN', 'val'=>$user->viewableMonitorIds()));
+    }
+
+    $str_opt = 'class="storageCol" data-sid="'.$Storage->Id().'"';
+  ?>
+              <tr>
+                <td class="colId"><?php echo makeLink('#', validHtmlStr($Storage->Id()), $canEdit, $str_opt) ?></td>
+                <td class="colName"><?php echo makeLink('#', validHtmlStr($Storage->Name()), $canEdit, $str_opt) ?></td>
+                <td class="colPath"><?php echo makeLink('#', validHtmlStr($Storage->Path()), $canEdit, $str_opt) ?></td>
+                <td class="colType"><?php echo makeLink('#', validHtmlStr($Storage->Type()), $canEdit, $str_opt) ?></td>
+                <td class="colScheme"><?php echo makeLink('#', validHtmlStr($Storage->Scheme()), $canEdit, $str_opt) ?></td>
+                <td class="colServer"><?php echo makeLink('#', validHtmlStr($Storage->Server()->Name()), $canEdit, $str_opt) ?></td>
+                <td class="colDiskSpace"><?php
+    if ($Storage->disk_total_space()) {
+      echo intval(100*$Storage->disk_used_space()/$Storage->disk_total_space()).'% ';
+    }
+    echo human_filesize($Storage->disk_used_space()) . ' of ' . human_filesize($Storage->disk_total_space()) ?></td>
+                <td class="ColEvents"><?php echo makeLink('?view=events'.$filter->querystring(), $Storage->EventCount().' using '.human_filesize($Storage->event_disk_space() ? $Storage->event_disk_space() : 0) ); ?></td>
+                <td class="colMark"><input type="checkbox" name="markIds[]" value="<?php echo $Storage->Id() ?>" data-on-click-this="configureDeleteButton"
+<?php
+    echo ($Storage->EventCount() or !$canEdit) ? ' disabled="disabled"' : '';
+    echo $Storage->EventCount() ? ' title="Can\'t delete as long as there are events stored here."' : '';
+?>
+                /></td>
+              </tr>
+<?php
+  } #end foreach Server
+?>
+            </tbody>
+          </table>
+        </div><!-- .col -->
+      </div> <!-- .row -->
+    </div> <!-- .wrapper-scroll-table -->
+  </div> <!-- .options -->
+</form>

--- a/web/skins/classic/views/_options_users.php
+++ b/web/skins/classic/views/_options_users.php
@@ -5,70 +5,72 @@
   <div id="options">
     <div class="row">
       <div class="col">
-        <table id="contentTable"
-           class="table-sm table-striped"
-           style="display:none;"
-           data-click-to-select="true"
-           data-check-on-init="true"
-           data-mobile-responsive="true"
-           data-min-width="562"
-           data-show-export="true"
-        >
-          <thead class="thead-highlight">
-            <tr>
-              <th class="colMark"><?php echo translate('Mark') ?></th>
-              <th data-sortable="true" class="colUsername"><?php echo translate('Username') ?></th>
-              <th data-sortable="true" class="colEmail"><?php echo translate('Email') ?></th>
-              <th data-sortable="true" class="colLanguage"><?php echo translate('Language') ?></th>
-              <th data-sortable="true" class="colEnabled"><?php echo translate('Enabled') ?></th>
-              <th data-sortable="true" class="colStream"><?php echo translate('Stream') ?></th>
-              <th data-sortable="true" class="colEvents"><?php echo translate('Events') ?></th>
-              <th data-sortable="true" class="colControl"><?php echo translate('Control') ?></th>
-              <th data-sortable="true" class="colMonitors"><?php echo translate('Monitors') ?></th>
-              <th data-sortable="true" class="colGroups"><?php echo translate('Groups') ?></th>
-              <th data-sortable="true" class="colSnapshots"><?php echo translate('Snapshots') ?></th>
-              <th data-sortable="true" class="colSystem"><?php echo translate('System') ?></th>
-              <th data-sortable="true" class="colDevices"><?php echo translate('Devices') ?></th>
-              <th data-sortable="true" class="colBandwidth"><?php echo translate('Bandwidth') ?></th>
-              <?php if ( ZM_OPT_USE_API ) { ?><th class="colAPIEnabled"><?php echo translate('APIEnabled') ?></th><?php } ?>
-            </tr>
-          </thead>
-          <tbody>
-  <?php
-    foreach (ZM\User::find([], ['order'=>'Username']) as $user_row) {
-      ?>
-            <tr>
-              <td class="colMark"><input type="checkbox" name="markUids[]" value="<?php echo $user_row->Id() ?>" data-on-click-this="configureDeleteButton"<?php echo (!$canEdit) ? ' disabled="disabled"' : '' ?>/></td>
-              <td class="colUsername"><?php echo makeLink('?view=user&amp;uid='.$user_row->Id(), validHtmlStr($user_row->Username()).($user->Username()==$user_row->Username()?'*':''), $canEdit) ?></td>
-              <td class="colEmail"><?php echo $user_row->Email()?validHtmlStr($user_row->Email()):'' ?></td>
-              <td class="colLanguage"><?php echo $user_row->Language()?validHtmlStr($user_row->Language()):'default' ?></td>
-              <td class="colEnabled"><?php echo translate($user_row->Enabled()?'Yes':'No') ?></td>
-              <td class="colStream"><?php echo validHtmlStr($user_row->Stream()) ?></td>
-              <td class="colEvents"><?php echo validHtmlStr($user_row->Events()) ?></td>
-              <td class="colControl"><?php echo validHtmlStr($user_row->Control()) ?></td>
-              <td class="colMonitors"><?php echo validHtmlStr($user_row->Monitors()) ?></td>
-              <td class="colGroups"><?php echo validHtmlStr($user_row->Groups()) ?></td>
-              <td class="colSnapshots"><?php echo validHtmlStr($user_row->Snapshots()) ?></td>
-              <td class="colSystem"><?php echo validHtmlStr($user_row->System()) ?></td>
-              <td class="colDevices"><?php echo validHtmlStr($user_row->Devices()) ?></td>
-              <td class="colBandwidth"><?php echo $user_row->MaxBandwidth()?$bandwidth_options[$user_row->MaxBandwidth()]:'&nbsp;' ?></td>
-              <?php if ( ZM_OPT_USE_API ) { ?><td class="colAPIEnabled"><?php echo translate($user_row->APIEnabled()?'Yes':'No') ?></td><?php } ?>
-            </tr>
-  <?php
-  }
-  ?>
-          </tbody>
-        </table>
-      </div><!-- .col -->
-    </div><!-- .row -->
-    <div class="row">
-      <div class="col">
         <div id="contentButtons">
           <?php echo makeButton('?view=user&uid=0', 'AddNewUser', $canEdit); ?>
           <button type="submit" class="btn-danger" name="deleteBtn" value="Delete" disabled="disabled"><?php echo translate('Delete') ?></button>
         </div>
       </div><!-- .col -->
     </div> <!-- .row -->
+    <div class="wrapper-scroll-table">
+      <div class="row">
+        <div class="col">
+          <table id="contentTable"
+             class="table-sm table-striped"
+             style="display:none;"
+             data-click-to-select="true"
+             data-check-on-init="true"
+             data-mobile-responsive="true"
+             data-min-width="562"
+             data-show-export="true"
+          >
+            <thead class="thead-highlight">
+              <tr>
+                <th class="colMark"><?php echo translate('Mark') ?></th>
+                <th data-sortable="true" class="colUsername"><?php echo translate('Username') ?></th>
+                <th data-sortable="true" class="colEmail"><?php echo translate('Email') ?></th>
+                <th data-sortable="true" class="colLanguage"><?php echo translate('Language') ?></th>
+                <th data-sortable="true" class="colEnabled"><?php echo translate('Enabled') ?></th>
+                <th data-sortable="true" class="colStream"><?php echo translate('Stream') ?></th>
+                <th data-sortable="true" class="colEvents"><?php echo translate('Events') ?></th>
+                <th data-sortable="true" class="colControl"><?php echo translate('Control') ?></th>
+                <th data-sortable="true" class="colMonitors"><?php echo translate('Monitors') ?></th>
+                <th data-sortable="true" class="colGroups"><?php echo translate('Groups') ?></th>
+                <th data-sortable="true" class="colSnapshots"><?php echo translate('Snapshots') ?></th>
+                <th data-sortable="true" class="colSystem"><?php echo translate('System') ?></th>
+                <th data-sortable="true" class="colDevices"><?php echo translate('Devices') ?></th>
+                <th data-sortable="true" class="colBandwidth"><?php echo translate('Bandwidth') ?></th>
+                <?php if ( ZM_OPT_USE_API ) { ?><th class="colAPIEnabled"><?php echo translate('APIEnabled') ?></th><?php } ?>
+              </tr>
+            </thead>
+            <tbody>
+  <?php
+    foreach (ZM\User::find([], ['order'=>'Username']) as $user_row) {
+      ?>
+              <tr>
+                <td class="colMark"><input type="checkbox" name="markUids[]" value="<?php echo $user_row->Id() ?>" data-on-click-this="configureDeleteButton"<?php echo (!$canEdit) ? ' disabled="disabled"' : '' ?>/></td>
+                <td class="colUsername"><?php echo makeLink('?view=user&amp;uid='.$user_row->Id(), validHtmlStr($user_row->Username()).($user->Username()==$user_row->Username()?'*':''), $canEdit) ?></td>
+                <td class="colEmail"><?php echo $user_row->Email()?validHtmlStr($user_row->Email()):'' ?></td>
+                <td class="colLanguage"><?php echo $user_row->Language()?validHtmlStr($user_row->Language()):'default' ?></td>
+                <td class="colEnabled"><?php echo translate($user_row->Enabled()?'Yes':'No') ?></td>
+                <td class="colStream"><?php echo validHtmlStr($user_row->Stream()) ?></td>
+                <td class="colEvents"><?php echo validHtmlStr($user_row->Events()) ?></td>
+                <td class="colControl"><?php echo validHtmlStr($user_row->Control()) ?></td>
+                <td class="colMonitors"><?php echo validHtmlStr($user_row->Monitors()) ?></td>
+                <td class="colGroups"><?php echo validHtmlStr($user_row->Groups()) ?></td>
+                <td class="colSnapshots"><?php echo validHtmlStr($user_row->Snapshots()) ?></td>
+                <td class="colSystem"><?php echo validHtmlStr($user_row->System()) ?></td>
+                <td class="colDevices"><?php echo validHtmlStr($user_row->Devices()) ?></td>
+                <td class="colBandwidth"><?php echo $user_row->MaxBandwidth()?$bandwidth_options[$user_row->MaxBandwidth()]:'&nbsp;' ?></td>
+                <?php if ( ZM_OPT_USE_API ) { ?><td class="colAPIEnabled"><?php echo translate($user_row->APIEnabled()?'Yes':'No') ?></td><?php } ?>
+              </tr>
+  <?php
+  }
+  ?>
+            </tbody>
+          </table>
+        </div><!-- .col -->
+      </div><!-- .row -->
+    </div><!-- .wrapper-scroll-table -->
   </div> <!-- #options -->
 <script nonce="<?php echo $cspNonce ?>">
 window.addEventListener("DOMContentLoaded",

--- a/web/skins/classic/views/groups.php
+++ b/web/skins/classic/views/groups.php
@@ -47,24 +47,39 @@ getBodyTopHTML();
   <div id="page">
     <?php echo $navbar = getNavBarHTML(); ?>
     <div id="content" class="row">
-      <div class="col">
+      <div id="optionsContainer" class="col">
         <form name="groupsForm" method="post" action="?">
-          <input type="hidden" name="view" value="groups"/>
-          <input type="hidden" name="action" value="setgroup"/>
-          <div class="row">
-            <div class="col">
-
-              <table id="contentTable" class="major table-sm table-striped">
-                <thead class="thead-highlight">
-                  <tr>
+          <div id="options">
+            <input type="hidden" name="view" value="groups"/>
+            <input type="hidden" name="action" value="setgroup"/>
+            <div class="row">
+              <div class="col">
+                <div id="contentButtons">
+                  <button type="button" value="New" data-on-click="newGroup"<?php echo canEdit('Groups')?'':' disabled="disabled"' ?>>
+                  <i class="material-icons md-18">add_circle</i>
+                  <span class="text"><?php echo translate('New') ?></span>
+                  </button>
+                  <button type="button" name="deleteBtn" value="Delete" data-on-click-this="deleteGroup" disabled="disabled">
+                  <i class="material-icons md-18">delete</i>
+                  <span class="text"><?php echo translate('Delete') ?></span>
+                  </button>
+                </div>
+              </div> <!-- .col -->
+            </div> <!-- .row -->
+            <div class="wrapper-scroll-table">
+              <div class="row">
+                <div class="col">
+                  <table id="contentTable" class="major table-sm table-striped">
+                    <thead class="thead-highlight">
+                      <tr>
 <?php if ( canEdit('Groups') ) { ?>
-                    <th class="colSelect"><?php echo translate('Mark') ?></th>
+                        <th class="colSelect"><?php echo translate('Mark') ?></th>
 <?php } ?>
-                    <th class="colName" colspan="<?php echo $max_depth+1 ?>"><?php echo translate('Name') ?></th>
-                    <th class="colIds"><?php echo translate('Monitors') ?></th>
-                  </tr>
-                </thead>
-                <tbody>
+                        <th class="colName" colspan="<?php echo $max_depth+1 ?>"><?php echo translate('Name') ?></th>
+                        <th class="colIds"><?php echo translate('Monitors') ?></th>
+                      </tr>
+                    </thead>
+                    <tbody>
 <?php
 function group_line( $Group ) {
   global $children;
@@ -93,24 +108,12 @@ if ( isset( $children[null] ) )
   foreach ( $children[null] as $Group )
     echo group_line($Group);
 ?>
-                </tbody>
-              </table>
-            </div> <!-- .col -->
-          </div> <!-- .row -->
-          <div class="row">
-            <div class="col">
-              <div id="contentButtons">
-                <button type="button" value="New" data-on-click="newGroup"<?php echo canEdit('Groups')?'':' disabled="disabled"' ?>>
-                <i class="material-icons md-18">add_circle</i>
-                <span class="text"><?php echo translate('New') ?></span>
-                </button>
-                <button type="button" name="deleteBtn" value="Delete" data-on-click-this="deleteGroup" disabled="disabled">
-                <i class="material-icons md-18">delete</i>
-                <span class="text"><?php echo translate('Delete') ?></span>
-                </button>
-              </div>
-            </div> <!-- .col -->
-          </div> <!-- .row -->
+                    </tbody>
+                  </table>
+                </div> <!-- .col -->
+              </div> <!-- .row -->
+            </div> <!-- .wrapper-scroll-table -->
+          </div><!-- .options -->
         </form>
       </div> <!-- .col -->
     </div> <!-- .row -->

--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -143,78 +143,7 @@ foreach (array_map('basename', glob('skins/'.$skin.'/css/*', GLOB_ONLYDIR)) as $
 } else if ($tab == 'servers') {
   include('_options_servers.php');
 } else if ($tab == 'storage') { 
-?>
-          <form name="storageForm" method="post" action="?">
-            <input type="hidden" name="view" value="<?php echo $view ?>"/>
-            <input type="hidden" name="tab" value="<?php echo $tab ?>"/>
-            <input type="hidden" name="action" value="delete"/>
-            <input type="hidden" name="object" value="storage"/>
-            <div class="col px-0">
-              <div class="row">
-                <div class="col overflow-auto">
-                  <table id="contentTable" class="table table-striped">
-                    <thead class="thead-highlight">
-                      <tr>
-                        <th class="colId"><?php echo translate('Id') ?></th>
-                        <th class="colName"><?php echo translate('Name') ?></th>
-                        <th class="colPath"><?php echo translate('Path') ?></th>
-                        <th class="colType"><?php echo translate('Type') ?></th>
-                        <th class="colScheme"><?php echo translate('StorageScheme') ?></th>
-                        <th class="colServer"><?php echo translate('Server') ?></th>
-                        <th class="colDiskSpace"><?php echo translate('DiskSpace') ?></th>
-                       <th class="colEvents"><?php echo translate('Events') ?></th>
-                        <th class="colMark"><?php echo translate('Mark') ?></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-<?php
-  foreach (ZM\Storage::find(null, array('order'=>'lower(Name)')) as $Storage) { 
-    $filter = new ZM\Filter();
-    $filter->addTerm(array('attr'=>'StorageId','op'=>'=','val'=>$Storage->Id()));
-    if (count($user->unviewableMonitorIds())) {
-      $filter = $filter->addTerm(array('cnj'=>'and', 'attr'=>'MonitorId', 'op'=>'IN', 'val'=>$user->viewableMonitorIds()));
-    }
-
-    $str_opt = 'class="storageCol" data-sid="'.$Storage->Id().'"';
-  ?>
-                      <tr>
-                        <td class="colId"><?php echo makeLink('#', validHtmlStr($Storage->Id()), $canEdit, $str_opt) ?></td>
-                        <td class="colName"><?php echo makeLink('#', validHtmlStr($Storage->Name()), $canEdit, $str_opt) ?></td>
-                        <td class="colPath"><?php echo makeLink('#', validHtmlStr($Storage->Path()), $canEdit, $str_opt) ?></td>
-                        <td class="colType"><?php echo makeLink('#', validHtmlStr($Storage->Type()), $canEdit, $str_opt) ?></td>
-                        <td class="colScheme"><?php echo makeLink('#', validHtmlStr($Storage->Scheme()), $canEdit, $str_opt) ?></td>
-                        <td class="colServer"><?php echo makeLink('#', validHtmlStr($Storage->Server()->Name()), $canEdit, $str_opt) ?></td>
-                        <td class="colDiskSpace"><?php
-    if ($Storage->disk_total_space()) {
-      echo intval(100*$Storage->disk_used_space()/$Storage->disk_total_space()).'% ';
-    }
-    echo human_filesize($Storage->disk_used_space()) . ' of ' . human_filesize($Storage->disk_total_space()) ?></td>
-                        <td class="ColEvents"><?php echo makeLink('?view=events'.$filter->querystring(), $Storage->EventCount().' using '.human_filesize($Storage->event_disk_space() ? $Storage->event_disk_space() : 0) ); ?></td>
-                        <td class="colMark"><input type="checkbox" name="markIds[]" value="<?php echo $Storage->Id() ?>" data-on-click-this="configureDeleteButton"
-<?php
-    echo ($Storage->EventCount() or !$canEdit) ? ' disabled="disabled"' : '';
-    echo $Storage->EventCount() ? ' title="Can\'t delete as long as there are events stored here."' : '';
-?>
-                        /></td>
-                      </tr>
-<?php
-  } #end foreach Server
-?>
-                    </tbody>
-                  </table>
-                </div><!-- .col -->
-              </div> <!-- .row -->
-              <div class="row">
-                <div class="col">
-                  <div id="contentButtons">
-                    <button type="button" id="NewStorageBtn" value="<?php echo translate('AddNewStorage') ?>" disabled="disabled"><?php echo translate('AddNewStorage') ?></button>
-                    <button type="submit" class="btn-danger" name="deleteBtn" value="Delete" disabled="disabled"><?php echo translate('Delete') ?></button>
-                  </div>
-                </div>
-              </div> <!-- .row -->
-            </div> <!-- .col px-0 -->
-          </form>
-<?php
+  include('_options_storage.php');
 } else if ($tab == 'dnsmasq' and file_exists('skins/classic/views/_options_dnsmasq.php')) {
   include('_options_dnsmasq.php');
 } else if ($tab == 'users') {
@@ -320,73 +249,73 @@ foreach (array_map('basename', glob('skins/'.$skin.'/css/*', GLOB_ONLYDIR)) as $
         <div class="row h-100">
           <div id="options">
 <?php
-        if (!isset($configCats[$tab])) {
-          echo 'There are no config entries for category '.$tab.'.<br/>';
-        } else {
-          foreach ($configCats[$tab] as $name=>$value) {
-            $shortName = preg_replace( '/^ZM_/', '', $name );
-            $optionPromptText = !empty($OLANG[$shortName])?$OLANG[$shortName]['Prompt']:$value['Prompt'];
-            $optionCanEdit = $canEdit && !$value['System'];
+          if (!isset($configCats[$tab])) {
+            echo 'There are no config entries for category '.$tab.'.<br/>';
+          } else {
+            foreach ($configCats[$tab] as $name=>$value) {
+              $shortName = preg_replace( '/^ZM_/', '', $name );
+              $optionPromptText = !empty($OLANG[$shortName])?$OLANG[$shortName]['Prompt']:$value['Prompt'];
+              $optionCanEdit = $canEdit && !$value['System'];
 ?>
           <div class="form-group form-row <?php echo $name ?>">
             <label for="<?php echo $name ?>" class="col-md-4 control-label text-md-right"><?php echo $shortName ?></label>
             <div class="col-md">
 <?php   
-            if ($value['Type'] == 'boolean') {
-              echo '<input type="checkbox" id="'.$name.'" name="newConfig['.$name.']" value="1"'.
-              ( $value['Value'] ? ' checked="checked"' : '').
-              ( $optionCanEdit ? '' : ' disabled="disabled"').' />'.PHP_EOL;
-            } else if (is_array($value['Hint'])) {
-              $attributes = ['id'=>$name, 'class'=>'form-control-sm chosen'];
-              if (!$optionCanEdit) $attributes['disabled']='disabled';
-              echo htmlSelect("newConfig[$name]", $value['Hint'], $value['Value'], $attributes);
-            } else if (preg_match('/\|/', $value['Hint'])) {
-              $options = explode('|', $value['Hint']);
-              if (count($options) > 3) {
-                $html_options = array();
-                foreach ($options as $option) {
-                  if (preg_match('/^([^=]+)=(.+)$/', $option, $matches)) {
-                    $html_options[$matches[2]] = $matches[1];
-                  } else {
-                    $html_options[$option] = $option;
-                  }
-                }
-                $attributes = ['id'=>$name, 'class'=>'form-control-sm'.(count($html_options)>10?' chosen':'')];
+              if ($value['Type'] == 'boolean') {
+                echo '<input type="checkbox" id="'.$name.'" name="newConfig['.$name.']" value="1"'.
+                ( $value['Value'] ? ' checked="checked"' : '').
+                ( $optionCanEdit ? '' : ' disabled="disabled"').' />'.PHP_EOL;
+              } else if (is_array($value['Hint'])) {
+                $attributes = ['id'=>$name, 'class'=>'form-control-sm chosen'];
                 if (!$optionCanEdit) $attributes['disabled']='disabled';
-                echo htmlSelect("newConfig[$name]", $html_options, $value['Value'], $attributes);
-              } else { 
-                foreach ($options as $option) {
-                  if (preg_match('/^([^=]+)=(.+)$/', $option)) {
-                    $optionLabel = $matches[1];
-                    $optionValue = $matches[2];
-                  } else {
-                    $optionLabel = $optionValue = $option;
+                echo htmlSelect("newConfig[$name]", $value['Hint'], $value['Value'], $attributes);
+              } else if (preg_match('/\|/', $value['Hint'])) {
+                $options = explode('|', $value['Hint']);
+                if (count($options) > 3) {
+                  $html_options = array();
+                  foreach ($options as $option) {
+                    if (preg_match('/^([^=]+)=(.+)$/', $option, $matches)) {
+                      $html_options[$matches[2]] = $matches[1];
+                    } else {
+                      $html_options[$option] = $option;
+                    }
                   }
+                  $attributes = ['id'=>$name, 'class'=>'form-control-sm'.(count($html_options)>10?' chosen':'')];
+                  if (!$optionCanEdit) $attributes['disabled']='disabled';
+                  echo htmlSelect("newConfig[$name]", $html_options, $value['Value'], $attributes);
+                } else { 
+                  foreach ($options as $option) {
+                    if (preg_match('/^([^=]+)=(.+)$/', $option)) {
+                      $optionLabel = $matches[1];
+                      $optionValue = $matches[2];
+                    } else {
+                      $optionLabel = $optionValue = $option;
+                    }
 ?>
                   <label class="font-weight-bold form-control-sm">
                     <input type="radio" id="<?php echo $name.'_'.preg_replace('/[^a-zA-Z0-9]/', '', $optionValue) ?>" name="newConfig[<?php echo $name ?>]" value="<?php echo $optionValue ?>"<?php if ( $value['Value'] == $optionValue ) { ?> checked="checked"<?php } ?><?php echo $optionCanEdit?'':' disabled="disabled"' ?>/>
                     <?php echo htmlspecialchars($optionLabel) ?>
                   </label>
 <?php
-                } # end foreach option
-              } # end if count options > 3
-            } else if ( $value['Type'] == 'text' ) {
-              echo '<textarea class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" rows="5" cols="40"'.($optionCanEdit?'':' disabled="disabled"').'>'.validHtmlStr($value['Value']).'</textarea>'.PHP_EOL;
-            } else if ( $value['Type'] == 'integer' ) {
-              echo '<input type="number" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).' step="1"/>'.PHP_EOL;
-            } else if ( $value['Type'] == 'hexadecimal' ) {
-              echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
-            } else if ( $value['Type'] == 'decimal' ) {
-              echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
-            } else if ( $value['Type'] == 'password' ) {
-              echo '<input type="password" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
-              echo '<span class="material-icons md-18" data-on-click-this="toggle_password_visibility" data-password-input="'.$name.'">visibility</span>';
-            } else {
-              echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
-            }
-            if ($value['Value'] != constant($name)) {
-              echo '<p class="warning">Note: This value has been overriden via configuration files in '.ZM_CONFIG. ' or ' . ZM_CONFIG_SUBDIR.'.<br/>The overriden value is: '.constant($name).'</p>'.PHP_EOL;
-            }
+                  } # end foreach option
+                } # end if count options > 3
+              } else if ( $value['Type'] == 'text' ) {
+                echo '<textarea class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" rows="5" cols="40"'.($optionCanEdit?'':' disabled="disabled"').'>'.validHtmlStr($value['Value']).'</textarea>'.PHP_EOL;
+              } else if ( $value['Type'] == 'integer' ) {
+                echo '<input type="number" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).' step="1"/>'.PHP_EOL;
+              } else if ( $value['Type'] == 'hexadecimal' ) {
+                echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
+              } else if ( $value['Type'] == 'decimal' ) {
+                echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
+              } else if ( $value['Type'] == 'password' ) {
+                echo '<input type="password" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
+                echo '<span class="material-icons md-18" data-on-click-this="toggle_password_visibility" data-password-input="'.$name.'">visibility</span>';
+              } else {
+                echo '<input type="text" class="form-control-sm" id="'.$name.'" name="newConfig['.$name.']" value="'.validHtmlStr($value['Value']).'" '.($optionCanEdit?'':' disabled="disabled"' ).'/>'.PHP_EOL;
+              }
+              if ($value['Value'] != constant($name)) {
+                echo '<p class="warning">Note: This value has been overriden via configuration files in '.ZM_CONFIG. ' or ' . ZM_CONFIG_SUBDIR.'.<br/>The overriden value is: '.constant($name).'</p>'.PHP_EOL;
+              }
 ?>
               <span class="form-text form-control-sm"><?php echo validHtmlStr($optionPromptText); echo makeHelpLink($name) ?></span>
             </div><!-- End .col-md -->


### PR DESCRIPTION
Add wrapper fo scroll table & remove padding-top from "form" & add padding to #optionsContainer

When sticky mode is enabled, the table must be scrolled vertically if it does not fit on the page. It may not be the best option, but now it is necessary. For example, for the pages "Servers, Storage, Groups", etc.

Changing the padding-top is necessary to maintain a single style if there are some other elements in front of the form (buttons for example) or there is nothing in front of the form.

It will be like this:
![170](https://github.com/ZoneMinder/zoneminder/assets/5006170/d0f6bb5b-5a03-4248-a737-ba4b32edff74)
![171](https://github.com/ZoneMinder/zoneminder/assets/5006170/fcbd5933-5208-4032-ba8b-21abefa793b4)
