### PR TITLE
Fix alarms() out of scope

### DIFF
--- a/src/zm_monitor_onvif.cpp
+++ b/src/zm_monitor_onvif.cpp
@@ -284,8 +284,9 @@ int SOAP_ENV__Fault(struct soap *soap, char *faultcode, char *faultstring, char 
 #endif
 
 void Monitor::ONVIF::SetNoteSet(Event::StringSet &noteSet) {
-  if (alarms.empty()) return;
   #ifdef WITH_GSOAP
+    if (alarms.empty()) return;
+
     std::string note = "";
     for (auto it = alarms.begin(); it != alarms.end(); ++it) {
       note = it->first + "/" + it->second;


### PR DESCRIPTION
The string alarms() is only valid when the define WITH_GSOAP is present.

Fixes: a0a95d887c03 ("Don't crash when alarms is empty")