### PR TITLE
feat(): Term layout

### DIFF
--- a/web/skins/classic/css/base/views/events.css
+++ b/web/skins/classic/css/base/views/events.css
@@ -84,10 +84,20 @@ body.sticky #eventTable thead {
   position: sticky;
   top: -1px;
 }
+
+.term {
+  display: flex;
+  flex-direction: column;
+}
+.term-value, .chosen-container{
+  width: 100% !important;
+  margin-left: 5px;
+}
+
 @media screen and (max-width:500px) {
   .term {
     width: 100%;
-    display: flex;
+    flex-direction: row;
   }
   .term-label-wrapper {
     text-wrap: nowrap;
@@ -96,10 +106,6 @@ body.sticky #eventTable thead {
   .term-value-wrapper {
     width: 100%;
     flex-grow: 1;
-  }
-  .term-value, .chosen-container{
-    width: 100% !important;
-    margin-left: 5px;
   }
   label {
     text-wrap: nowrap;


### PR DESCRIPTION
Changed the term layout from:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/91726f94-f8d7-46ed-8873-b114ce8bc730)


to:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/be05f8da-b78c-4e8e-927f-4d4ca1d28d1d)
