### PR TITLE
Fix: calculating scaleX/Y in handleClick(event) => skins\classic\views\js\watch.js

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -598,8 +598,8 @@ function handleClick(event) {
   const width = target.width();
   const height = target.height();
 
-  const scaleX = parseInt(monitorWidth / width);
-  const scaleY = parseInt(monitorHeight / height);
+  const scaleX = parseFloat(monitorWidth / width);
+  const scaleY = parseFloat(monitorHeight / height);
   const pos = target.offset();
   const x = parseInt((event.pageX - pos.left) * scaleX);
   const y = parseInt((event.pageY - pos.top) * scaleY);


### PR DESCRIPTION

Cannot round to a whole number, otherwise navigation through  image to the extreme corners is not possible!