### PR TITLE
fix(events): Initial hidden columns when cookie doesn't exist

### DIFF
--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -311,7 +311,7 @@ function initPage() {
   table.bootstrapTable({icons: icons});
 
   // Hide these columns on first run when no cookie is saved
-  if (!getCookie('zmEventsTable.bs.table.columns')) {
+  if (!getCookie('zmEventsTable.bs.table.hiddenColumns')) {
     // table.bootstrapTable('hideColumn', 'Archived');
     table.bootstrapTable('hideColumn', 'Emailed');
   }


### PR DESCRIPTION
The name of the cookie is 
zmEventsTable.bs.table.hiddenColumns

not
zmEventsTable.bs.table.columns