### PR TITLE
FIx: Montage page, remove stream.src = ''

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -281,7 +281,6 @@ function MonitorStream(monitorData) {
     }
     if (stream.src != src) {
       console.log("Setting to streaming: " + src);
-      stream.src = '';
       stream.src = src;
     }
     stream.onerror = this.img_onerror.bind(this);


### PR DESCRIPTION
I don’t understand why it was necessary to reset the attribute if it is immediately redefined “stream.src = src” ???