### PR TITLE
Fix: For ".chosen" do not show blocks when loading document

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -770,6 +770,10 @@ ul.nav.nav-pills.flex-column {
   float: left;  
 }
 
+.chosen {
+  position: absolute !important; left: -999em !important;
+}
+
 .chosen-container-active .chosen-choices {
     border-color:rgb(200,200,200);
 }


### PR DESCRIPTION
Prevents blocks from appearing before apply "Chosen"