### PR TITLE
Fix: Apply .wrapper-scroll-table only to body.sticky

### DIFF
--- a/web/skins/classic/css/base/views/groups.css
+++ b/web/skins/classic/css/base/views/groups.css
@@ -35,7 +35,7 @@ body.sticky #options {
   padding-top: 15px;
 }
 
-.wrapper-scroll-table {
+body.sticky .wrapper-scroll-table {
   position: absolute;
   margin-right: calc(var(--indent-bootstrap-row) * -1);
   margin-left: calc(var(--indent-bootstrap-row) * -1);

--- a/web/skins/classic/css/base/views/options.css
+++ b/web/skins/classic/css/base/views/options.css
@@ -163,7 +163,7 @@ textarea.form-control-sm {
   min-height: 3rem;
 }
 
-.wrapper-scroll-table {
+body.sticky .wrapper-scroll-table {
   position: absolute;
   margin-right: calc(var(--indent-bootstrap-row) * -1);
   margin-left: calc(var(--indent-bootstrap-row) * -1);


### PR DESCRIPTION
Fix https://github.com/ZoneMinder/zoneminder/commit/3953ad982f46255e276e40816c84f5a573883d80#commitcomment-140457470