### PR TITLE
Fix: placement of monitors when initializing Layout (montage.js)

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -158,7 +158,9 @@ function selectLayout(new_layout_id) {
         monitor_wrapper.attr('gs-w', widthFrame).removeAttr('gs-x').removeAttr('gs-y').removeAttr('gs-h');
       }
     }
-    initGridStack();
+    setTimeout(() => {
+      initGridStack();
+    }, 500);
   } else { //CUSTOM
     document.getElementById("btnDeleteLayout").removeAttribute('disabled');
     for (let i = 0, length = monitors.length; i < length; i++) {


### PR DESCRIPTION
This is a temporary dirty code to check if the monitors are positioned correctly on preset layouts