### PR TITLE
Feat: Added support for full screen when double clicking on Stream on Event page

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1224,6 +1224,12 @@ var doubleClickOnStream = function(event, touchEvent) {
     } else {
       openFullscreen(target);
     }
+    if (isMobile()) {
+      setTimeout(function() {
+        //For some mobile devices resizing does not work. You need to set a delay and re-call the 'resize' event
+        window.dispatchEvent(new Event('resize'));
+      }, 500);
+    }
   }
 };
 

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1202,18 +1202,18 @@ function loadFontFaceObserver() {
   });
 }
 
-var doubleClickOnStream = function (event, touchEvent) {
+var doubleClickOnStream = function(event, touchEvent) {
   let target = null;
   if (event.target) {// Click NOT on touch screen, use THIS
-    //Process only double clicks directly on the image, excluding clicks, 
+    //Process only double clicks directly on the image, excluding clicks,
     //for example, on zoom buttons and other elements located in the image area.
-    if (event.target.id && 
-      (event.target.id.indexOf('evtStream') != -1 || event.target.id.indexOf('liveStream') != -1)){
+    if (event.target.id &&
+      (event.target.id.indexOf('evtStream') != -1 || event.target.id.indexOf('liveStream') != -1)) {
       target = this;
     }
   } else {// Click on touch screen, use EVENT
-    if (touchEvent.target.id && 
-      (touchEvent.target.id.indexOf('evtStream') != -1 || touchEvent.target.id.indexOf('liveStream') != -1)){
+    if (touchEvent.target.id &&
+      (touchEvent.target.id.indexOf('evtStream') != -1 || touchEvent.target.id.indexOf('liveStream') != -1)) {
       target = event;
     }
   }
@@ -1225,9 +1225,9 @@ var doubleClickOnStream = function (event, touchEvent) {
       openFullscreen(target);
     }
   }
-}
+};
 
-var doubleTouch = function (e) {
+var doubleTouch = function(e) {
   if (e.touches.length === 1) {
     if (!expiredTap) {
       expiredTap = e.timeStamp + 300;
@@ -1242,6 +1242,6 @@ var doubleTouch = function (e) {
       expiredTap = e.timeStamp + 300;
     }
   }
-}
+};
 
 loadFontFaceObserver();

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -39,6 +39,7 @@ var icons = {
 };
 
 var panZoomEnabled = true; //Add it to settings in the future
+var expiredTap; //Time between touch screen clicks. Used to analyze double clicks
 
 function checkSize() {
   if ( 0 ) {
@@ -1199,6 +1200,48 @@ function loadFontFaceObserver() {
   }, function() {
     $j('.material-icons').css('display', 'inline-block');
   });
+}
+
+var doubleClickOnStream = function (event, touchEvent) {
+  let target = null;
+  if (event.target) {// Click NOT on touch screen, use THIS
+    //Process only double clicks directly on the image, excluding clicks, 
+    //for example, on zoom buttons and other elements located in the image area.
+    if (event.target.id && 
+      (event.target.id.indexOf('evtStream') != -1 || event.target.id.indexOf('liveStream') != -1)){
+      target = this;
+    }
+  } else {// Click on touch screen, use EVENT
+    if (touchEvent.target.id && 
+      (touchEvent.target.id.indexOf('evtStream') != -1 || touchEvent.target.id.indexOf('liveStream') != -1)){
+      target = event;
+    }
+  }
+
+  if (target) {
+    if (document.fullscreenElement) {
+      closeFullscreen();
+    } else {
+      openFullscreen(target);
+    }
+  }
+}
+
+var doubleTouch = function (e) {
+  if (e.touches.length === 1) {
+    if (!expiredTap) {
+      expiredTap = e.timeStamp + 300;
+    } else if (e.timeStamp <= expiredTap) {
+      // remove the default of this event ( Zoom )
+      e.preventDefault();
+      doubleClickOnStream(this, e);
+      // then reset the variable for other "double Touches" event
+      expiredTap = null;
+    } else {
+      // if the second touch was expired, make it as it's the first
+      expiredTap = e.timeStamp + 300;
+    }
+  }
 }
 
 loadFontFaceObserver();

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1642,6 +1642,14 @@ function initPage() {
     removeTag(tag);
   });
 
+  // Event listener for double click
+  //var elStream = document.querySelectorAll('[id ^= "liveStream"], [id ^= "evtStream"]');
+  var elStream = document.querySelectorAll('[id = "wrapperEventVideo"]');
+  Array.prototype.forEach.call(elStream, (el) => {
+    el.addEventListener('touchstart', doubleTouch);
+    el.addEventListener('dblclick', doubleClickOnStream);
+  });
+
   streamPlay();
 
   if ( parseInt(ZM_OPT_USE_GEOLOCATION) && parseFloat(eventData.Latitude) && parseFloat(eventData.Longitude)) {


### PR DESCRIPTION
Double-clicking on the event you are viewing will either enable or disable full-screen mode specifically for Stream, including the DVR control buttons.
Works for both touch screens and regular keyboards.
I find this quite useful.
