### PR TITLE
Update charset header in ja_jp.php from Shift_JIS to UTF-8

### DIFF
--- a/web/lang/ja_jp.php
+++ b/web/lang/ja_jp.php
@@ -51,7 +51,7 @@
 //
 // Example
 // header( "Content-Type: text/html; charset=iso-8859-1" );
-header( "Content-Type: text/html; charset=Shift_JIS" );
+header( "Content-Type: text/html; charset=UTF-8" );
 
 // You may need to change your locale here if your default one is incorrect for the
 // language described in this file, or if you have multiple languages supported.


### PR DESCRIPTION
Given that most Japanese servers now use UTF-8, it makes sense to set UTF-8 as the default charset.