### PR TITLE
feat(tags): Two buttons to tag and play next/prev

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -236,6 +236,19 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
         <input type="search" id="tagInput" class="tag-input" placeholder="Add tag" data-role="tagsinput">
         <div class="tag-dropdown-content"></div>
       </div>
+      <button type="button" id="tagPrevBtn" title="<?php echo translate('Apply the last tag, then play the previous event') ?>" class="inactive" data-on-click-true="tagAndPrev">
+        <i class="material-icons md-18" 
+          style="-moz-transform: scaleX(-1);
+            -o-transform: scaleX(-1);
+            -webkit-transform: scaleX(-1);
+            transform: scaleX(-1);
+            filter: FlipH;
+            -ms-filter: 'FlipH';">
+            label</i>
+      </button>
+      <button type="button" id="tagNextBtn" title="<?php echo translate('Apply the last tag, then play the next event') ?>" class="inactive" data-on-click-true="tagAndNext">
+        <i class="material-icons md-18">label</i>
+      </button>
     </div>
 <!-- BEGIN VIDEO CONTENT ROW -->
     <div id="inner-content">

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -614,6 +614,16 @@ function streamNext(action) {
   }
 } // end function streamNext(action)
 
+function tagAndNext(action) {
+  addTag(availableTags[0]);
+  streamNext(action);
+}
+
+function tagAndPrev(action) {
+  addTag(availableTags[0]);
+  streamPrev(action);
+}
+
 function vjsPanZoom(action, x, y) { //Pan and zoom with centering where the click occurs
   var outer = $j('#videoobj');
   var video = outer.children().first();


### PR DESCRIPTION
This adds two buttons to the right side of the Tags input field.  The buttons apply the last tag to the current event and then play the next or previous event.  This makes it very fast and convenient to review events one by one and apply the same tag.

![ApplyLastTag](https://github.com/ZoneMinder/zoneminder/assets/5922273/326dc662-86fc-4470-bfa1-9a8f2a7061b1)
