### PR TITLE
Feat: Added a button to hide/show the timeline panel on the "Montage Review" page

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -365,8 +365,9 @@ if ( currentView != 'none' && currentView != 'login' ) {
     // Manage the web console filter bar minimize chevron
     $j("#mfbflip").click(function() {
       $j("#mfbpanel").slideToggle("slow", function() {
-        //changeScale(); //This function disappeared somewhere... It needs to be restored. Function call appeared Aug 10, 2023 https://github.com/ZoneMinder/zoneminder/commit/b8982dce53137d86d33d2d6d79104d4a25673ef7
-        redrawScreen(); //Temporarily use changeScale() instead. You can try using refreshWindow()
+        if ($j.isFunction('changeScale')) {
+          changeScale();
+        }
       });
       var mfbflip = $j("#mfbflip");
       if ( mfbflip.html() == 'keyboard_arrow_up' ) {

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -262,9 +262,13 @@ if ( currentView != 'none' && currentView != 'login' ) {
 
   $j(document).ready(function() {
     // List of functions that are allowed to be called via the value of an object's DOM attribute.
-    let safeFunc = {
-       drawGraph: function() {drawGraph()},
-       refreshWindow: function() {refreshWindow()}
+    const safeFunc = {
+      drawGraph: function() {
+        drawGraph();
+      },
+      refreshWindow: function() {
+        refreshWindow();
+      }
     }
 
     // Load the Logout and State modals into the dom
@@ -321,11 +325,11 @@ if ( currentView != 'none' && currentView != 'login' ) {
       const nameFuncBefore = _this_.attr('data-flip-сontrol-run-before-func') ? _this_.attr('data-flip-сontrol-run-before-func') : null;
       const nameFuncAfter = _this_.attr('data-flip-сontrol-run-after-func') ? _this_.attr('data-flip-сontrol-run-after-func') : null;
 
-      if (nameFuncBefore){
+      if (nameFuncBefore) {
         if (typeof safeFunc[nameFuncBefore] === 'function') safeFunc[nameFuncBefore]();
       }
       obj.slideToggle("fast");
-      if (nameFuncAfter){
+      if (nameFuncAfter) {
         if (typeof safeFunc[nameFuncAfter] === 'function') safeFunc[nameFuncAfter]();
       }
     });

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -261,6 +261,12 @@ if ( currentView != 'none' && currentView != 'login' ) {
   $j.ajaxSetup({timeout: AJAX_TIMEOUT}); //sets timeout for all getJSON.
 
   $j(document).ready(function() {
+    // List of functions that are allowed to be called via the value of an object's DOM attribute.
+    let safeFunc = {
+       drawGraph: function() {drawGraph()},
+       refreshWindow: function() {refreshWindow()}
+    }
+
     // Load the Logout and State modals into the dom
     $j('#logoutButton').click(clickLogout);
     if ( canEdit.System ) $j('#stateModalBtn').click(getStateModal);
@@ -312,7 +318,16 @@ if ( currentView != 'none' && currentView != 'login' ) {
         setCookie('zmFilterBarFlip'+_this_.attr('data-flip-сontrol-object'), 'visible');
       }
 
+      const nameFuncBefore = _this_.attr('data-flip-сontrol-run-before-func') ? _this_.attr('data-flip-сontrol-run-before-func') : null;
+      const nameFuncAfter = _this_.attr('data-flip-сontrol-run-after-func') ? _this_.attr('data-flip-сontrol-run-after-func') : null;
+
+      if (nameFuncBefore){
+        if (typeof safeFunc[nameFuncBefore] === 'function') safeFunc[nameFuncBefore]();
+      }
       obj.slideToggle("fast");
+      if (nameFuncAfter){
+        if (typeof safeFunc[nameFuncAfter] === 'function') safeFunc[nameFuncAfter]();
+      }
     });
 
     // Manage visible filter bar & control button (after document ready)
@@ -346,7 +361,8 @@ if ( currentView != 'none' && currentView != 'login' ) {
     // Manage the web console filter bar minimize chevron
     $j("#mfbflip").click(function() {
       $j("#mfbpanel").slideToggle("slow", function() {
-        changeScale();
+        //changeScale(); //This function disappeared somewhere... It needs to be restored. Function call appeared Aug 10, 2023 https://github.com/ZoneMinder/zoneminder/commit/b8982dce53137d86d33d2d6d79104d4a25673ef7
+        redrawScreen(); //Temporarily use changeScale() instead. You can try using refreshWindow()
       });
       var mfbflip = $j("#mfbflip");
       if ( mfbflip.html() == 'keyboard_arrow_up' ) {

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -269,7 +269,7 @@ if ( currentView != 'none' && currentView != 'login' ) {
       refreshWindow: function() {
         refreshWindow();
       }
-    }
+    };
 
     // Load the Logout and State modals into the dom
     $j('#logoutButton').click(clickLogout);

--- a/web/skins/classic/views/montagereview.php
+++ b/web/skins/classic/views/montagereview.php
@@ -324,6 +324,9 @@ if (count($filter->terms())) {
 ?>
           <button type="button" id="downloadVideo" data-on-click="click_download"><?php echo translate('Download Video') ?></button>
 <?php } // end if !live ?>
+          <button type="button" id="collapse" data-flip-сontrol-object="#timelinediv" data-flip-сontrol-run-after-func="drawGraph"> <!-- OR run redrawScreen? -->
+            <i class="material-icons" data-icon-visible="history_toggle_off" data-icon-hidden="schedule"></i>
+          </button>
         </div>
         <div id="timelinediv">
           <canvas id="timeline"></canvas>


### PR DESCRIPTION
This PR includes two changes:
**1.** Added the ability to execute a function BEFORE or AFTER the hide/show event of a DOM element block. In addition to the implementation in PR #3860

**Usage:** 
Add an attribute to the control button: `data-flip-control-run-before-func="NameFuntion"` or `data-flip-control-run-after-func="NameFuntion"`

**2.** Added a button to hide/show the timeline panel on the "Montage Review" page
