### PR TITLE
fix(): Typo

### DIFF
--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -224,7 +224,7 @@ function getNormalNavBarHTML($running, $user, $bandwidth_options, $view, $skin) 
       <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-two" aria-expanded="true">
         <span class="sr-only">Toggle guages</span>
         <span class="navbar-toggler-icon">
-          <i class="material-icons md-20">monitoring</i>
+          <i class="material-icons md-20">monitor</i>
         </span>
       </button>
 <!--


### PR DESCRIPTION
Current icon looks like this when clicked:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/40be9e4f-f318-4c6a-bbb6-0dc4b22a0759)

After change, icon looks like this when clicked:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/31a35f00-8b0f-4167-9152-aa5d01bf8663)
