### PR TITLE
Fix: If "opts.focal" - calculate coordinates taking into account the planned Scale, and not just the calculated Scale (jquery.panzoom.js)

### DIFF
--- a/web/skins/classic/assets/jquery.panzoom/dist/jquery.panzoom.js
+++ b/web/skins/classic/assets/jquery.panzoom/dist/jquery.panzoom.js
@@ -573,6 +573,7 @@
             if (!opts.force && opts.disableZoom) {
                 return;
             }
+            const toScalePlanned = toScale;
             toScale = result.scale;
             var toX = x;
             var toY = y;
@@ -581,8 +582,8 @@
                 // plus the current translation after the scale
                 // neutralized to no scale (as the transform scale will apply to the translation)
                 var focal = opts.focal;
-                toX = (focal.x / toScale - focal.x / scale + x * toScale) / toScale;
-                toY = (focal.y / toScale - focal.y / scale + y * toScale) / toScale;
+                toX = (focal.x / toScale - focal.x / scale + x * toScalePlanned) / toScalePlanned;
+                toY = (focal.y / toScale - focal.y / scale + y * toScalePlanned) / toScalePlanned;
             }
             var panResult = constrainXY(toX, toY, toScale, { relative: false, force: true });
             x = panResult.x;


### PR DESCRIPTION
I created a PR in the author's repository, but there is no feedback yet. https://github.com/timmywil/panzoom/pull/669

This PR corrects the position of the stream in #4072