### PR TITLE
Fix: Text color when hovering over select.chosen for light theme

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -147,6 +147,10 @@ a:hover {
     border-radius:4px;
 }
 
+a:not([href]):hover {
+    color: #212529;
+}
+
 label {
     margin: 0 4px;
 }


### PR DESCRIPTION
Bootstrap uses the "inherit" color, but our text color for "#header" is white. Overridden color to standard dark bootstrap that is used on page