### PR TITLE
Fix: Tracking the "shift" button press on live view page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -605,7 +605,7 @@ function handleClick(event) {
   const y = parseInt((event.pageY - pos.top) * scaleY);
 
   if (showMode == 'events' || !imageControlMode) {
-    if ( event.shift ) {
+    if ( event.shift || event.shiftKey ) {
       streamCmdPan(x, y);
     } else if (event.ctrlKey) {
       streamCmdZoomOut();


### PR DESCRIPTION
Necessary for moving the frame without scaling.