### PR TITLE
Do not create a Warning if you could not get the current monitor status from the DB (Monitor.php)

### DIFF
--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -423,7 +423,7 @@ public static function getStatuses() {
         $sql = 'SELECT * FROM `Monitor_Status` WHERE `MonitorId`=?';
         $row = dbFetchOne($sql, NULL, array($this->{'Id'}));
         if (!$row) {
-          Warning('Unable to load Monitor status record for Id='.$this->{'Id'}.' using '.$sql);
+          // Warning('Unable to load Monitor status record for Id='.$this->{'Id'}.' using '.$sql);
         } else {
           foreach ($row as $k => $v) {
             $this->{$k} = $v;


### PR DESCRIPTION
The only reason why the status could not be obtained is the absence of a monitor in the 'Monitor_Status' table. For example - Montage page is open and
- at this moment the connection with the camera is lost
- go to the camera settings and resave
- disabled Capturing
- and so on. In all of the above cases, a useless warning will be generated that only fills the log.

Or am I wrong?