### PR TITLE
Fix: Initial video load makes the UI jump around too much on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1132,6 +1132,7 @@ function initPage() {
     }
   }, 500);
 
+  document.getElementById('monitor').classList.remove('hidden-shift');
   changeObjectClass();
   changeSize();
 } // initPage

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -326,7 +326,7 @@ echo htmlSelect('cyclePeriod', $cyclePeriodOptions, $period, array('id'=>'cycleP
           </ul>
         </nav>
         <div id="wrapperMonitor" class="container-fluid col">
-          <div id="monitor" class="monitor"
+          <div id="monitor" class="monitor hidden-shift"
 >
 <?php 
 if ($monitor->Type() != 'WebSite') {


### PR DESCRIPTION
Hide image when page starts opening
Partial fix #4059