### PR TITLE
Fix: Unified style for Buttons=disabled

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -668,7 +668,7 @@ input[type=button]:disabled,
 input[type=submit]:disabled,
   a.disabled,
   a.btn-primary.disabled,
-.btn-primary:disabled {
+.btn-primary.disabled, .btn-primary:disabled, .btn-secondary.disabled, .btn-secondary:disabled {
     background-color: #aaaaaa;    
     border-color: #bbbbbb;
 }

--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -167,7 +167,7 @@ button:disabled,
 input[disabled],
 input[type=button]:disabled,
 input[type=submit]:disabled,
-.btn-primary:disabled {
+.btn-primary.disabled, .btn-primary:disabled, .btn-secondary.disabled, .btn-secondary:disabled {
   color: #888888;
   background-color: #666666;
   border-color: #666666;


### PR DESCRIPTION
The styles were specified in the CSS, for ".btn-primary:disabled" but were not applied to `button.disabled` because bootstrap style was a priority.
The style for ".btn-secondary:disabled" = ".btn-primary:disabled" is also set