### PR TITLE
Set ZM_RUNDIR to /run/zoneminder for EL/FC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ if(NOT ZM_JWT_BACKEND IN_LIST ZM_JWT_BACKEND_OPTIONS)
 endif()
 
 if((ZM_TARGET_DISTRO MATCHES "^el") OR (ZM_TARGET_DISTRO MATCHES "^fc"))
-  set(ZM_RUNDIR "/var/run/zoneminder")
+  set(ZM_RUNDIR "/run/zoneminder")
   set(ZM_SOCKDIR "/var/lib/zoneminder/sock")
   set(ZM_TMPDIR "/var/lib/zoneminder/temp")
   set(ZM_LOGDIR "/var/log/zoneminder")


### PR DESCRIPTION
Currently we get:
```
Apr 09 05:03:25 systemd[1]: /usr/lib/systemd/system/zoneminder.service:15: PIDFile= references a path below legacy directory /var/run/, updating /var/run/zoneminder/zm.pid → /run/zoneminder/zm.pid; please update the unit file accordingly.
```
`/var/run` is a symbolic link to `/run`.