### PR TITLE
Feat: Change scrollbar style for dark css

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -21,6 +21,11 @@
  * Primary look and feel styles
  */
 
+:root {
+  --scrollbarBG: #CFD8DC;
+  --sliderBG: #95AFC0;
+}
+
 body {
     color: #dddddd;
     background-color: #222222;
@@ -272,4 +277,24 @@ ul.nav.nav-pills.flex-column {
 
 .hlight{
   background:#444444;
+}
+/* Change scrollbar style */
+div::-webkit-scrollbar, nav::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+
+div, nav {
+  scrollbar-width: thin;
+  scrollbar-color: var(--sliderBG) var(--scrollbarBG);
+}
+
+div::-webkit-scrollbar-track, nav::-webkit-scrollbar-track {
+  background: var(--scrollbarBG);
+}
+
+div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb {
+  background-color: var(--sliderBG);
+  border-radius: 6px;
+  border: 3px solid var(--scrollbarBG);
 }

--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -280,22 +280,23 @@ ul.nav.nav-pills.flex-column {
 }
 
 /* Change scrollbar style */
-div::-webkit-scrollbar, nav::-webkit-scrollbar, .chosen-results::-webkit-scrollbar {
+::-webkit-scrollbar, div::-webkit-scrollbar, nav::-webkit-scrollbar, .chosen-results::-webkit-scrollbar {
   width: 11px;
   height: 11px;
 }
 
-div, nav, .chosen-results {
+html, body, div, nav, .chosen-results {
   scrollbar-width: thin;
   scrollbar-color: var(--sliderBG) var(--scrollbarBG);
 }
 
-div::-webkit-scrollbar-track, nav::-webkit-scrollbar-track, .chosen-results::-webkit-scrollbar-track {
+::-webkit-scrollbar-track, div::-webkit-scrollbar-track, nav::-webkit-scrollbar-track, .chosen-results::-webkit-scrollbar-track {
   background: var(--scrollbarBG);
 }
 
-div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb, .chosen-results::-webkit-scrollbar-thumb {
+::-webkit-scrollbar-thumb, div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb, .chosen-results::-webkit-scrollbar-thumb {
   background-color: var(--sliderBG);
   border-radius: 6px;
   border: 3px solid var(--scrollbarBG);
 }
+

--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -278,22 +278,23 @@ ul.nav.nav-pills.flex-column {
 .hlight{
   background:#444444;
 }
+
 /* Change scrollbar style */
-div::-webkit-scrollbar, nav::-webkit-scrollbar {
+div::-webkit-scrollbar, nav::-webkit-scrollbar, .chosen-results::-webkit-scrollbar {
   width: 11px;
   height: 11px;
 }
 
-div, nav {
+div, nav, .chosen-results {
   scrollbar-width: thin;
   scrollbar-color: var(--sliderBG) var(--scrollbarBG);
 }
 
-div::-webkit-scrollbar-track, nav::-webkit-scrollbar-track {
+div::-webkit-scrollbar-track, nav::-webkit-scrollbar-track, .chosen-results::-webkit-scrollbar-track {
   background: var(--scrollbarBG);
 }
 
-div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb {
+div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb, .chosen-results::-webkit-scrollbar-thumb {
   background-color: var(--sliderBG);
   border-radius: 6px;
   border: 3px solid var(--scrollbarBG);


### PR DESCRIPTION
I'm not sure about changing the style of the scrollbar, but I thought the dark theme made the scrollbar look too prominent.
I decided to change it a little.
Tested in Chrome and Firefox.
![1](https://github.com/ZoneMinder/zoneminder/assets/5006170/5d4aa4ae-d4a3-4d5c-a28d-23a855c8a026)
![2](https://github.com/ZoneMinder/zoneminder/assets/5006170/6d181b68-bc11-43f3-9d12-d3888dbd7985)
