### PR TITLE
fix(events): Expand/Collapse for navbar-two works when narrow

### DIFF
--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -221,7 +221,7 @@ function getNormalNavBarHTML($running, $user, $bandwidth_options, $view, $skin) 
           <i class="material-icons md-20">menu</i>
         </span>
       </button>
-      <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-two" aria-expanded="true">
+      <button id="flipNarrow" type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar-two" aria-expanded="true">
         <span class="sr-only">Toggle guages</span>
         <span class="navbar-toggler-icon">
           <i class="material-icons md-20">monitor</i>

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -274,7 +274,10 @@ if ( currentView != 'none' && currentView != 'login' ) {
     // Update update reminders when the user makes a selection from the dropdown
     reminderClickFunction();
     // Manage the widget bar minimize chevron
-    $j("#flip").click(function() {
+    $j("#flip").click(navbarTwoFlip);
+    $j("#flipNarrow").click(navbarTwoFlip);
+
+    function navbarTwoFlip() {
       $j("#navbar-two").slideToggle("slow");
       const flip = $j("#flip");
       if ( flip.html() == 'keyboard_arrow_up' ) {
@@ -284,7 +287,7 @@ if ( currentView != 'none' && currentView != 'login' ) {
         flip.html('keyboard_arrow_up');
         setCookie('zmHeaderFlip', 'up');
       }
-    });
+    }
 
     // Manage visible object & control button (when pressing a button)
     $j("[data-flip-сontrol-object]").click(function() {


### PR DESCRIPTION
Fixed the flip button for navbar-two when in narrow mode.  It now honors the cookie in both narrow and wide displays.