### PR TITLE
Feat: Mouse moving an enlarged video frame during live viewing

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -339,6 +339,10 @@ function MonitorStream(monitorData) {
     console.log('onclick');
   };
 
+  this.onmove = function(evt) {
+    console.log('onmove');
+  };
+
   this.setup_onclick = function(func) {
     if (func) {
       this.onclick = func;
@@ -347,6 +351,17 @@ function MonitorStream(monitorData) {
       const el = this.getFrame();
       if (!el) return;
       el.addEventListener('click', this.onclick, false);
+    }
+  };
+
+  this.setup_onmove = function(func) {
+    if (func) {
+      this.onmove = func;
+    }
+    if (this.onmove) {
+      const el = this.getFrame();
+      if (!el) return;
+      el.addEventListener('mousemove', this.onmove, false);
     }
   };
 

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -630,8 +630,8 @@ function handleClick(event) {
 }
 
 function shiftImgFrame() { //We calculate the coordinates of the image displacement and shift the image
-  let newPosX = parseInt((PrevCoordinatFrame.x - coordinateMouse.shiftMouse_x) * 1);
-  let newPosY = parseInt((PrevCoordinatFrame.y - coordinateMouse.shiftMouse_y) * 1);
+  let newPosX = parseInt(PrevCoordinatFrame.x - coordinateMouse.shiftMouse_x);
+  let newPosY = parseInt(PrevCoordinatFrame.y - coordinateMouse.shiftMouse_y);
 
   if (newPosX < 0) newPosX = 0;
   if (newPosX > monitorWidth) newPosX = monitorWidth;

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -613,15 +613,15 @@ function handleClick(event) {
     const x = parseInt((event.pageX - pos.left) * scaleX);
     const y = parseInt((event.pageY - pos.top) * scaleY);
 
-    updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
-
     if (showMode == 'events' || !imageControlMode) {
       if (event.shift || event.shiftKey) {
         streamCmdPan(x, y);
+        updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
       } else if (event.ctrlKey) {
         streamCmdZoomOut();
       } else {
         streamCmdZoomIn(x, y);
+        updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
       }
     } else {
       controlCmdImage(x, y);

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -696,7 +696,6 @@ function handleMove(event) {
   if ((leftBtnStatus.UpAfterDown) || //The left button was raised or the cursor was moved more than 30 pixels relative to the actual size of the image
     ((coordinateMouse.shiftMouseForTrigger_x > 30) && leftBtnStatus.Down) ||
     ((coordinateMouse.shiftMouseForTrigger_y > 30) && leftBtnStatus.Down)) {
-
     //We perform frame shift
     shiftImgFrame();
     updateCoordinateMouse(x, y);

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -665,7 +665,9 @@ function getCoordinateMouse(event) { //We get the current cursor coordinates tak
 
 function handleMove(event) {
   if (event.ctrlKey && event.shiftKey) {
-    document.ondragstart = function() {return false}; //Allow drag and drop
+    document.ondragstart = function() {
+      return false;
+    }; //Allow drag and drop
   } else {
     document.ondragstart = function() {}; //Prevent drag and drop
     return false;
@@ -839,19 +841,19 @@ function controlSetClicked() {
     console.log('loading');
     // Load the PTZ Preset modal into the DOM
     $j.getJSON(monitorUrl + '?request=modal&modal=controlpreset&mid=' + monitorId+'&'+auth_relay)
-      .done(function(data) {
-        insertModalHtml('ctrlPresetModal', data.html);
-        updatePresetLabels();
-        // Manage the Preset Select box
-        $j('#preset').change(updatePresetLabels);
-        // Manage the Save button
-        $j('#cPresetSubmitModal').click(function(evt) {
-          evt.preventDefault();
-          $j('#ctrlPresetForm').submit();
-        });
-        $j('#ctrlPresetModal').modal('show');
-      })
-      .fail(logAjaxFail);
+        .done(function(data) {
+          insertModalHtml('ctrlPresetModal', data.html);
+          updatePresetLabels();
+          // Manage the Preset Select box
+          $j('#preset').change(updatePresetLabels);
+          // Manage the Save button
+          $j('#cPresetSubmitModal').click(function(evt) {
+            evt.preventDefault();
+            $j('#ctrlPresetForm').submit();
+          });
+          $j('#ctrlPresetModal').modal('show');
+        })
+        .fail(logAjaxFail);
   } else {
     console.log('not loading');
     modal.modal('show');

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -841,19 +841,19 @@ function controlSetClicked() {
     console.log('loading');
     // Load the PTZ Preset modal into the DOM
     $j.getJSON(monitorUrl + '?request=modal&modal=controlpreset&mid=' + monitorId+'&'+auth_relay)
-      .done(function(data) {
-        insertModalHtml('ctrlPresetModal', data.html);
-        updatePresetLabels();
-        // Manage the Preset Select box
-        $j('#preset').change(updatePresetLabels);
-        // Manage the Save button
-        $j('#cPresetSubmitModal').click(function(evt) {
-          evt.preventDefault();
-          $j('#ctrlPresetForm').submit();
-        });
-        $j('#ctrlPresetModal').modal('show');
-      })
-      .fail(logAjaxFail);
+        .done(function(data) {
+          insertModalHtml('ctrlPresetModal', data.html);
+          updatePresetLabels();
+          // Manage the Preset Select box
+          $j('#preset').change(updatePresetLabels);
+          // Manage the Save button
+          $j('#cPresetSubmitModal').click(function(evt) {
+            evt.preventDefault();
+            $j('#ctrlPresetForm').submit();
+          });
+          $j('#ctrlPresetModal').modal('show');
+        })
+        .fail(logAjaxFail);
   } else {
     console.log('not loading');
     modal.modal('show');

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -648,7 +648,7 @@ function updateCoordinateMouse(x, y) { //We fix the coordinates when pressing th
   coordinateMouse.start_y = y;
 }
 
-function updatePrevCoordinatFrame(x, y) { //Update the Frame's current coordinates 
+function updatePrevCoordinatFrame(x, y) { //Update the Frame's current coordinates
   PrevCoordinatFrame.x = x;
   PrevCoordinatFrame.y = y;
 }
@@ -664,7 +664,6 @@ function getCoordinateMouse(event) { //We get the current cursor coordinates tak
 }
 
 function handleMove(event) {
-  
   if (event.ctrlKey && event.shiftKey) {
     document.ondragstart = function() {return false}; //Allow drag and drop
   } else {
@@ -676,8 +675,8 @@ function handleMove(event) {
     var {x, y} = getCoordinateMouse(event);
     const k = Math.log(2.72) / Math.log(parseFloat($j('#zoomValue'+monitorId).html())) - 0.3; //Necessary for correctly shifting the image in accordance with the scaling proportions
 
-    coordinateMouse.shiftMouse_x =  parseInt((x - coordinateMouse.start_x) * k);
-    coordinateMouse.shiftMouse_y =  parseInt((y - coordinateMouse.start_y) * k);
+    coordinateMouse.shiftMouse_x = parseInt((x - coordinateMouse.start_x) * k);
+    coordinateMouse.shiftMouse_y = parseInt((y - coordinateMouse.start_y) * k);
 
     coordinateMouse.shiftMouseForTrigger_x = Math.abs(parseInt(x - coordinateMouse.start_x));
     coordinateMouse.shiftMouseForTrigger_y = Math.abs(parseInt(y - coordinateMouse.start_y));
@@ -692,11 +691,10 @@ function handleMove(event) {
     leftBtnStatus.UpAfterDown = true;
   }
 
-  if ((leftBtnStatus.UpAfterDown) //The left button was raised or the cursor was moved more than 30 pixels relative to the actual size of the image
-    || ((coordinateMouse.shiftMouseForTrigger_x > 30) && leftBtnStatus.Down)
-    || ((coordinateMouse.shiftMouseForTrigger_y > 30) && leftBtnStatus.Down)
-     )
-  {
+  if ((leftBtnStatus.UpAfterDown) || //The left button was raised or the cursor was moved more than 30 pixels relative to the actual size of the image
+    ((coordinateMouse.shiftMouseForTrigger_x > 30) && leftBtnStatus.Down) ||
+    ((coordinateMouse.shiftMouseForTrigger_y > 30) && leftBtnStatus.Down)) {
+
     //We perform frame shift
     shiftImgFrame();
     updateCoordinateMouse(x, y);
@@ -841,19 +839,19 @@ function controlSetClicked() {
     console.log('loading');
     // Load the PTZ Preset modal into the DOM
     $j.getJSON(monitorUrl + '?request=modal&modal=controlpreset&mid=' + monitorId+'&'+auth_relay)
-        .done(function(data) {
-          insertModalHtml('ctrlPresetModal', data.html);
-          updatePresetLabels();
-          // Manage the Preset Select box
-          $j('#preset').change(updatePresetLabels);
-          // Manage the Save button
-          $j('#cPresetSubmitModal').click(function(evt) {
-            evt.preventDefault();
-            $j('#ctrlPresetForm').submit();
-          });
-          $j('#ctrlPresetModal').modal('show');
-        })
-        .fail(logAjaxFail);
+      .done(function(data) {
+        insertModalHtml('ctrlPresetModal', data.html);
+        updatePresetLabels();
+        // Manage the Preset Select box
+        $j('#preset').change(updatePresetLabels);
+        // Manage the Save button
+        $j('#cPresetSubmitModal').click(function(evt) {
+          evt.preventDefault();
+          $j('#ctrlPresetForm').submit();
+        });
+        $j('#ctrlPresetModal').modal('show');
+      })
+      .fail(logAjaxFail);
   } else {
     console.log('not loading');
     modal.modal('show');


### PR DESCRIPTION
Now it is possible to move an enlarged video frame by moving the mouse and not just by clicking while holding down "Shift"
This function works by simultaneously pressing “Ctrl” + “Shift”. Those. you need to hold down “Ctrl” + “Shift”, then by pressing the left mouse button “capture” the video frame and moving the mouse will move the video frame.
I found this very convenient, especially when it is necessary to move a greatly enlarged video frame a short distance.
All the previous functionality when holding “Ctrl” (decrease) or “Shift” (positioning) or simply “click” (increase) remained unchanged.