### PR TITLE
Fix: Changed color of "background" and "text" in base theme for Frames table

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -24,6 +24,8 @@
 :root {
   --scrollbarBG: #F1F1F1;
   --sliderBG: #C1C1C1;
+  --alarmBG: #FFC0C0;
+  --alarmText: inherit;
 }
 
 @font-face {

--- a/web/skins/classic/css/base/views/frames.css
+++ b/web/skins/classic/css/base/views/frames.css
@@ -3,7 +3,8 @@
 }
 
 tr.alarm {
-  background-color: #fa8072;
+  background-color: var(--alarmBG);
+  color: var(--alarmText);
 }
 
 tr.bulk {


### PR DESCRIPTION
- Added vars color for "background" & "text" in base theme (skin.css)
- Set color "background" and "text" for "tr.alarm" from variables

**Before**
![before](https://github.com/ZoneMinder/zoneminder/assets/5006170/ea7928d1-8f03-4b13-b4c1-06815ef0c02a)


**After**
![1](https://github.com/ZoneMinder/zoneminder/assets/5006170/47508437-7904-4e35-9487-e4a50cf836da)

The text color definitely needed changing.
The background color seemed too bright to me and I changed it. But I'm not sure what should have been done.