### PR TITLE
Fix: Location of PTZ Controls buttons when scaling browser less than 100%

### DIFF
--- a/web/skins/classic/css/base/views/control.css
+++ b/web/skins/classic/css/base/views/control.css
@@ -100,9 +100,66 @@
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .arrowBtn {
-    width: calc(32px - 0.1rem); /* ( - 0.1rem) Necessary for correct operation at browser scale less than 100% */
-    height: calc(32px - 0.1rem);
+    width: 32px;
+    height: 32px;
     cursor: pointer;
+}
+.pantiltButtons {
+    position: relative;
+}
+
+.arrowBtn {
+    position: absolute;
+}
+
+.arrowBtn.upLeftBtn {
+    left: 0;
+    top: 0;
+}
+
+.arrowBtn.upBtn {
+    left: 33px;
+    top: 0;
+}
+
+.arrowBtn.upRightBtn {
+    left: 66px;
+    top: 0;
+}
+
+.arrowBtn.leftBtn {
+    left: 0;
+    top: 33px;
+}
+
+.arrowBtn.centerBtn {
+    left: 33px;
+    top: 33px;
+}
+
+.arrowBtn.centerBtn {
+    left: 33px;
+    top: 33px;
+}
+
+.arrowBtn.rightBtn {
+    left: 66px;
+    top: 33px;
+}
+
+.arrowBtn.downLeftBtn {
+    left: 0;
+    top: 66px;
+}
+
+.arrowBtn.downBtn {
+    left: 33px;
+    top: 66px;
+}
+
+.arrowBtn.downRightBtn {
+    left: 66px;
+    top: 66px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .upLeftBtn {

--- a/web/skins/classic/css/base/views/control.css
+++ b/web/skins/classic/css/base/views/control.css
@@ -85,7 +85,7 @@
 
 .ptzControls .controlsPanel .pantiltPanel {
     margin: 0 auto;
-    width: 100px;
+    /* width: 100px; */ /* Probably unnecessary */
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .pantiltButtons {
@@ -100,8 +100,8 @@
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .arrowBtn {
-    width: 32px;
-    height: 32px;
+    width: calc(32px - 0.1rem); /* ( - 0.1rem) Necessary for correct operation at browser scale less than 100% */
+    height: calc(32px - 0.1rem);
     cursor: pointer;
 }
 

--- a/web/skins/classic/css/base/views/control.css
+++ b/web/skins/classic/css/base/views/control.css
@@ -112,90 +112,58 @@
     position: absolute;
 }
 
-.arrowBtn.upLeftBtn {
-    left: 0;
-    top: 0;
-}
-
-.arrowBtn.upBtn {
-    left: 33px;
-    top: 0;
-}
-
-.arrowBtn.upRightBtn {
-    left: 66px;
-    top: 0;
-}
-
-.arrowBtn.leftBtn {
-    left: 0;
-    top: 33px;
-}
-
-.arrowBtn.centerBtn {
-    left: 33px;
-    top: 33px;
-}
-
-.arrowBtn.centerBtn {
-    left: 33px;
-    top: 33px;
-}
-
-.arrowBtn.rightBtn {
-    left: 66px;
-    top: 33px;
-}
-
-.arrowBtn.downLeftBtn {
-    left: 0;
-    top: 66px;
-}
-
-.arrowBtn.downBtn {
-    left: 33px;
-    top: 66px;
-}
-
-.arrowBtn.downRightBtn {
-    left: 66px;
-    top: 66px;
-}
-
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .upLeftBtn {
     background: url("../skins/classic/graphics/arrow-ul.png") no-repeat 0 0;
+    left: 0;
+    top: 0;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .upBtn {
     background: url("../skins/classic/graphics/arrow-u.png") no-repeat 0 0;
+    left: 33px;
+    top: 0;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .upRightBtn {
     background: url("../skins/classic/graphics/arrow-ur.png") no-repeat 0 0;
+    left: 66px;
+    top: 0;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .leftBtn {
     background: url("../skins/classic/graphics/arrow-l.png") no-repeat 0 0;
+    left: 0;
+    top: 33px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .centerBtn {
     background: url("../skins/classic/graphics/center.png") no-repeat 0 0;
+    left: 33px;
+    top: 33px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .rightBtn {
     background: url("../skins/classic/graphics/arrow-r.png") no-repeat 0 0;
+    left: 66px;
+    top: 33px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .downLeftBtn {
     background: url("../skins/classic/graphics/arrow-dl.png") no-repeat 0 0;
+    left: 0;
+    top: 66px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .downBtn {
     background: url("../skins/classic/graphics/arrow-d.png") no-repeat 0 0;
+    left: 33px;
+    top: 66px;
 }
 
 .ptzControls .controlsPanel .pantiltPanel .pantiltControls .downRightBtn {
     background: url("../skins/classic/graphics/arrow-dr.png") no-repeat 0 0;
+    left: 66px;
+    top: 66px;
 }
 
 .ptzControls .controlsPanel .powerControls,

--- a/web/skins/classic/css/base/views/control.css
+++ b/web/skins/classic/css/base/views/control.css
@@ -104,6 +104,7 @@
     height: 32px;
     cursor: pointer;
 }
+
 .pantiltButtons {
     position: relative;
 }


### PR DESCRIPTION
Possible fix #3877