### PR TITLE
Fix: If Select has no Options, don't try to select 1 Option in Filter page

### DIFF
--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -383,7 +383,8 @@ function addTerm( element ) {
   row.find('select').chosen('destroy');
   var newRow = row.clone().insertAfter(row);
   newRow.find('select').each( function() { //reset new row to default
-    this[0].selected = 'selected';
+		if ($j(this).find('option').length > 0 )
+      this[0].selected = 'selected';
   });
   newRow.find('input[type="text"]').val('');
   newRow[0].querySelectorAll("button[data-on-click-this]").forEach(function(el) {

--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -382,10 +382,10 @@ function addTerm( element ) {
   var row = $j(element).closest('tr');
   row.find('select').chosen('destroy');
   var newRow = row.clone().insertAfter(row);
-  newRow.find('select').each( function() { //reset new row to default
-    if ($j(this).find('option').length > 0 )
-      this[0].selected = 'selected';
-  });
+  //newRow.find('select').each( function() { //reset new row to default
+  //  if ($j(this).find('option').length > 0 )
+  //    this[0].selected = 'selected';
+  //});
   newRow.find('input[type="text"]').val('');
   newRow[0].querySelectorAll("button[data-on-click-this]").forEach(function(el) {
     var fnName = el.getAttribute("data-on-click-this");

--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -383,7 +383,7 @@ function addTerm( element ) {
   row.find('select').chosen('destroy');
   var newRow = row.clone().insertAfter(row);
   newRow.find('select').each( function() { //reset new row to default
-		if ($j(this).find('option').length > 0 )
+    if ($j(this).find('option').length > 0 )
       this[0].selected = 'selected';
   });
   newRow.find('input[type="text"]').val('');


### PR DESCRIPTION
Because selecting an option that does not exist results in an error.
For example, when cloning a Tags filter string when there are no tags.