### PR TITLE
clearer example of API parameters when changing the running state of zoneminder

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -245,7 +245,7 @@ This API changes monitor 1 to enable motion detection and recording on motion de
 
 ::
 
-  curl -XPOST http://server/zm/api/monitors/1.json -d "Monitor[Analysing]=Always&Monitor[Recording]=OnMotion"
+  curl -XPOST http://server/zm/api/monitors/1.json -d "Monitor[Function]=Modect&Monitor[Enabled]=1"
   
 Get Daemon Status of Monitor 1
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Small suggested documentation change.

I found this example in an older version of the API documentation and found it to be a MUCH clearer example of the parameters and their function.

I was looking for a way to easily change the state of zoneminder running within Docker/Kubernetes using Cron of the host system. I struggled with this until I came across this version of the documentation;
https://zoneminder.readthedocs.io/en/1.32.3/api.html

```
curl http://localhost:9980/zm/api/monitors/3.json -d "Monitor[Function]=Modect&Monitor[Enabled]=1"
```
instead of
```
curl -XPOST http://server/zm/api/monitors/1.json -d "Monitor[Analysing]=Always&Monitor[Recording]=OnMotion"
```

Thanks ^,^