### PR TITLE
Fix: function "this.setMaxFPS" (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -819,7 +819,7 @@ function MonitorStream(monitorData) {
 
   this.setMaxFPS = function(maxfps) {
     if (1) {
-      this.streamCommand({command: CMD_MAXFPS, maxfps: currentSpeed});
+      this.streamCommand({command: CMD_MAXFPS, maxfps: maxfps});
     } else {
       var streamImage = this.getElement();
       const oldsrc = streamImage.attr('src');


### PR DESCRIPTION
The function didn't work!
The parameter "maxfps" was passed to the function, and "currentSpeed" was passed to "streamCommand" instead of "maxfps"