### PR TITLE
Fix: Event table coloring in dark css in live view

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -24,6 +24,7 @@
 :root {
   --scrollbarBG: #CFD8DC;
   --sliderBG: #95AFC0;
+  --alarmBG: #352424;
 }
 
 body {

--- a/web/skins/classic/css/dark/views/watch.css
+++ b/web/skins/classic/css/dark/views/watch.css
@@ -24,7 +24,7 @@ span.alert {
 }
 
 #eventList tr.recent {
-    background-color: #B0E0E6;
+    background-color: var(--alarmBG);
 }
 
 #eventList tr.highlight {

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -420,7 +420,7 @@ if ( canView('Events') && ($monitor->Type() != 'WebSite') ) {
           data-show-refresh="true"
           class="table-sm table-borderless"
         >
-          <thead>
+          <thead class="thead-highlight">
             <!-- Row styling is handled by bootstrap-tables -->
             <tr>
               <th data-sortable="false" data-field="Delete"><?php echo translate('Delete') ?></th>


### PR DESCRIPTION
- Table header
- Table row background color for the currently active event

**After change:**
![After](https://github.com/ZoneMinder/zoneminder/assets/5006170/be04848b-2e2e-4b57-8b3c-646a9a47f55f)
