### PR TITLE
feat(narrow): Remove entire header when narrow

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -524,6 +524,19 @@ body.sticky #page {
   }
 }
 
+@media screen and (max-width:500px) {
+  .eventStats,
+  #navbar-one,
+  #navbar-two,
+  #exportBtn,
+  #downloadBtn,
+  #videoBtn,
+  #statsBtn,
+  #fullscreenBtn,
+  #zoomOutBtn {
+    display: none;
+  }
+}
 
 #header h2 {
     left: 0;


### PR DESCRIPTION
When in viewing on a narrow screen (mobile in portrait mode), remove the navbar and a couple of the event buttons to make it display nicer.  The user can easily rotate to landscape mode to get them back.