### PR TITLE
Fix: Scaling of control buttons (Zoom, Edit, etc.) located on the Stream depending on the width of the Stream on Event page witch use video.js

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1284,7 +1284,7 @@ var doubleTouch = function(e) {
 };
 
 function setButtonSizeOnStream() {
-  const elStream = document.querySelectorAll('[id ^= "liveStream"], [id ^= "evtStream"]');
+  const elStream = document.querySelectorAll('[id ^= "liveStream"], [id ^= "evtStream"], [id = "videoobj"]');
   Array.prototype.forEach.call(elStream, (el) => {
     //It is necessary to calculate the size for each Stream, because on the Montage page they can be of different sizes.
     const w = el.offsetWidth;


### PR DESCRIPTION
Fix to https://github.com/ZoneMinder/zoneminder/pull/4121/files