### PR TITLE
Update debian.rst

### DIFF
--- a/docs/installationguide/debian.rst
+++ b/docs/installationguide/debian.rst
@@ -39,7 +39,7 @@ Run the following commands.
 
 ::
 
-    sudo apt install mariadb-server
+    sudo apt install apache2 mariadb-server
 
 Switch into root user and create database and database user
 


### PR DESCRIPTION
Failing to install `apache2` results in subsequent calls to `a2enconf` and `a2enmod` failing because they might not have been installed. (in my case, I was using a minimal Debian 12 install which doesn't install `apache2` by default)