### PR TITLE
Feat: Added mouse wheel control for Zoom & others (montage.js)

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -53,7 +53,7 @@ function stringToNumber(str) {
 }
 
 function isPresetLayout(name) {
-  return (( name=='Freeform' || name=='1 Wide' || name=='2 Wide' || name=='3 Wide' || name=='4 Wide' || name=='6 Wide' || name=='8 Wide' name=='12 Wide' || name=='16 Wide' ) ? true : false);
+  return (( name=='Freeform' || name=='1 Wide' || name=='2 Wide' || name=='3 Wide' || name=='4 Wide' || name=='6 Wide' || name=='8 Wide' || name=='12 Wide' || name=='16 Wide' ) ? true : false);
 }
 
 function getCurrentNameLayout() {


### PR DESCRIPTION
Similar to Watch page.
"Shift" button + mouse wheel - Zoom In / Zoom Out
"Shift" button + mouse click anywhere in the image = applies Zoom Out to the clicked location. "Ctrl" button + mouse click anywhere in the image = reset Zoom to 1. Depending on the available actions, the appearance of the mouse cursor changes.

Removed unused Layout names '5 Wide', '7 Wide', '9 Wide', '10 Wide'

Scale recalculation no more than once every 0.2 sec.