### PR TITLE
Fix: isOutOfViewport calculation of the block bottom for sticky mode & change calculation "out.all" on Montage page

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -837,6 +837,7 @@ function initPage() {
 
   document.addEventListener('scrollend', on_scroll); // for non-sticky
   document.getElementById('content').addEventListener('scrollend', on_scroll);
+  window.addEventListener('resize', on_scroll);
 } // end initPage
 
 function on_scroll() {

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -862,7 +862,7 @@ function isOutOfViewport(elem) {
   const out = {};
   out.top = (bounding.top < headerHeight) || ( bounding.top > (window.innerHeight || document.documentElement.clientHeight) );
   out.left = (bounding.left < 0) || (bounding.left > (window.innerWidth || document.documentElement.clientWidth));
-  out.bottom = (bounding.bottom > (window.innerHeight-headerHeight || document.documentElement.clientHeight-headerHeight) ) || (bounding.bottom < 0);
+  out.bottom = (bounding.bottom > (window.innerHeight-headerHeight || document.documentElement.clientHeight-headerHeight) ) || (bounding.bottom < headerHeight);
   out.right = (bounding.right > (window.innerWidth || document.documentElement.clientWidth) ) || (bounding.right < 0);
   out.any = out.top || out.left || out.bottom || out.right;
   out.all = (out.top && out.bottom ) || (out.left && out.right);

--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -860,12 +860,16 @@ function isOutOfViewport(elem) {
 
   // Check if it's out of the viewport on each side
   const out = {};
-  out.top = (bounding.top < headerHeight) || ( bounding.top > (window.innerHeight || document.documentElement.clientHeight) );
+  out.topUp = (bounding.top < headerHeight);
+  out.topDown = ( bounding.top > (window.innerHeight || document.documentElement.clientHeight) );
+  out.top = (out.topUp || out.topDown);
   out.left = (bounding.left < 0) || (bounding.left > (window.innerWidth || document.documentElement.clientWidth));
-  out.bottom = (bounding.bottom > (window.innerHeight-headerHeight || document.documentElement.clientHeight-headerHeight) ) || (bounding.bottom < headerHeight);
+  out.bottomUp = (bounding.bottom < headerHeight);
+  out.bottomDown = (bounding.bottom > (window.innerHeight-headerHeight || document.documentElement.clientHeight-headerHeight) );
+  out.bottom = (out.bottomUp || out.bottomDown);
   out.right = (bounding.right > (window.innerWidth || document.documentElement.clientWidth) ) || (bounding.right < 0);
   out.any = out.top || out.left || out.bottom || out.right;
-  out.all = (out.top && out.bottom ) || (out.left && out.right);
+  out.all = (out.topUp && out.bottomUp ) || (out.topDown && out.bottomDown ) || (out.left && out.right);
   //console.log( 'top: ' + out.top + ' left: ' + out.left + ' bottom: '+out.bottom + ' right: '+out.right);
 
   return out;


### PR DESCRIPTION
- There may be a situation where the top part of the image extends beyond the top border of the document, and the bottom part of the image extends beyond the bottom border of the document. In this case, the monitor should not stop, because the middle part is displayed on the screen! This requires a separate calculation of the exit beyond the boundaries of the visible area. The image will be considered hidden only if the top and bottom parts of the image are hidden in the same place (either at the top or at the bottom) of the document.

- When resizing the browser window, execute "isOutOfViewport"