### PR TITLE
Fix: Cursor style for moving along the timeline when viewing a recorded event

### DIFF
--- a/web/skins/classic/css/base/views/event.css
+++ b/web/skins/classic/css/base/views/event.css
@@ -31,6 +31,7 @@
   z-index: 10;
   border: none;
   border-right: 1px solid black;
+  cursor: pointer;
 }
 
 #alarmCues span {
@@ -192,6 +193,7 @@ height: 100%;
    */
   margin: 0;
   z-index: 5;
+  overflow-x: clip;
 }
 
 #progressBar .progressBox {
@@ -337,7 +339,7 @@ svg.zones {
 #indicator {
   height: 2.75em;
   position: absolute;
-  border-left: 1px solid blue;
+  border-left: 2px solid blue;
   margin-top: -1.25em;
 }
 .video-js .vjs-text-track-display {


### PR DESCRIPTION
1. Changed the cursor style to "pointer", because the cursor could take on two different styles, which doesn’t look nice.
2. Changed the width of the vertical blue stripe +1 pixel.
3. When the cursor was in the extreme right position, a horizontal scroll bar previously appeared, because "#indicator" went beyond "#progressBar".
![11r](https://github.com/ZoneMinder/zoneminder/assets/5006170/3512b705-2dcf-436a-bcc9-bcdb0d24a626)
![22r](https://github.com/ZoneMinder/zoneminder/assets/5006170/80e8e03a-bab0-4c98-b4e6-98476bfa5a6c)
