### PR TITLE
Feat: Enable "touchAction" if Zoom=1 and disable if Zoom<>1 (panzoom.js)

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -177,9 +177,9 @@ var zmPanZoom = {
   setTouchAction: function(el) {
     const currentScale = el.getScale().toFixed(1);
     if (currentScale == 1) {
-      el.setOptions({ touchAction: 'manipulation' });
+      el.setOptions({touchAction: 'manipulation'});
     } else {
-      el.setOptions({ touchAction: 'none' });
+      el.setOptions({touchAction: 'none'});
     }
   },
 

--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -176,7 +176,6 @@ var zmPanZoom = {
 
   setTouchAction: function(el) {
     const currentScale = el.getScale().toFixed(1);
-console.log("currentScale_=>", currentScale);
     if (currentScale == 1) {
       el.setOptions({ touchAction: 'manipulation' });
     } else {


### PR DESCRIPTION
Enable "touchAction" if Zoom=1 and disable if Zoom<>1 
This will allow canvas panning when capturing an image on mobile devices with Zoom=1 The issue may be closed: https://forums.zoneminder.com/viewtopic.php?p=135128&sid=7e7685052e5f107a364dfd445565643f#p135128