### PR TITLE
Added the ability to initialize with parameters (PanZoom)

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -30,13 +30,12 @@ var zmPanZoom = {
   * params['id'] : monitor id
   * params['contain'] : "inside" | "outside", default="outside"
   * params['disablePan'] : true || false
-  * & etc 
+  * & etc
   */
   action: function(action, params) {
     const _this = this;
     const objString = params['objString'];
     const contain = (params['contain']) ? params['contain'] : "outside";
-    const disablePan = params['disablePan'];
     const minScale = (contain != "outside") ? 0.1 : 1.0;
     if (action == "enable") {
       var id;
@@ -56,7 +55,7 @@ var zmPanZoom = {
       $j('.btn-zoom-in').removeClass('hidden');
       $j('.btn-zoom-out').removeClass('hidden');
       const objPanZoom = (params['additional'] && objString) ? id+objString : id;
-      
+
       // default value for ZM, if not explicitly specified in the parameters
       if (!('contain' in params)) params.contain = contain;
       if (!('minScale' in params)) params.minScale = minScale;
@@ -81,12 +80,12 @@ var zmPanZoom = {
           event.preventDefault(); //Avoid page scrolling
           if (!_this.panZoom[objPanZoom].additional) return;
 
-          const obj = (event.target.closest('#monitor'+id)) ? event.target.closest('#monitor'+id) /*Watch & Montage*/ : event.target.closest('#eventVideo') /*Event*/;
+          const obj = (event.target.closest('#monitor'+id)) ? event.target.closest('#monitor'+id)/*Watch & Montage*/ : event.target.closest('#eventVideo')/*Event*/;
           const objDim = obj.getBoundingClientRect();
           //Get the coordinates (x - the middle of the image, y - the top edge) of the point relative to which we will scale the image
           const x = objDim.x + objDim.width/2;
           const y = objDim.y;
-          const scale = (event.deltaY < 0) ? _this.panZoom[objPanZoom].getScale() * Math.exp(_this.panZoomStep) /*scrolling up*/ : _this.panZoom[objPanZoom].getScale() / Math.exp(_this.panZoomStep) /*scrolling down*/;
+          const scale = (event.deltaY < 0) ? _this.panZoom[objPanZoom].getScale() * Math.exp(_this.panZoomStep)/*scrolling up*/ : _this.panZoom[objPanZoom].getScale() / Math.exp(_this.panZoomStep)/*scrolling down*/;
           _this.panZoom[objPanZoom].zoomToPoint(scale, {clientX: x, clientY: y});
         } else if (_this.shifted && !_this.alted) {
           if (!_this.panZoom[id]) return;

--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -94,6 +94,18 @@ var zmPanZoom = {
       param['obj'].addEventListener('panzoomzoom', (event) => {
         if (typeof panZoomEventPanzoomzoom !== 'undefined' && $j.isFunction(panZoomEventPanzoomzoom)) panZoomEventPanzoomzoom(param['obj'], event);
       })
+      param['obj'].addEventListener('panzoomstart', (event) => {
+        if (typeof panZoomEventPanzoomstart !== 'undefined' && $j.isFunction(panZoomEventPanzoomstart)) panZoomEventPanzoomstart(param['obj'], event);
+      })
+      param['obj'].addEventListener('panzoompan', (event) => {
+        if (typeof panZoomEventPanzoompan !== 'undefined' && $j.isFunction(panZoomEventPanzoompan)) panZoomEventPanzoompan(param['obj'], event);
+      })
+      param['obj'].addEventListener('panzoomend', (event) => {
+        if (typeof panZoomEventPanzoomend !== 'undefined' && $j.isFunction(panZoomEventPanzoomend)) panZoomEventPanzoomend(param['obj'], event);
+      })
+      param['obj'].addEventListener('panzoomreset', (event) => {
+        if (typeof panZoomEventPanzoomreset !== 'undefined' && $j.isFunction(panZoomEventPanzoomreset)) panZoomEventPanzoomreset(param['obj'], event);
+      })
     } else if (action == "disable") { //Disable a specific object
       if (!this.panZoom[param['id']]) {
         console.log(`PanZoom for monitor "${param['id']}" was not initialized.`);

--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -60,7 +60,7 @@ var zmPanZoom = {
         const obj = $j(param['obj']).find('[id ^= "liveStream"]')[0];
         if (obj) {
           id = stringToNumber(obj.id); //Montage page
-        } 
+        }
       }
       if (!id) {
         console.log("The for panZoom action object was not found.", param);
@@ -90,22 +90,22 @@ var zmPanZoom = {
       param['obj'].addEventListener('panzoomchange', (event) => {
         if (typeof panZoomEventPanzoomchange !== 'undefined' && $j.isFunction(panZoomEventPanzoomchange)) panZoomEventPanzoomchange(param['obj'], event);
         //console.log('panzoomchange', event.detail) // => { x: 0, y: 0, scale: 1 }
-      })
+      });
       param['obj'].addEventListener('panzoomzoom', (event) => {
         if (typeof panZoomEventPanzoomzoom !== 'undefined' && $j.isFunction(panZoomEventPanzoomzoom)) panZoomEventPanzoomzoom(param['obj'], event);
-      })
+      });
       param['obj'].addEventListener('panzoomstart', (event) => {
         if (typeof panZoomEventPanzoomstart !== 'undefined' && $j.isFunction(panZoomEventPanzoomstart)) panZoomEventPanzoomstart(param['obj'], event);
-      })
+      });
       param['obj'].addEventListener('panzoompan', (event) => {
         if (typeof panZoomEventPanzoompan !== 'undefined' && $j.isFunction(panZoomEventPanzoompan)) panZoomEventPanzoompan(param['obj'], event);
-      })
+      });
       param['obj'].addEventListener('panzoomend', (event) => {
         if (typeof panZoomEventPanzoomend !== 'undefined' && $j.isFunction(panZoomEventPanzoomend)) panZoomEventPanzoomend(param['obj'], event);
-      })
+      });
       param['obj'].addEventListener('panzoomreset', (event) => {
         if (typeof panZoomEventPanzoomreset !== 'undefined' && $j.isFunction(panZoomEventPanzoomreset)) panZoomEventPanzoomreset(param['obj'], event);
-      })
+      });
     } else if (action == "disable") { //Disable a specific object
       if (!this.panZoom[param['id']]) {
         console.log(`PanZoom for monitor "${param['id']}" was not initialized.`);
@@ -189,8 +189,8 @@ var zmPanZoom = {
           obj_btn.style['cursor'] = 'auto';
         }
       } else {
-       const cursor = (disableZoom) ? 'auto' : 'zoom-out';
-       obj.style['cursor'] = cursor;
+        const cursor = (disableZoom) ? 'auto' : 'zoom-out';
+        obj.style['cursor'] = cursor;
         if (obj_btn) {
           obj_btn.style['cursor'] = cursor;
         }

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1067,6 +1067,7 @@ function streamReStart(oldId, newId) {
   applyMonitorControllable();
   streamPrepareStart(currentMonitor);
   zmPanZoom.init();
+  zmPanZoom.init({objString: '.imageFeed', disablePan: true, contain: 'inside', additional: true});
   loadFontFaceObserver();
   //document.getElementById('monitor').classList.remove('hidden-shift');
 }
@@ -1124,6 +1125,7 @@ function initPage() {
   // --- Support of old ZoomPan algorithm
 
   zmPanZoom.init();
+  zmPanZoom.init({objString: '.imageFeed', disablePan: true, contain: 'inside', additional: true});
 
   // Manage the BACK button
   bindButton('#backBtn', 'click', null, function onBackClick(evt) {
@@ -1404,6 +1406,30 @@ function panZoomIn(el) {
 
 function panZoomOut(el) {
   zmPanZoom.zoomOut(el);
+}
+
+function panZoomEventPanzoomzoom(event) {
+  //Temporarily not in use
+  /*
+  const obj = event.target;
+  const parent = obj.parentNode;
+  const objDim = obj.getBoundingClientRect();
+  const parentDim = parent.getBoundingClientRect();
+  const top = objDim.top - parentDim.top;
+  const h = objDim.height + top;
+  console.log("object", obj);
+  console.log("parentDim:", parentDim);
+  console.log("objDim:", objDim);
+  console.log("H:", h);
+  if (h>30) {
+    parent.style.height = h+'px';
+    console.log('panzoomzoom', event.detail) // => { x: 0, y: 0, scale: 1 }
+  }
+  */
+}
+
+function panZoomEventPanzoomchange(event) {
+
 }
 
 function monitorsSetScale(id=null) {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -629,8 +629,7 @@ function handleClick(event) {
 
     const obj_id = obj.getAttribute('id');
     if (obj_id) {
-      if (obj_id.indexOf("liveStream") >= 0)
-        zmPanZoom.click(monitorId);
+      if (obj_id.indexOf("liveStream") >= 0) zmPanZoom.click(monitorId);
     } else {
       console.log("obj does not have an id", obj);
     }


### PR DESCRIPTION
+ Change cursor style depending on disablePan & disableZoom
+ Added handling of error situations.
+ Added assignment of functions for listening to events "panzoomchange", "panzoomzoom"
+ During initialization, you can specify any parameters that will later be transferred directly to "Panzoom"
+ Added an experimental function for reducing the block containing the image (Shift+Alt+mouse wheel).
To do this, you need to initialize another object. For example like this:
 `"zmPanZoom.init({objString: '.imageFeed', disablePan: true, contain: 'inside', additional: true});"`
 The key parameter for additional control (Alt key) is "additional: true"

+ Code optimization
+ Added initialization of the experimental PanZoom function for reducing a block containing an image (Shift+Alt+mouse wheel) on Watch page