### PR TITLE
Allow changing start/end weekday after generating events from a filter

### DIFF
--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1085,6 +1085,10 @@ class Filter extends ZM_Object {
     foreach ( $Servers as $server ) {
       $servers[$server->Id()] = validHtmlStr($server->Name());
     }
+    $weekdays = array();
+    for ( $i = 0; $i < 7; $i++ ) {
+      $weekdays[$i] = date('D', mktime(12, 0, 0, 1, $i+1, 2001));
+    }
     $availableTags = array();
     foreach ( dbFetchAll('SELECT Id, Name FROM Tags ORDER BY LastAssignedDate DESC') AS $tag ) {
       $availableTags[$tag['Id']] = validHtmlStr($tag['Name']);

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -155,6 +155,7 @@ a.btn,
 button.btn {
   line-height: 1;
   font-size: 18px;
+  margin-bottom: 3px;
 }
 input, textarea, select, button, .btn-primary {
     border: 1px #ccc solid;


### PR DESCRIPTION
Looks like this has been broken for a long time.  The $weekday array wasn't being populated in this scenario.