### PR TITLE
Don't execute "location.replace" when moving to next event (event.js)

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -690,8 +690,8 @@ function streamNext(action) {
   // How about we just reload the page?
   //
   if (vid==null) streamReq({command: CMD_QUIT});
-  location.replace(thisUrl + '?view=event&eid=' + nextEventId + filterQuery + sortQuery);
-  return;
+  //location.replace(thisUrl + '?view=event&eid=' + nextEventId + filterQuery + sortQuery);
+  //return;
   if (vid && ( NextEventDefVideoPath.indexOf('view_video') > 0 )) {
     // on and staying with videojs
     CurEventDefVideoPath = NextEventDefVideoPath;


### PR DESCRIPTION
This works for Gapless.
I haven't tested the rest.
The information block certainly isn't updated. Maybe something else isn't updated either.
I don't know who did this and why they didn't finish it....

Related to #4132