### PR TITLE
Removing avcodec_close, avcodec_free_context is replacement and been …

### DIFF
--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -440,7 +440,7 @@ int zm_send_frame_receive_packet(AVCodecContext *ctx, AVFrame *frame, AVPacket &
 
 void zm_free_codec(AVCodecContext **ctx) {
   if (*ctx) {
-    avcodec_close(*ctx);
+    //avcodec_close(*ctx);
     // We allocate and copy in newer ffmpeg, so need to free it
     avcodec_free_context(ctx);
     *ctx = nullptr;

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -607,14 +607,14 @@ int FfmpegCamera::Close() {
   mLastAudioPTS = 0;
 
   if (mVideoCodecContext) {
-    avcodec_close(mVideoCodecContext);
+    //avcodec_close(mVideoCodecContext);
     avcodec_free_context(&mVideoCodecContext);
     mVideoCodecContext = nullptr;
   }
 
   if (mAudioCodecContext and !mSecondInput) {
     // If second input, then these will get freed in FFmpeg_Input's destructor
-    avcodec_close(mAudioCodecContext);
+    //avcodec_close(mAudioCodecContext);
     avcodec_free_context(&mAudioCodecContext);
     mAudioCodecContext = nullptr;
   }

--- a/src/zm_ffmpeg_input.cpp
+++ b/src/zm_ffmpeg_input.cpp
@@ -123,7 +123,7 @@ int FFmpeg_Input::Open(const char *filepath) {
 int FFmpeg_Input::Close( ) {
   if (streams) {
     for (unsigned int i = 0; i < input_format_context->nb_streams; i += 1) {
-      avcodec_close(streams[i].context);
+      //avcodec_close(streams[i].context);
       avcodec_free_context(&streams[i].context);
       streams[i].context = nullptr;
     }

--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -369,7 +369,8 @@ VideoStream::~VideoStream( ) {
 
   /* close each codec */
   if ( ost ) {
-    avcodec_close( codec_context );
+    //avcodec_close( codec_context );
+    avcodec_free_context(&codec_context);
     av_free( video_outbuf );
   }
 

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -86,7 +86,8 @@ RemoteCameraRtsp::RemoteCameraRtsp(
 RemoteCameraRtsp::~RemoteCameraRtsp() {
 
   if ( mVideoCodecContext ) {
-    avcodec_close(mVideoCodecContext);
+    //avcodec_close(mVideoCodecContext);
+    avcodec_free_context(&mVideoCodecContext);
     mVideoCodecContext = nullptr; // Freed by avformat_free_context in the destructor of RtspThread class
   }
   // Is allocated in RTSPThread and is free there as well

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -746,7 +746,7 @@ VideoStore::~VideoStore() {
   video_in_ctx = nullptr;
 
   if (video_out_ctx) {
-    avcodec_close(video_out_ctx);
+    //avcodec_close(video_out_ctx);
     Debug(3, "Freeing video_out_ctx");
     avcodec_free_context(&video_out_ctx);
     if (hw_device_ctx) {
@@ -758,13 +758,13 @@ VideoStore::~VideoStore() {
   if (audio_out_stream) {
     audio_in_codec = nullptr;
     if (audio_in_ctx) {
-      avcodec_close(audio_in_ctx);
+      //avcodec_close(audio_in_ctx);
       avcodec_free_context(&audio_in_ctx);
     }
 
     if (audio_out_ctx) {
       Debug(4, "Success closing audio_out_ctx");
-      avcodec_close(audio_out_ctx);
+      //avcodec_close(audio_out_ctx);
       avcodec_free_context(&audio_out_ctx);
     }
 


### PR DESCRIPTION
…around since 2014, so should be no reason to version test. just did them as comments first, but if look good I will remove the lines with second commit before we merge.

src/zm_remote_camera_rtsp.cpp was the one I was not so sure I should add the free to.