### PR TITLE
Fix: Allow Chosen leave empty value in Select

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -787,6 +787,14 @@ li.search-choice {
     border-color:rgb(200,200,200);
 }
 
+.chosen-container-single .chosen-single-with-deselect span {
+  margin-right: 30px;
+}
+
+.chosen-container-single .chosen-single abbr {
+  right: 18px;
+}
+
 .reduced-text { 
    font-size:0.9em;
 }

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1144,9 +1144,9 @@ function applyChosen() {
   const limit_search_threshold = 10;
 
   $j('.chosen').chosen('destroy');
-  $j('.chosen').not('.chosen-full-width, .chosen-auto-width').chosen({disable_search_threshold: limit_search_threshold, search_contains: true});
-  $j('.chosen.chosen-full-width').chosen({disable_search_threshold: limit_search_threshold, search_contains: true, width: "100%"});
-  $j('.chosen.chosen-auto-width').chosen({disable_search_threshold: limit_search_threshold, search_contains: true, width: "auto"});
+  $j('.chosen').not('.chosen-full-width, .chosen-auto-width').chosen({allow_single_deselect: true, disable_search_threshold: limit_search_threshold, search_contains: true});
+  $j('.chosen.chosen-full-width').chosen({allow_single_deselect: true, disable_search_threshold: limit_search_threshold, search_contains: true, width: "100%"});
+  $j('.chosen.chosen-auto-width').chosen({allow_single_deselect: true, disable_search_threshold: limit_search_threshold, search_contains: true, width: "auto"});
 }
 
 const font = new FontFaceObserver('Material Icons', {weight: 400});


### PR DESCRIPTION
For example, in Filter page selecting brackets in a condition

![06](https://github.com/ZoneMinder/zoneminder/assets/5006170/023cdd1d-5a53-4836-a6ea-39546e8d6def)
