### PR TITLE
Update debian.rst -- fix redirect of stdout in sudo

### DIFF
--- a/docs/installationguide/debian.rst
+++ b/docs/installationguide/debian.rst
@@ -74,7 +74,7 @@ The backports repository is deactivated by default, so with the second line we e
 
 ::
 
-    sudo echo 'deb http://deb.debian.org/debian bookworm-backports main contrib' >> /etc/apt/sources.list
+    sudo bash -c "echo 'deb http://deb.debian.org/debian bookworm-backports main contrib' >> /etc/apt/sources.list"
     sudo apt update
     sudo apt -t bookworm-backports install zoneminder
 


### PR DESCRIPTION
As written, you can't redirect sudo output as desired. Wrapping the "echo deb..." in quotes and prefacing with "bash -c" will permit a regular user to redirect stdout to /etc/apt/sources.list