### PR TITLE
When save cookies via PHP >= 7.3.0, add handling of the "path" value in the options (session.php)

### DIFF
--- a/web/includes/session.php
+++ b/web/includes/session.php
@@ -1,6 +1,9 @@
 <?php
 // Wrapper around setcookie that auto-sets samesite, and deals with older versions of php
 function zm_setcookie($cookie, $value, $options=array()) {
+  if (!isset($options['path'])) {
+    $options['path'] = '/';
+  }
   if (!isset($options['expires'])) {
     $options['expires'] = time()+3600*24*30*12*10; // 10 years?!
   }


### PR DESCRIPTION
Otherwise, cookies set via PHP will not be able to be changed in JS. Because JS saves cookies with path="/"
Closed: #4024