### PR TITLE
Fix: Autoplay for MP4 (event.php)

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -301,11 +301,11 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
 <?php
 if ($video_tag) {
 ?>
-                  <video autoplay id="videoobj" class="video-js vjs-default-skin"
+                  <video autoplay="true" muted="muted" id="videoobj" class="video-js vjs-default-skin"
                     style="transform: matrix(1, 0, 0, 1, 0, 0);"
                    <?php echo $scale ? 'width="'.reScale($Event->Width(), $scale).'"' : '' ?>
                    <?php echo $scale ? 'height="'.reScale($Event->Height(), $scale).'"' : '' ?>
-                    data-setup='{ "controls": true, "autoplay": true, "preload": "auto", "playbackRates": [ <?php echo implode(',',
+                    data-setup='{ "controls": true, "autoplay": true, "muted": "muted", "preload": "auto", "playbackRates": [ <?php echo implode(',',
                       array_map(function($r){return $r/100;},
                         array_filter(
                           array_keys($rates),


### PR DESCRIPTION
Now there are no problems with autoplay.
Probably you still need to update the player #4006 or you don’t need to install “autoplay” & “muted” in “data-setup”

The error in the browser console has been resolved: "Uncaught (in promise) DOMException: play() failed because the user didn't interact with the document first."