### PR TITLE
Fix: incorrect placement of brackets (event.php)

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -151,7 +151,7 @@ if ((!$replayMode) or !$replayModes[$replayMode]) {
 }
 
 $video_tag = ($codec == 'MP4') || 
-  ((false !== strpos($Event->DefaultVideo(), 'h264')) || (false !== strpos($Event->DefaultVideo(), 'av1')) && ($codec === 'auto'));
+  ((false !== strpos($Event->DefaultVideo(), 'h264') || false !== strpos($Event->DefaultVideo(), 'av1')) && ($codec === 'auto'));
 
 // videojs zoomrotate only when direct recording
 $Zoom = 1;


### PR DESCRIPTION
Because of this it is not possible to switch to the "Codec = MGPEG" mode The error appeared here: https://github.com/ZoneMinder/zoneminder/commit/2229e880b187525110a17501c3697d30216b6c65