### PR TITLE
Enabled support for old ZoomPan algorithm, Added ZoomPan (In & Out) options  & other (watch.js)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -940,15 +940,15 @@ a.flip {
   color: #dddddd;
 }
 
-.monitor.idle img {
+.monitor.idle img, .monitor.idle .imageFeed {
   border: 2px solid #ffffff;
 }
 
-.monitor.alarm img {
+.monitor.alarm img, .monitor.alarm .imageFeed {
   border: 2px solid #ff0000;
 }
 
-.monitor.alert img {
+.monitor.alert img, .monitor.alert .imageFeed {
   border: 2px solid #ffa500;
 }
 .monitor.alert {

--- a/web/skins/classic/css/base/views/watch.css
+++ b/web/skins/classic/css/base/views/watch.css
@@ -43,15 +43,15 @@
   margin: 0 auto;
 }
 
-#monitor .grid-stack-item .imageFeed ,
-#monitor .grid-stack-item .imageFeed ,
-#monitor .grid-stack-item .imageFeed {
+.monitor .imageFeed,
+.monitor .imageFeed,
+.monitor .imageFeed {
   border: 2px solid #999999;
 }
 
-#monitor .grid-stack-item .imageFeed img ,
-#monitor .grid-stack-item .imageFeed video ,
-#monitor .grid-stack-item .imageFeed svg {
+.monitor .imageFeed img,
+.monitor .imageFeed video,
+.monitor .imageFeed svg {
   border: none;
   display: inline-block;
   width: 100%;
@@ -232,7 +232,7 @@ button.btn.btn-edit-monitor {
     1px 1px 0 #575757;
 }
 
-button.btn.btn-view-watch {
+button.btn.btn-view-watch, button.btn.btn-fullscreen, .ratioControl {
   display: none;
 }
 
@@ -258,3 +258,12 @@ button.btn.btn-edit-monitor:hover,
 button.btn.btn-view-watch:hover {
   background-color: darkgrey;
 }
+
+/* +++ Support for old ZoomPan algorithm */
+.form-check.control-use-old-zoom-pan {
+  display: inline-block;
+}
+#headerButtons .form-check.control-use-old-zoom-pan input.form-check-input {
+  margin-left: -1.0rem;
+}
+/* --- Support for old ZoomPan algorithm */

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1005,11 +1005,16 @@ function manageCursor(Id) {
 function initPage() {
 // +++ Support of old ZoomPan algorithm
   var useOldZoomPan = getCookie('zmUseOldZoomPan');
+  const btnZoomOutBtn = document.getElementById('zoomOutBtn'); //Zoom out button below Frame. She may not
   if (useOldZoomPan) {
     panZoomEnabled = false;
-    document.getElementById('zoomOutBtn').classList.remove("hidden");
+    if (btnZoomOutBtn) {
+      btnZoomOutBtn.classList.remove("hidden");
+    }
   } else {
-    document.getElementById('zoomOutBtn').classList.add("hidden");
+    if (btnZoomOutBtn) {
+      btnZoomOutBtn.classList.add("hidden");
+    }
   }
   $j("#use-old-zoom-pan").click(function() {
     useOldZoomPan = this.checked;

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1022,12 +1022,12 @@ function initPage() {
   if (panZoomEnabled) {
     $j('.zoompan').each( function() {
       panZoomAction('enable', {obj: this});
-      $j(document).on('keyup keydown', function(e){
+      $j(document).on('keyup keydown', function(e) {
         shifted = e.shiftKey ? e.shiftKey : e.shift;
         ctrled = e.ctrlKey;
         manageCursor(monitorId);
       });
-      this.addEventListener('mousemove', function(e){ 
+      this.addEventListener('mousemove', function(e) {
         //Temporarily not use
       });
     });
@@ -1352,8 +1352,8 @@ function panZoomAction(action, param) {
       if (!shifted) {
         return;
       }
-      panZoom[i].zoomWithWheel(event)
-    })
+      panZoom[i].zoomWithWheel(event);
+    });
   } else if (action == "disable") {
     //Disable a specific object
     $j('.btn-zoom-in').addClass('hidden');

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -614,51 +614,51 @@ function fetchImage(streamImage) {
 
 function handleClick(event) {
   if (panZoomEnabled) {
-  event.preventDefault();
-  if (event.target.id) {
-  //We are looking for an object with an ID, because there may be another element in the button.
-    var obj = event.target;
-  } else {
-    var obj = event.target.parentElement;
-  }
-  if (obj.className.includes('btn-zoom-out') || obj.className.includes('btn-zoom-in')) return;
-
-  if (obj.className.includes('btn-edit-monitor')) {
-    const url = '?view=monitor&mid='+monitorId;
-    if (event.ctrlKey) {
-      window.open(url, '_blank');
+    event.preventDefault();
+    if (event.target.id) {
+    //We are looking for an object with an ID, because there may be another element in the button.
+      var obj = event.target;
     } else {
-      window.location.assign(url);
+      var obj = event.target.parentElement;
     }
-  }
+    if (obj.className.includes('btn-zoom-out') || obj.className.includes('btn-zoom-in')) return;
+
+    if (obj.className.includes('btn-edit-monitor')) {
+      const url = '?view=monitor&mid='+monitorId;
+      if (event.ctrlKey) {
+        window.open(url, '_blank');
+      } else {
+        window.location.assign(url);
+      }
+    }
   } else {
     // +++ Old ZoomPan algorithm.
-  if (!(event.ctrlKey && (event.shift || event.shiftKey))) {
-  // target should be the img tag
-    const target = $j(event.target);
-    const width = target.width();
-    const height = target.height();
+    if (!(event.ctrlKey && (event.shift || event.shiftKey))) {
+    // target should be the img tag
+      const target = $j(event.target);
+      const width = target.width();
+      const height = target.height();
 
-    const scaleX = parseFloat(monitorWidth / width);
-    const scaleY = parseFloat(monitorHeight / height);
-    const pos = target.offset();
-    const x = parseInt((event.pageX - pos.left) * scaleX);
-    const y = parseInt((event.pageY - pos.top) * scaleY);
+      const scaleX = parseFloat(monitorWidth / width);
+      const scaleY = parseFloat(monitorHeight / height);
+      const pos = target.offset();
+      const x = parseInt((event.pageX - pos.left) * scaleX);
+      const y = parseInt((event.pageY - pos.top) * scaleY);
 
-    if (showMode == 'events' || !imageControlMode) {
-      if (event.shift || event.shiftKey) {
-        streamCmdPan(x, y);
-        updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
-      } else if (event.ctrlKey) {
-        streamCmdZoomOut();
+      if (showMode == 'events' || !imageControlMode) {
+        if (event.shift || event.shiftKey) {
+          streamCmdPan(x, y);
+          updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
+        } else if (event.ctrlKey) {
+          streamCmdZoomOut();
+        } else {
+          streamCmdZoomIn(x, y);
+          updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
+        }
       } else {
-        streamCmdZoomIn(x, y);
-        updatePrevCoordinatFrame(x, y); //Fixing current coordinates after scaling or shifting
+        controlCmdImage(x, y);
       }
-    } else {
-      controlCmdImage(x, y);
     }
-  }
     // --- Old ZoomPan algorithm.
   }
 }
@@ -969,13 +969,13 @@ function initPage() {
   } else {
     document.getElementById('zoomOutBtn').classList.add("hidden");
   }
-  $j("#use-old-zoom-pan").click(function(){
+  $j("#use-old-zoom-pan").click(function() {
     useOldZoomPan = this.checked;
     setCookie('zmUseOldZoomPan', this.checked);
     location.reload();
   });
   document.getElementById('use-old-zoom-pan').checked = useOldZoomPan;
-// --- Support of old ZoomPan algorithm
+  // --- Support of old ZoomPan algorithm
 
   if (panZoomEnabled) {
     $j('.zoompan').each( function() {
@@ -1322,7 +1322,7 @@ function panZoomIn(el) {
     // Double the zoom step.
     panZoom[id].zoom(panZoom[id].getScale() * Math.exp(panZoomStep*2), {animate: true});
   } else {
-  panZoom[id].zoomIn();
+    panZoom[id].zoomIn();
   }
   monitorsSetScale(id);
   var el = document.getElementById('liveStream'+id);
@@ -1347,7 +1347,7 @@ function panZoomOut(el) {
     // Reset zoom
     panZoom[id].zoom(1, {animate: true});
   } else {
-  panZoom[id].zoomOut();
+    panZoom[id].zoomOut();
   }
   monitorsSetScale(id);
   var el = document.getElementById('liveStream'+id);

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -252,6 +252,12 @@ echo htmlSelect('changeRate', $maxfps_options, $options['maxfps']);
 ?>
         </span>
       </div>
+      <div class="form-check control-use-old-zoom-pan">
+        <input id="use-old-zoom-pan" class="form-check-input" type="checkbox" value="">
+        <label class="form-check-label" for="use-old-zoom-pan">
+          <?php echo translate('Use old ZoomPan') ?>
+        </label>
+      </div>
       <div id="sizeControl">
 
       </div><!--sizeControl-->


### PR DESCRIPTION
- Added variables: "panZoomMaxScale", "panZoomStep"
- The "setScale" function is no longer used
- Changed the "changeScale" Function (Fix: problem with image scaling when changing browser width)
- Enabled support for the old ZoomPan algorithm (Added a checkbox for switching)
- Added reset zoom option (Ctrl+click on the Zoom Out button)
- Added an option to double the Zoom In step (Ctrl+click on the Zoom In button)
- Fix: border IMG for alarm & alert status

Added:
- "Shift" button + mouse wheel - Zoom In / Zoom Out
- "Shift" button + mouse click anywhere in the image = applies Zoom Out to the clicked location.
- "Ctrl" button + mouse click anywhere in the image = reset Zoom to 1.
- Depending on the available actions, the appearance of the mouse cursor changes.