### PR TITLE
Fix: removed unnecessary parameter

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -68,7 +68,6 @@ body.sticky {
   display: flex;
   flex-flow: column nowrap;
   flex-direction: column;
-  height: 100%;
 }
 
 h1 {


### PR DESCRIPTION
Height has already been determined:

html,
body {
  height: 100%;
  margin: 0;
}