### PR TITLE
Fix: PanZoom Panning didn't work when using "preventDefault"

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -251,6 +251,12 @@ var zmPanZoom = {
         }
       }
     }
+
+    if (this.panZoom[id].getScale().toFixed(1) > 1) {
+      this.panZoom[id].setOptions({handleStartEvent: (event) => {event.preventDefault()}});
+    } else {
+      this.panZoom[id].setOptions({handleStartEvent: (event) => {}});
+    }
   },
 
   click: function(id) {

--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -253,7 +253,9 @@ var zmPanZoom = {
     }
 
     if (this.panZoom[id].getScale().toFixed(1) > 1) {
-      this.panZoom[id].setOptions({handleStartEvent: (event) => {event.preventDefault()}});
+      this.panZoom[id].setOptions({handleStartEvent: (event) => {
+        event.preventDefault();
+      }});
     } else {
       this.panZoom[id].setOptions({handleStartEvent: (event) => {}});
     }


### PR DESCRIPTION
This happened after PR #4137
When Scale panZoom > 1, you need to use "preventDefault" for Panning to work correctly. But at the same time (if Scale panZoom > 1), clicking on the progress bar generated by video.js will not work. In principle, this is not critical, because when increasing, the progress bar generated by video.js usually goes beyond the visible boundaries.