### PR TITLE
Feat: Show filter "Archive Status" on Events page

### DIFF
--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1120,7 +1120,7 @@ class Filter extends ZM_Object {
 
         if ( $term['attr'] == 'Archived' ) {
           $html .= '<span class="term-value-wrapper">';
-          $html .= htmlSelect("filter[Query][terms][$i][val]", $archiveTypes, $term['val'],['class'=>'chosen chosen-auto-width']).PHP_EOL;
+          $html .= htmlSelect("filter[Query][terms][$i][val]", $archiveTypes, $term['val'],['id'=>'filterArchived', 'class'=>'chosen chosen-auto-width']).PHP_EOL;
           $html .= '</span>';
         } else if ( $term['attr'] == 'Tags' ) {
           $selected = explode(',', $term['val']);
@@ -1128,7 +1128,7 @@ class Filter extends ZM_Object {
           if (count($selected) == 1 and !$selected[0]) {
             $selected = null;
           }
-          $options = ['class'=>'chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Tags')];
+          $options = ['id'=>'filterTags', 'class'=>'chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Tags')];
           if (isset($term['cookie'])) {
             $options['data-cookie'] = $term['cookie'];
 
@@ -1256,7 +1256,7 @@ class Filter extends ZM_Object {
             ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple']).PHP_EOL;
           $html .= '</span>';
         } else if ( $term['attr'] == 'Notes' ) {
-          $attrs = ['class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('Event Type')];
+          $attrs = ['id'=>'filterNotes', 'class'=>'term-value chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('Event Type')];
           $selected = explode(',', $term['val']);
           if (count($selected) == 1 and !$selected[0]) {
             $selected = null;

--- a/web/skins/classic/views/events.php
+++ b/web/skins/classic/views/events.php
@@ -64,7 +64,12 @@ if (!$filter->Id()) {
       'val' => $num_terms ? '' : (isset($_COOKIE['eventsTags']) ? $_COOKIE['eventsTags'] : ''),
       'cnj' => 'and', 'cookie'=>'eventsTags'));
   }
-  $filter->sort_terms(['Group','Monitor','StartDateTime','EndDateTime','Notes','Tags']);
+  if (!$filter->has_term('Archived')) {
+    $filter->addTerm(array('attr' => 'Archived', 'op' => '=',
+      'val' => $num_terms ? '' : (isset($_COOKIE['zmFilterArchived']) ? $_COOKIE['zmFilterArchived'] : ''),
+      'cnj' => 'and', 'cookie'=>'zmFilterArchived'));
+  }
+  $filter->sort_terms(['Group','Monitor','StartDateTime','EndDateTime','Notes','Tags','Archived']);
   #$filter->addTerm(array('cnj'=>'and', 'attr'=>'AlarmFrames', 'op'=> '>', 'val'=>'10'));
   #$filter->addTerm(array('cnj'=>'and', 'attr'=>'StartDateTime', 'op'=> '<=', 'val'=>''));
 }

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -519,7 +519,7 @@ function initPage() {
 }
 
 function filterEvents(clickedElement) {
-  if (clickedElement.target.id == 'Archived') {
+  if (clickedElement.target.id == 'filterArchived') {
     setCookie('zmFilterArchived', clickedElement.target.value);
   }
   filterQuery = '';

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -519,7 +519,7 @@ function initPage() {
 }
 
 function filterEvents(clickedElement) {
-  if (clickedElement.target.id == 'filterArchived') {
+  if (clickedElement.target && clickedElement.target.id == 'filterArchived') {
     setCookie('zmFilterArchived', clickedElement.target.value);
   }
   filterQuery = '';

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -518,7 +518,10 @@ function initPage() {
   table.show();
 }
 
-function filterEvents() {
+function filterEvents(clickedElement) {
+  if (clickedElement.target.id == 'Archived') {
+    setCookie('zmFilterArchived', clickedElement.target.value);
+  }
   filterQuery = '';
   $j('#fieldsTable input').each(function(index) {
     const el = $j(this);


### PR DESCRIPTION
Currently, if there is no "Archive Status" filter in the browser query string, then it is not displayed on the page. Now the "Archive Status" filter will always be displayed.