### PR TITLE
Fix libgsoap linking in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,11 +165,15 @@ target_link_libraries(zm
   PRIVATE
     zm-core-interface)
 
+set(GSOAP_LIBRARIES ${GSOAP_CXX_LIBRARIES})
+if(HAVE_LIBOPENSSL)
+  set(GSOAP_LIBRARIES ${GSOAP_SSL_CXX_LIBRARIES})
+endif()
+
 if(GSOAP_FOUND)
   target_link_libraries(zm
     PUBLIC
-      ${GSOAP_CXX_LIBRARIES}
-      ${GSOAP_SSL_CXX_LIBRARIES}
+      ${GSOAP_LIBRARIES}
       ${OPENSSL_SSL_LIBRARY}
       ${OPENSSL_CRYPTO_LIBRARY})
 endif()


### PR DESCRIPTION
libgsoap supplies both libgsoap++.a and libgsoapssl++.a however an application should link to one of those libraries not both.

An example from gsoap-2.8 samples:

With SSL:
/usr/bin/clang++ -DLINUX -g -O2   -o json-GitHub json_GitHub-json-GitHub.o json_GitHub-xml-rpc.o json_GitHub-json.o  json_GitHub-soapC.o ../../../gsoap/libgsoapssl++.a -lm -lssl -lcrypto -lz

Without SSL:
/usr/bin/clang++ -DLINUX -g -O2   -o json-currentTimeServer json-currentTimeServer.o xml-rpc.o json.o  soapC.o ../../../gsoap/libgsoap++.a -lm -lpthread

Right now src/CMakeLists.txt is try to link to both libgsoap++ and libgsoapssl++.

/usr/bin/ld: /lib/libgsoapssl++.a(libgsoapssl___a-stdsoap2_ssl_cpp.o): in function `soap_query':
(.text+0x1880): multiple definition of `soap_query'; /lib/libgsoap++.a(libgsoap___a-stdsoap2_cpp.o):(.text+0x1890): first defined here
/usr/bin/ld: /lib/libgsoapssl++.a(libgsoapssl___a-stdsoap2_ssl_cpp.o): in function `soap_query_decode':
(.text+0x18a0): multiple definition of `soap_query_decode'; /lib/libgsoap++.a(libgsoap___a-stdsoap2_cpp.o):(.text+0x18b0): first defined here
/usr/bin/ld: /lib/libgsoapssl++.a(libgsoapssl___a-stdsoap2_ssl_cpp.o): in function `soap_query_key':
(.text+0x1a50): multiple definition of `soap_query_key'; /lib/libgsoap++.a(libgsoap___a-stdsoap2_cpp.o):(.text+0x1a60): first defined here

Change src/CMakeLists.txt so that

1. libgsoap++ is the default library to link
2. libgsoapssl++ is linked to instead if HAVE_OPENSSL is true

This means that if openssl is not detected libgsoap++ will be linked otherwise libgsoapssl++ will be linked.