### PR TITLE
Undo changes #4051 ".chosen" (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -792,7 +792,7 @@ ul.nav.nav-pills.flex-column {
 }
 
 .chosen {
-  /* position: absolute !important; left: -999em !important; */
+  position: absolute !important; left: -999em !important;
 }
 
 .chosen-container-active .chosen-choices {


### PR DESCRIPTION
.chosen still needs to be hidden at the beginning of loading. Affects some pages. For example Events page
A more in-depth analysis is required.