### PR TITLE
Feat: Progress bar now works when viewing MP4 via video.js on Event page

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -960,16 +960,22 @@ function drawProgressBar() {
 
 // Shows current stream progress.
 function updateProgressBar() {
+  if (vid) {
+    if (!eventData) return;
+    var currentTime = vid.currentTime();
+    var progressDate = new Date(currentTime);
+  } else {
   if (!(eventData && streamStatus)) {
     return;
-  } // end if ! eventData && streamStatus
-  let curWidth = (streamStatus.progress / parseFloat(eventData.Length)) * 100;
-  if (curWidth > 100) curWidth = 100;
-
-  const progressDate = new Date(eventData.StartDateTime);
+    }
+    var currentTime = streamStatus.progress;
+    var progressDate = new Date(eventData.StartDateTime);
   progressDate.setTime(progressDate.getTime() + (streamStatus.progress*1000));
-
+  }
   const progressBox = $j("#progressBox");
+  let curWidth = (currentTime / parseFloat(eventData.Length)) * 100;
+  if (curWidth > 100) curWidth = 100;
+  
   progressBox.css('width', curWidth + '%');
   progressBox.attr('title', progressDate.toLocaleTimeString());
 } // end function updateProgressBar()
@@ -1709,6 +1715,12 @@ function initPage() {
       updateScale = false;
     }
   }, 500);
+
+  if (vid) {
+    setInterval(() => {
+      updateProgressBar();
+    }, streamTimeout);
+  }
 } // end initPage
 
 function addOrCreateTag(tagValue) {

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -965,17 +965,15 @@ function updateProgressBar() {
     var currentTime = vid.currentTime();
     var progressDate = new Date(currentTime);
   } else {
-  if (!(eventData && streamStatus)) {
-    return;
-    }
+    if (!(eventData && streamStatus)) return;
     var currentTime = streamStatus.progress;
     var progressDate = new Date(eventData.StartDateTime);
-  progressDate.setTime(progressDate.getTime() + (streamStatus.progress*1000));
+    progressDate.setTime(progressDate.getTime() + (streamStatus.progress*1000));
   }
   const progressBox = $j("#progressBox");
   let curWidth = (currentTime / parseFloat(eventData.Length)) * 100;
   if (curWidth > 100) curWidth = 100;
-  
+
   progressBox.css('width', curWidth + '%');
   progressBox.attr('title', progressDate.toLocaleTimeString());
 } // end function updateProgressBar()


### PR DESCRIPTION
I'm not sure if this PR fixes #4134
But now the Progress bar correctly displays the timeline..
I don't know if this ever worked before....
![12345r](https://github.com/user-attachments/assets/e6bf0f1a-2cb5-4a39-8708-057a997acfa2)
