### PR TITLE
Fix: placement of monitors when initializing Layout №2 (montage.js)

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -815,9 +815,9 @@ function initPage() {
   }, 200);
 
   setTimeout(() => {
-    $j('#monitors').removeClass('hidden-shift');
     selectLayout();
-  }, 50); //No matter what flickers. But perhaps this will not be necessary in the future...
+    $j('#monitors').removeClass('hidden-shift');
+	}, 50); //No matter what flickers. But perhaps this will not be necessary in the future...
   changeMonitorStatusPositon();
 
   if (panZoomEnabled) {

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -817,7 +817,7 @@ function initPage() {
   setTimeout(() => {
     selectLayout();
     $j('#monitors').removeClass('hidden-shift');
-	}, 50); //No matter what flickers. But perhaps this will not be necessary in the future...
+  }, 50); //No matter what flickers. But perhaps this will not be necessary in the future...
   changeMonitorStatusPositon();
 
   if (panZoomEnabled) {


### PR DESCRIPTION
This code is clean.
Should fix the situation with incorrect placement of monitors on preset layouts, but should be checked.