### PR TITLE
Fix: Add monitors to the filter only if the filter limit is set

### DIFF
--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -174,14 +174,21 @@ $html .= '</span>
   $html .= '</span>
 ';
 
-  $sql = 'SELECT M.*, S.*, E.*
+  $sqlAll = 'SELECT M.*, S.*, E.*
   FROM Monitors AS M
- LEFT JOIN Monitor_Status AS S ON S.MonitorId=M.Id 
- LEFT JOIN Event_Summaries AS E ON E.MonitorId=M.Id 
-WHERE M.`Deleted`=false
-' .
-  ( count($conditions) ? ' AND ' . implode(' AND ', $conditions) : '' ).' ORDER BY Sequence ASC';
-  $monitors = dbFetchAll($sql, null, $values);
+  LEFT JOIN Monitor_Status AS S ON S.MonitorId=M.Id 
+  LEFT JOIN Event_Summaries AS E ON E.MonitorId=M.Id 
+  WHERE M.`Deleted`=false';
+  $sqlSelected = $sqlAll . ( count($conditions) ? ' AND ' . implode(' AND ', $conditions) : '' ).' ORDER BY Sequence ASC';
+  $monitors = dbFetchAll($sqlSelected, null, $values);
+
+  $colAllAvailableMonitors = 0;
+  foreach ( dbFetchAll($sqlAll) as $row ) {
+    if ( visibleMonitor($row['Id']) ) { #We count only available monitors.
+      ++$colAllAvailableMonitors;
+    }
+  }  
+  
   $displayMonitors = array();
   $monitors_dropdown = array();
 

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -255,7 +255,7 @@ ob_start();
       $filter = addFilterTerm(
         $eventCounts[$i]['filter'],
         count($eventCounts[$i]['filter']['Query']['terms']),
-        gettype ($_SESSION['MonitorId']) == "array" #Add monitors to the filter only if they are selected in select
+        count($displayMonitorIds) != $colAllAvailableMonitors #Add monitors to the filter only if the filter limit is set
           ? array(
             'cnj'=>'and',
             'attr'=>'Monitor',


### PR DESCRIPTION
My previous PR #3895 did not analyze the Group, Capturing, Analysing, etc. filters, but only took into account the Monitor filter
