### PR TITLE
Fix(filter): Set tags operator to = instead of LIKE

### DIFF
--- a/web/ajax/events.php
+++ b/web/ajax/events.php
@@ -205,7 +205,7 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
 
   $values = array();
   $likes = array();
-  // Error($filter->sql());
+  ZM\Error($filter->sql());
   $where = $filter->sql()?' WHERE ('.$filter->sql().')' : '';
   $has_post_sql_conditions = count($filter->post_sql_conditions());
 

--- a/web/ajax/events.php
+++ b/web/ajax/events.php
@@ -205,7 +205,7 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
 
   $values = array();
   $likes = array();
-  ZM\Error($filter->sql());
+  // ZM\Error($filter->sql());
   $where = $filter->sql()?' WHERE ('.$filter->sql().')' : '';
   $has_post_sql_conditions = count($filter->post_sql_conditions());
 

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -861,8 +861,8 @@ class Filter extends ZM_Object {
   public static function tags_opTypes() {
     if (!self::$tags_opTypes) {
       self::$tags_opTypes = array(
-        'LIKE' => translate('OpLike'),
-        'NOT LIKE' => translate('OpNotLike'),
+        '=' => translate('OpEq'),
+        '!=' => translate('OpNe'),
       );
     }
     return self::$tags_opTypes;

--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -333,7 +333,7 @@ function parseRows(rows) {
     } else if (attr == 'Tags') {
       if ( ! opVal ) {
         // Default to LIKE so that something gets selected
-        opVal = 'LIKE';
+        opVal = '=';
       }
       for ( var key in tags_opTypes ) {
         opSelect.append('<option value="' + key + '"'+(key == opVal ? ' selected="selected"' : '')+'>' + tags_opTypes[key] + '</option>');


### PR DESCRIPTION
Fixes #3960 
Sets the filter operator for Tags to = instead of LIKE since the tag Ids are used (not tag names).
LIKE produces wrong results when used against Ids.