### PR TITLE
fix(): Accommodate commit 6f5d51c

### DIFF
--- a/web/skins/classic/css/base/views/events.css
+++ b/web/skins/classic/css/base/views/events.css
@@ -104,4 +104,7 @@ body.sticky #eventTable thead {
   label {
     text-wrap: nowrap;
   }
+  input.hasDatepicker {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
[Yesterday's commit](https://github.com/ZoneMinder/zoneminder/commit/6f5d51c45fef91ca175dbcf3f2ede11de5d87050) didn't account for narrow view.