### PR TITLE
Fix: Always use only #wrapperEventVideo to enable fullscreen mode on Event page

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1654,9 +1654,10 @@ function initPage() {
 
   // Event listener for double click
   //var elStream = document.querySelectorAll('[id ^= "liveStream"], [id ^= "evtStream"]');
-  // When using video.js, the document will have both #videoobj and #wrapperEventVideo, but we only need #videoobj
-  const elStreamVideoJS = document.querySelectorAll("[id = 'videoobj']");
-  const elStream = (elStreamVideoJS.length > 0) ? elStreamVideoJS : document.querySelectorAll("[id = 'wrapperEventVideo']");
+  //// When using video.js, the document will have both #videoobj and #wrapperEventVideo, but we only need #videoobj
+  //const elStreamVideoJS = document.querySelectorAll("[id = 'videoobj']");
+  //const elStream = (elStreamVideoJS.length > 0) ? elStreamVideoJS : document.querySelectorAll("[id = 'wrapperEventVideo']");
+  const elStream = document.querySelectorAll("[id = 'wrapperEventVideo']");
   Array.prototype.forEach.call(elStream, (el) => {
     el.addEventListener('touchstart', doubleTouch);
     el.addEventListener('dblclick', doubleClickOnStream);

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1654,7 +1654,9 @@ function initPage() {
 
   // Event listener for double click
   //var elStream = document.querySelectorAll('[id ^= "liveStream"], [id ^= "evtStream"]');
-  var elStream = document.querySelectorAll("[id = 'wrapperEventVideo'], [id = 'videoobj']");
+  // When using video.js, the document will have both #videoobj and #wrapperEventVideo, but we only need #videoobj
+  const elStreamVideoJS = document.querySelectorAll("[id = 'videoobj']");
+  const elStream = (elStreamVideoJS.length > 0) ? elStreamVideoJS : document.querySelectorAll("[id = 'wrapperEventVideo']");
   Array.prototype.forEach.call(elStream, (el) => {
     el.addEventListener('touchstart', doubleTouch);
     el.addEventListener('dblclick', doubleClickOnStream);


### PR DESCRIPTION
addEventListener should be used only for one block on the page, otherwise there will be problems. Closed: https://forums.zoneminder.com/viewtopic.php?p=135677#p135677