### PR TITLE
feat(): Term fields spacing for both console and events

### DIFF
--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1245,7 +1245,7 @@ class Filter extends ZM_Object {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $storageareas, $term['val'],
             ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
-              $html .= '</span>';
+          $html .= '</span>';
         } else if ( $term['attr'] == 'AlarmedZoneId' ) {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $zones, $term['val'],

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1151,7 +1151,8 @@ class Filter extends ZM_Object {
 
 
         } else if ( $term['attr'] == 'DateTime' || $term['attr'] == 'StartDateTime' || $term['attr'] == 'EndDateTime') {
-          $html .= '<span class="term-value-wrapper"><input type="text" class="term-value datetimepicker" name="filter[Query][terms]['.$i.'][val]"';
+          $html .= '<span class="term-value-wrapper">';
+          $html .= '<input type="text" class="term-value datetimepicker" name="filter[Query][terms]['.$i.'][val]"';
           if (isset($term['id'])) {
             $html .= ' id="'.$term['id'].'"';
           } else {
@@ -1164,9 +1165,11 @@ class Filter extends ZM_Object {
           $html .= ' value="'.(isset($term['val'])?validHtmlStr(str_replace('T', ' ', $term['val'])):'').'"';
 
           if (!isset($term['placeholder'])) $term['placeholder'] = translate('Attr'.$term['attr']);
-          $html .= ' placeholder="'.$term['placeholder'].'"/></span>'.PHP_EOL;
+          $html .= ' placeholder="'.$term['placeholder'].'"/>'.PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'Date' || $term['attr'] == 'StartDate' || $term['attr'] == 'EndDate' ) {
-          $html .= '<span class="term-value-wrapper"><input type="text" class="term-value datepicker" name="filter[Query][terms]['.$i.'][val]" id="filter[Query][terms]['.$i.'][val]"';
+          $html .= '<span class="term-value-wrapper">';
+          $html .= '<input type="text" class="term-value datepicker" name="filter[Query][terms]['.$i.'][val]" id="filter[Query][terms]['.$i.'][val]"';
           if (isset($term['cookie'])) {
             if (!$term['val'] and isset($_COOKIE[$term['cookie']])) $term['val'] = $_COOKIE[$term['cookie']];
             $html .= ' data-cookie="'.$term['cookie'].'"';
@@ -1174,7 +1177,9 @@ class Filter extends ZM_Object {
           $html .= ' value="'.(isset($term['val'])?validHtmlStr($term['val']):'').'" placeholder="'.translate('Attr'.$term['attr']).'"';
           $html .= '/></span>'.PHP_EOL;
         } else if ( $term['attr'] == 'StartTime' || $term['attr'] == 'EndTime' ) {
-          $html .= '<span class="term-value-wrapper"><input type="text" name="filter[Query][terms]['.$i.'][val]" id="filter[Query][terms]['.$i.'][val]" value="'.(isset($term['val'])?validHtmlStr(str_replace('T', ' ', $term['val'])):'' ).'"/></span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= '<input type="text" name="filter[Query][terms]['.$i.'][val]" id="filter[Query][terms]['.$i.'][val]" value="'.(isset($term['val'])?validHtmlStr(str_replace('T', ' ', $term['val'])):'' ).'"/>'.PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'ExistsInFileSystem' ) {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $booleanValues, $term['val'], ['class'=>'chosen chosen-auto-width']).PHP_EOL;
@@ -1186,7 +1191,7 @@ class Filter extends ZM_Object {
             ['class'=>'term-value chosen chosen-auto-width',
             'multiple'=>'multiple', 
             'data-placeholder'=>translate('All Groups')]).PHP_EOL;
-            $html .= '</span>';
+          $html .= '</span>';
         } else if ( $term['attr'] == 'StateId' ) {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $states, $term['val'], ['class'=>'chosen chosen-auto-width']).PHP_EOL;
@@ -1231,7 +1236,7 @@ class Filter extends ZM_Object {
         } else if ( $term['attr'] == 'ServerId' || $term['attr'] == 'MonitorServerId' || $term['attr'] == 'StorageServerId' || $term['attr'] == 'FilterServerId' ) {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $servers, $term['val'],
-          ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+            ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
           $html .= '</span>';
         } else if ( ($term['attr'] == 'StorageId') || ($term['attr'] == 'SecondaryStorageId') ) {
           if (!$storageareas) {
@@ -1239,12 +1244,12 @@ class Filter extends ZM_Object {
           }
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $storageareas, $term['val'],
-              ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+            ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
               $html .= '</span>';
         } else if ( $term['attr'] == 'AlarmedZoneId' ) {
           $html .= '<span class="term-value-wrapper">';
           $html .= htmlSelect("filter[Query][terms][$i][val]", $zones, $term['val'],
-              ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+            ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
           $html .= '</span>';
         } else if ( $term['attr'] == 'Notes' ) {
           $attrs = ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('Event Type')];
@@ -1273,7 +1278,9 @@ class Filter extends ZM_Object {
           $html .= '</span>';
         } else {
           #$html .= $term['attr'];
-          $html .= '<span class="term-value-wrapper"><input  class="term-value"type="text" name="filter[Query][terms]['.$i.'][val]" value="'.validHtmlStr($term['val']).'"/></span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= '<input  class="term-value"type="text" name="filter[Query][terms]['.$i.'][val]" value="'.validHtmlStr($term['val']).'"/>'.PHP_EOL;
+          $html .= '</span>';
         }
       } else { # no attr ?
         $html .= '<span class="term-value-wrapper">';

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1115,14 +1115,16 @@ class Filter extends ZM_Object {
         #$html .= '<span>'.htmlSelect("filter[Query][terms][$i][op]", $opTypes, $term['op']).'</span>'.PHP_EOL;
 
         if ( $term['attr'] == 'Archived' ) {
-          $html .= htmlSelect("filter[Query][terms][$i][val]", $archiveTypes, $term['val'],['class'=>'chosen chosen-full-width']).PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $archiveTypes, $term['val'],['class'=>'chosen chosen-auto-width']).PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'Tags' ) {
           $selected = explode(',', $term['val']);
           // echo '<pre>selected: '; print_r($selected); echo '</pre>';
           if (count($selected) == 1 and !$selected[0]) {
             $selected = null;
           }
-          $options = ['class'=>'term-value-wrapper chosen chosen-full-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Tags')];
+          $options = ['class'=>'chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Tags')];
           if (isset($term['cookie'])) {
             $options['data-cookie'] = $term['cookie'];
 
@@ -1134,7 +1136,9 @@ class Filter extends ZM_Object {
           // echo '<pre>selected: '; print_r($selected); echo '</pre>';
           // echo '<pre>options: '; print_r($options); echo '</pre>';
 
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $availableTags, $selected, $options).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $availableTags, $selected, $options).PHP_EOL;
+          $html .= '</span>';
           // $html .= '<span>'.htmlSelect("filter[Query][terms][$i][val]", array_combine($availableTags,$availableTags), $term['val'],
           // $options).'</span>'.PHP_EOL;
           // $html .= '<span>'.htmlSelect("filter[Query][terms][$i][val]", $availableTags, $term['val'], $options).'</span>'.PHP_EOL;
@@ -1172,17 +1176,25 @@ class Filter extends ZM_Object {
         } else if ( $term['attr'] == 'StartTime' || $term['attr'] == 'EndTime' ) {
           $html .= '<span class="term-value-wrapper"><input type="text" name="filter[Query][terms]['.$i.'][val]" id="filter[Query][terms]['.$i.'][val]" value="'.(isset($term['val'])?validHtmlStr(str_replace('T', ' ', $term['val'])):'' ).'"/></span>'.PHP_EOL;
         } else if ( $term['attr'] == 'ExistsInFileSystem' ) {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $booleanValues, $term['val'], ['class'=>'chosen chosen-full-width']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $booleanValues, $term['val'], ['class'=>'chosen chosen-auto-width']).PHP_EOL;
+          $html .= '</span>';
 
         } else if ( $term['attr'] == 'Group') {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", Group::get_dropdown_options(), $term['val'],
-            ['class'=>'term-value chosen chosen-full-width',
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", Group::get_dropdown_options(), $term['val'],
+            ['class'=>'term-value chosen chosen-auto-width',
             'multiple'=>'multiple', 
-            'data-placeholder'=>translate('All Groups')]).'</span>'.PHP_EOL;
+            'data-placeholder'=>translate('All Groups')]).PHP_EOL;
+            $html .= '</span>';
         } else if ( $term['attr'] == 'StateId' ) {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $states, $term['val'], ['class'=>'chosen chosen-full-width']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $states, $term['val'], ['class'=>'chosen chosen-auto-width']).PHP_EOL;
+          $html .= '</span>';
         } else if ( strpos($term['attr'], 'Weekday') !== false ) {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $weekdays, $term['val'], ['class'=>'chosen chosen-full-width']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $weekdays, $term['val'], ['class'=>'chosen chosen-auto-width']).PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'Monitor' ) {
           $monitors = [];
           foreach (Monitor::find(['Deleted'=>false], ['order'=>'lower(Name)']) as $m) {
@@ -1195,14 +1207,16 @@ class Filter extends ZM_Object {
           if (count($selected) == 1 and !$selected[0]) {
             $selected = null;
           }
-          $options = ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Monitors')];
+          $options = ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Monitors')];
           if (isset($term['cookie'])) {
             $options['data-cookie'] = $term['cookie'];
 
             if (!$selected and isset($_COOKIE[$term['cookie']]) and $_COOKIE[$term['cookie']])
               $selected = explode(',', $_COOKIE[$term['cookie']]);
           }
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $monitors, $selected, $options).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $monitors, $selected, $options).PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'MonitorName' ) {
           $monitor_names = [];
           foreach (Monitor::find(['Deleted'=>false], ['order'=>'lower(Name)']) as $m) {
@@ -1210,22 +1224,30 @@ class Filter extends ZM_Object {
               $monitor_names[$m->Name()] = validHtmlStr($m->Name());
             }
           }
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", array_combine($monitor_names,$monitor_names), $term['val'],
-            ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Monitors')]).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", array_combine($monitor_names,$monitor_names), $term['val'],
+            ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Monitors')]).PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'ServerId' || $term['attr'] == 'MonitorServerId' || $term['attr'] == 'StorageServerId' || $term['attr'] == 'FilterServerId' ) {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $servers, $term['val'],
-          ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $servers, $term['val'],
+          ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+          $html .= '</span>';
         } else if ( ($term['attr'] == 'StorageId') || ($term['attr'] == 'SecondaryStorageId') ) {
           if (!$storageareas) {
             $storageareas = array('' => array('Name'=>'NULL Unspecified'), '0' => array('Name'=>'Zero')) + ZM_Object::Objects_Indexed_By_Id('ZM\Storage');
           }
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $storageareas, $term['val'],
-              ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $storageareas, $term['val'],
+              ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+              $html .= '</span>';
         } else if ( $term['attr'] == 'AlarmedZoneId' ) {
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $zones, $term['val'],
-              ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple']).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $zones, $term['val'],
+              ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
+          $html .= '</span>';
         } else if ( $term['attr'] == 'Notes' ) {
-          $attrs = ['class'=>'term-value chosen chosen-full-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('Event Type')];
+          $attrs = ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('Event Type')];
           $selected = explode(',', $term['val']);
           if (count($selected) == 1 and !$selected[0]) {
             $selected = null;
@@ -1246,13 +1268,17 @@ class Filter extends ZM_Object {
             'car' => 'Car',
             'truck' => 'Truck',
             'vehicle' => 'Vehicle'];
-          $html .= '<span class="term-value-wrapper">'.htmlSelect("filter[Query][terms][$i][val]", $options, $selected, $attrs).'</span>'.PHP_EOL;
+          $html .= '<span class="term-value-wrapper">';
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $options, $selected, $attrs).PHP_EOL;
+          $html .= '</span>';
         } else {
           #$html .= $term['attr'];
           $html .= '<span class="term-value-wrapper"><input  class="term-value"type="text" name="filter[Query][terms]['.$i.'][val]" value="'.validHtmlStr($term['val']).'"/></span>'.PHP_EOL;
         }
       } else { # no attr ?
-        $html .= '<span class="term-value-wrapper"><input class="term-value" type="text" name="filter[Query][terms]['.$i.'][val]" value="'.(isset($term['val'])?validHtmlStr($term['val']):'' ).'"/></span>'.PHP_EOL;
+        $html .= '<span class="term-value-wrapper">';
+        $html .= '<input class="term-value" type="text" name="filter[Query][terms]['.$i.'][val]" value="'.(isset($term['val'])?validHtmlStr($term['val']):'' ).'"/></span>'.PHP_EOL;
+        $html .= '</span>';
       }
 
       $html .= '</span>';

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -156,7 +156,7 @@ button.btn {
   line-height: 1;
   font-size: 18px;
 }
-input,textarea,select,button,.btn-primary {
+input, textarea, select, button, .btn-primary {
     border: 1px #ccc solid;
     padding: 5px;
     border-radius: 1px;
@@ -167,7 +167,6 @@ input,textarea,select,button,.btn-primary {
     background-color: #f8f8f8;
     text-align: left;
     border-radius:4px;
-    margin: 1px 0;
 }
 
 input.noborder {
@@ -743,7 +742,7 @@ ul.nav.nav-pills.flex-column {
 
 .chosen-container {
 text-align: left;
-/*min-width: 11em;*/ /* Why ???*/
+min-width: 11em; /* Makes a nice uniform display */
 }
 
 .chosen-container-active .chosen-choices {
@@ -896,13 +895,14 @@ a.flip {
 .controlHeader {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: center;
 }
 /* to match chosen text input height */
 .controlHeader input[type="text"] {
   height: 29px;
   padding: 2px 5px 4px 5px;
   margin-top:0;
+  width: 100%;
 }
 @media screen and (max-width:767px) {
   .controlHeader {

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -509,7 +509,6 @@ body.sticky #page {
 
 #header {
     width: 100%;
-    text-align: left;
     background-color: #34495e;
     padding: 5px 0px;
     margin: 0 auto 4px auto;
@@ -740,9 +739,9 @@ ul.nav.nav-pills.flex-column {
   background-color: #f5f5f5; 
 }
 
-.chosen-container {
-text-align: left;
-min-width: 11em; /* Makes a nice uniform display */
+#fbpanel .chosen-container, #toolbar .chosen-container {
+  text-align: left;
+  min-width: 11em; /* Makes a nice uniform display */
 }
 
 .chosen-container-active .chosen-choices {
@@ -892,7 +891,7 @@ a.flip {
   border-radius: 0;
   border: none;
 }
-.controlHeader {
+.controlHeader, #fieldsTable {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -1003,10 +1002,6 @@ button .material-icons {
   display: block;
 }
 
-input.hasDatepicker {
-  max-width:140px;
-}
-
 /* Change scrollbar style */
 div::-webkit-scrollbar, nav::-webkit-scrollbar, .chosen-results::-webkit-scrollbar {
   width: 11px;
@@ -1026,4 +1021,38 @@ div::-webkit-scrollbar-thumb, nav::-webkit-scrollbar-thumb, .chosen-results::-we
   background-color: var(--sliderBG);
   border-radius: 6px;
   border: 3px solid var(--scrollbarBG);
+}
+
+.term {
+  display: flex;
+  flex-direction: column;
+  margin-left: 15px;
+}
+
+@media screen and (max-width:500px) {
+  .term {
+    width: 100% !important;
+    flex-direction: row;
+    margin-right: 15px;
+    margin-bottom: 5px;
+  }
+  .term-label-wrapper {
+    text-wrap: nowrap;
+    margin-top: 7px;
+    margin-right: 5px;
+  }
+  .term-value-wrapper {
+    width: 100%;
+    flex-grow: 1;
+  }
+  .term-value-wrapper .chosen-container {
+    width: 100% !important;
+  }
+  label {
+    text-wrap: nowrap;
+  }
+  input.hasDatepicker {
+    max-width: 100%;
+    width: 100%;
+  }
 }

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -740,6 +740,7 @@ ul.nav.nav-pills.flex-column {
 }
 
 .controlHeader .chosen-container,
+#header .chosen-container,
 #fbpanel .chosen-container,
 #toolbar .chosen-container {
   text-align: left;

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -739,7 +739,9 @@ ul.nav.nav-pills.flex-column {
   background-color: #f5f5f5; 
 }
 
-#fbpanel .chosen-container, #toolbar .chosen-container {
+.controlHeader .chosen-container,
+#fbpanel .chosen-container,
+#toolbar .chosen-container {
   text-align: left;
   min-width: 11em; /* Makes a nice uniform display */
 }

--- a/web/skins/classic/css/base/views/console.css
+++ b/web/skins/classic/css/base/views/console.css
@@ -103,13 +103,13 @@
   margin-bottom: 2rem;
 }
 
-.MonitorNameFilter,
+/* .MonitorNameFilter,
 .FunctionFilter,
 .StatusFilter,
 .SourceFilter,
 .MonitorFilter {
   display: inline-block;
-}
+} */
 form[name="monitorForm"] {
   display: flex;
   flex-flow: column nowrap;
@@ -157,20 +157,5 @@ body.sticky #monitorList thead {
   }
   button .material-icons {
     font-size: 16px;
-  }
-}
-
-.term {
-  display: flex;
-  flex-direction: column;
-  margin-left: 15px;
-}
-
-@media screen and (max-width:500px) {
-  .term {
-    width: 100%;
-    flex-direction: row;
-    margin-top: 5px;
-    margin-right: 15px;
   }
 }

--- a/web/skins/classic/css/base/views/console.css
+++ b/web/skins/classic/css/base/views/console.css
@@ -159,3 +159,18 @@ body.sticky #monitorList thead {
     font-size: 16px;
   }
 }
+
+.term {
+  display: flex;
+  flex-direction: column;
+  margin-left: 15px;
+}
+
+@media screen and (max-width:500px) {
+  .term {
+    width: 100%;
+    flex-direction: row;
+    margin-top: 5px;
+    margin-right: 15px;
+  }
+}

--- a/web/skins/classic/css/base/views/events.css
+++ b/web/skins/classic/css/base/views/events.css
@@ -52,7 +52,6 @@ input[type="number"].form-control {
 #toolbar,
 .filterTable > span{
   padding-bottom: 5px;
-  padding-right: 15px;
 }
 
 #events {
@@ -88,6 +87,7 @@ body.sticky #eventTable thead {
 .term {
   display: flex;
   flex-direction: column;
+  margin-right: 15px;
 }
 .term-value, .chosen-container{
   width: 100% !important;
@@ -97,10 +97,12 @@ body.sticky #eventTable thead {
   .term {
     width: 100%;
     flex-direction: row;
+    margin-right: 0px;
   }
   .term-label-wrapper {
     text-wrap: nowrap;
     margin-top: 7px;
+    margin-right: 5px;
   }
   .term-value-wrapper {
     width: 100%;

--- a/web/skins/classic/css/base/views/events.css
+++ b/web/skins/classic/css/base/views/events.css
@@ -49,11 +49,6 @@ input[type="number"].form-control {
   flex-wrap: wrap;
 }
 
-#toolbar,
-.filterTable > span{
-  padding-bottom: 5px;
-}
-
 #events {
   height: 100%;
   overflow: visible;
@@ -84,34 +79,6 @@ body.sticky #eventTable thead {
   top: -1px;
 }
 
-.term {
-  display: flex;
-  flex-direction: column;
-  margin-right: 15px;
-}
 .term-value, .chosen-container{
   width: 100% !important;
-}
-
-@media screen and (max-width:500px) {
-  .term {
-    width: 100%;
-    flex-direction: row;
-    margin-right: 0px;
-  }
-  .term-label-wrapper {
-    text-wrap: nowrap;
-    margin-top: 7px;
-    margin-right: 5px;
-  }
-  .term-value-wrapper {
-    width: 100%;
-    flex-grow: 1;
-  }
-  label {
-    text-wrap: nowrap;
-  }
-  input.hasDatepicker {
-    max-width: 100%;
-  }
 }

--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -61,7 +61,7 @@ if (canView('Groups')) {
   }
 
   if (count($GroupsById)) {
-    $html .= '<span id="groupControl"><label>'. translate('Group') .'</label>';
+    $html .= '<span class="term" id="groupControl"><label>'. translate('Group') .'</label>';
     # This will end up with the group_id of the deepest selection
     $group_id = isset($_SESSION['GroupId']) ? $_SESSION['GroupId'] : null;
     $html .= ZM\Group::get_group_dropdown();
@@ -99,12 +99,12 @@ if (count($user->unviewableMonitorIds()) ) {
   $values = array_merge($values, $ids);
 }
 
-$html .= '<span class="MonitorNameFilter"><label>'.translate('Name').'</label>';
+$html .= '<span class="term MonitorNameFilter"><label>'.translate('Name').'</label>';
 $html .= '<input type="text" name="MonitorName" value="'.(isset($_SESSION['MonitorName'])?validHtmlStr($_SESSION['MonitorName']):'').'" placeholder="text or regular expression"/>';
 $html .= '</span>'.PHP_EOL;
 
 function addFilterSelect($name, $options) {
-  $html = '<span class="'.$name.'Filter"><label>'.translate($name).'</label>';
+  $html = '<span class="term '.$name.'Filter"><label>'.translate($name).'</label>';
   $html .= htmlSelect($name.'[]', $options,
     (isset($_SESSION[$name])?$_SESSION[$name]:''),
       array(
@@ -123,7 +123,7 @@ $html .= addFilterSelect('Analysing', array('None'=>translate('None'), 'Always'=
 $html .= addFilterSelect('Recording', array('None'=>translate('None'), 'OnMotion'=>translate('On Motion'),'Always'=>translate('Always')));
 
 if ( count($ServersById) > 1 ) {
-  $html .= '<span class="ServerFilter"><label>'. translate('Server').'</label>';
+  $html .= '<span class="term ServerFilter"><label>'. translate('Server').'</label>';
   $html .= htmlSelect('ServerId[]', $ServersById,
     (isset($_SESSION['ServerId'])?$_SESSION['ServerId']:''),
     array(
@@ -138,7 +138,7 @@ if ( count($ServersById) > 1 ) {
 } # end if have Servers
 
 if ( count($StorageById) > 1 ) {
-  $html .= '<span class="StorageFilter"><label>'.translate('Storage').'</label>';
+  $html .= '<span class="term StorageFilter"><label>'.translate('Storage').'</label>';
   $html .= htmlSelect('StorageId[]', $StorageById,
     (isset($_SESSION['StorageId'])?$_SESSION['StorageId']:''),
     array(
@@ -151,7 +151,7 @@ if ( count($StorageById) > 1 ) {
 ';
 } # end if have Storage Areas
 
-$html .= '<span class="StatusFilter"><label>'.translate('Status').'</label>';
+$html .= '<span class="term StatusFilter"><label>'.translate('Status').'</label>';
 $status_options = array(
     'Unknown' => translate('StatusUnknown'),
     'NotRunning' => translate('StatusNotRunning'),
@@ -169,7 +169,7 @@ $html .= htmlSelect( 'Status[]', $status_options,
 $html .= '</span>
 ';
 
-  $html .= '<span class="SourceFilter"><label>'.translate('Source').'</label>';
+  $html .= '<span class="term SourceFilter"><label>'.translate('Source').'</label>';
   $html .= '<input type="text" name="Source" value="'.(isset($_SESSION['Source'])?validHtmlStr($_SESSION['Source']):'').'" placeholder="text or regular expression"/>';
   $html .= '</span>
 ';
@@ -262,7 +262,7 @@ $html .= '</span>
     }
     $displayMonitors[] = $monitors[$i];
   } # end foreach monitor
-  $html .= '<span class="MonitorFilter"><label>'.translate('Monitor').'</label>';
+  $html .= '<span class="term MonitorFilter"><label>'.translate('Monitor').'</label>';
   $html .= htmlSelect('MonitorId[]', $monitors_dropdown, $selected_monitor_ids,
     array(
       'data-on-change'=>'submitThisForm',

--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -153,8 +153,8 @@ if ( count($StorageById) > 1 ) {
       'multiple'=>'multiple',
       'data-placeholder'=>'All',
     ) );
-    $html .= '</span>';
-    $html .= '</span>';
+  $html .= '</span>';
+  $html .= '</span>';
 } # end if have Storage Areas
 
 $html .= '<span class="term StatusFilter"><label>'.translate('Status').'</label>';

--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -62,12 +62,13 @@ if (canView('Groups')) {
 
   if (count($GroupsById)) {
     $html .= '<span class="term" id="groupControl"><label>'. translate('Group') .'</label>';
+    $html .= '<span class="term-value-wrapper">';
     # This will end up with the group_id of the deepest selection
     $group_id = isset($_SESSION['GroupId']) ? $_SESSION['GroupId'] : null;
     $html .= ZM\Group::get_group_dropdown();
     $groupSql = ZM\Group::get_group_sql($group_id);
-    $html .= '</span>
-  ';
+    $html .= '</span>';
+    $html .= '</span>';
   }
 }
 
@@ -100,11 +101,13 @@ if (count($user->unviewableMonitorIds()) ) {
 }
 
 $html .= '<span class="term MonitorNameFilter"><label>'.translate('Name').'</label>';
-$html .= '<input type="text" name="MonitorName" value="'.(isset($_SESSION['MonitorName'])?validHtmlStr($_SESSION['MonitorName']):'').'" placeholder="text or regular expression"/>';
+$html .= '<span class="term-value-wrapper">';
+$html .= '<input type="text" name="MonitorName" value="'.(isset($_SESSION['MonitorName'])?validHtmlStr($_SESSION['MonitorName']):'').'" placeholder="text or regular expression"/></span>';
 $html .= '</span>'.PHP_EOL;
 
 function addFilterSelect($name, $options) {
   $html = '<span class="term '.$name.'Filter"><label>'.translate($name).'</label>';
+  $html .= '<span class="term-value-wrapper">';
   $html .= htmlSelect($name.'[]', $options,
     (isset($_SESSION[$name])?$_SESSION[$name]:''),
       array(
@@ -113,7 +116,8 @@ function addFilterSelect($name, $options) {
         'multiple'=>'multiple',
         'data-placeholder'=>'All',
       )
-   );
+    );
+  $html .= '</span>';
   $html .= '</span>'.PHP_EOL;
   return $html;
 }
@@ -124,6 +128,7 @@ $html .= addFilterSelect('Recording', array('None'=>translate('None'), 'OnMotion
 
 if ( count($ServersById) > 1 ) {
   $html .= '<span class="term ServerFilter"><label>'. translate('Server').'</label>';
+  $html .= '<span class="term-value-wrapper">';
   $html .= htmlSelect('ServerId[]', $ServersById,
     (isset($_SESSION['ServerId'])?$_SESSION['ServerId']:''),
     array(
@@ -133,12 +138,13 @@ if ( count($ServersById) > 1 ) {
       'data-placeholder'=>'All',
     )
   );
-  $html .= '</span>
-';
+  $html .= '</span>';
+  $html .= '</span>';
 } # end if have Servers
 
 if ( count($StorageById) > 1 ) {
   $html .= '<span class="term StorageFilter"><label>'.translate('Storage').'</label>';
+  $html .= '<span class="term-value-wrapper">';
   $html .= htmlSelect('StorageId[]', $StorageById,
     (isset($_SESSION['StorageId'])?$_SESSION['StorageId']:''),
     array(
@@ -147,8 +153,8 @@ if ( count($StorageById) > 1 ) {
       'multiple'=>'multiple',
       'data-placeholder'=>'All',
     ) );
-  $html .= '</span>
-';
+    $html .= '</span>';
+    $html .= '</span>';
 } # end if have Storage Areas
 
 $html .= '<span class="term StatusFilter"><label>'.translate('Status').'</label>';
@@ -158,7 +164,8 @@ $status_options = array(
     'Running' => translate('StatusRunning'),
     'Connected' => translate('StatusConnected'),
     );
-$html .= htmlSelect( 'Status[]', $status_options,
+    $html .= '<span class="term-value-wrapper">';
+    $html .= htmlSelect( 'Status[]', $status_options,
   ( isset($_SESSION['Status']) ? $_SESSION['Status'] : '' ),
   array(
     'data-on-change'=>'submitThisForm',
@@ -166,13 +173,14 @@ $html .= htmlSelect( 'Status[]', $status_options,
     'multiple'=>'multiple',
     'data-placeholder'=>'All'
   ) );
-$html .= '</span>
-';
+  $html .= '</span>';
+  $html .= '</span>';
 
   $html .= '<span class="term SourceFilter"><label>'.translate('Source').'</label>';
+  $html .= '<span class="term-value-wrapper">';
   $html .= '<input type="text" name="Source" value="'.(isset($_SESSION['Source'])?validHtmlStr($_SESSION['Source']):'').'" placeholder="text or regular expression"/>';
-  $html .= '</span>
-';
+  $html .= '</span>';
+  $html .= '</span>';
 
   $sqlAll = 'SELECT M.*, S.*, E.*
   FROM Monitors AS M
@@ -263,6 +271,7 @@ $html .= '</span>
     $displayMonitors[] = $monitors[$i];
   } # end foreach monitor
   $html .= '<span class="term MonitorFilter"><label>'.translate('Monitor').'</label>';
+  $html .= '<span class="term-value-wrapper">';
   $html .= htmlSelect('MonitorId[]', $monitors_dropdown, $selected_monitor_ids,
     array(
       'data-on-change'=>'submitThisForm',
@@ -272,8 +281,8 @@ $html .= '</span>
     ) );
   # Repurpose this variable to be the list of MonitorIds as a result of all the filtering
   $display_monitor_ids = array_map(function($monitor_row){return $monitor_row['Id'];}, $displayMonitors);
-  $html .= '</span>
-';
+  $html .= '</span>';
+  $html .= '</span>';
   echo $html;
 ?>
 </div>


### PR DESCRIPTION
Modified spacing for term fields in both the console and events views:

Console from:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/467360c9-4a69-4933-b5a7-33d3491b80d2)


to:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/6cca9015-a6c1-4705-b461-9718c144c38b)



Events from:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/d0d8d565-5f80-414d-836e-cebf83042388)


to:
![image](https://github.com/ZoneMinder/zoneminder/assets/5922273/55e5cbc9-ebb0-419c-ae11-35cd9c4f6109)


