### PR TITLE
Fix: Offset zoom frame in console table and viewing alarm frames table

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -806,10 +806,14 @@ li.search-choice {
 
 .zoom,
 .zoom-console {
-  transform-origin: 0% 50%;
+  transform-origin: 0% 00%;
   transform: scale(5); /* (arbitray zoom value - Note if the zoom is too large, it will go outside of the viewport) */
   position: sticky;
   z-index: 1001;
+}
+
+#framesTable .zoom {
+  transform-origin: 100% 0%;
 }
 
 a.flip {


### PR DESCRIPTION
1. Vertical offset = 0, because otherwise, the topmost frame in the table will be cut off at the top. The bottommost frame will create a vertical scroll bar and will therefore be fully viewable.
2. If the frame is on the right in the table, then its right position must be = 0, otherwise it will also go beyond the right border and will not be visible.