### PR TITLE
Fix: Recovering the Lost $storage_areas, $StorageById & $selected_monitor_ids Variable ( _monitor_filters.php, console.php, montagereview.php, report_event_audit.php)

### DIFF
--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -290,6 +290,7 @@ function buildMonitorsFilters() {
   return [
     "filterBar" => $html,
     "displayMonitors" => $displayMonitors,
+    "storage_areas" => $storage_areas
   ];
 }
 ?>

--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -290,7 +290,8 @@ function buildMonitorsFilters() {
   return [
     "filterBar" => $html,
     "displayMonitors" => $displayMonitors,
-    "storage_areas" => $storage_areas
+    "storage_areas" => $storage_areas,
+    "selected_monitor_ids" => $selected_monitor_ids
   ];
 }
 ?>

--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -291,6 +291,7 @@ function buildMonitorsFilters() {
     "filterBar" => $html,
     "displayMonitors" => $displayMonitors,
     "storage_areas" => $storage_areas,
+    "StorageById" => $StorageById,
     "selected_monitor_ids" => $selected_monitor_ids
   ];
 }

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -101,6 +101,7 @@ include('_monitor_filters.php');
 $resultMonitorFilters = buildMonitorsFilters();
 $filterbar = $resultMonitorFilters['filterBar'];
 $displayMonitors = $resultMonitorFilters['displayMonitors'];
+$storage_areas = $resultMonitorFilters['storage_areas'];
 
 $displayMonitorIds = array_map(function($m){return $m['Id'];}, $displayMonitors);
 

--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -102,6 +102,7 @@ $resultMonitorFilters = buildMonitorsFilters();
 $filterbar = $resultMonitorFilters['filterBar'];
 $displayMonitors = $resultMonitorFilters['displayMonitors'];
 $storage_areas = $resultMonitorFilters['storage_areas'];
+$StorageById = $resultMonitorFilters['StorageById'];
 
 $displayMonitorIds = array_map(function($m){return $m['Id'];}, $displayMonitors);
 

--- a/web/skins/classic/views/montagereview.php
+++ b/web/skins/classic/views/montagereview.php
@@ -61,6 +61,7 @@ include('_monitor_filters.php');
 $resultMonitorFilters = buildMonitorsFilters();
 $filterbar = $resultMonitorFilters['filterBar'];
 $displayMonitors = $resultMonitorFilters['displayMonitors'];
+$selected_monitor_ids = $resultMonitorFilters['selected_monitor_ids'];
 
 $preference = ZM\User_Preference::find_one([
     'UserId'=>$user->Id(),

--- a/web/skins/classic/views/report_event_audit.php
+++ b/web/skins/classic/views/report_event_audit.php
@@ -23,6 +23,7 @@ include('_monitor_filters.php');
 $resultMonitorFilters = buildMonitorsFilters();
 $filterbar = $resultMonitorFilters['filterBar'];
 $displayMonitors = $resultMonitorFilters['displayMonitors'];
+$selected_monitor_ids = $resultMonitorFilters['selected_monitor_ids'];
 
 if ( isset($_REQUEST['minTime']) ) {
   $minTime = validHtmlStr($_REQUEST['minTime']);


### PR DESCRIPTION
Fix for #4091