### PR TITLE
Small fix for Apache virtual server configuration instructions.

### DIFF
--- a/distros/beowulf/README.Debian
+++ b/distros/beowulf/README.Debian
@@ -64,8 +64,8 @@ Apache can be configured as folder "/zm" using sample .conf:
 Alternatively Apache web site configuration template can be used to setup
 zoneminder as "http://zoneminder":
 
-    sudo cp -v /usr/share/doc/zoneminder/examples/apache.conf /etc/apache2/sites-available/
-    sudo a2ensite zoneminder.conf
+    sudo cp -v /usr/share/doc/zoneminder/examples/apache.conf /etc/apache2/sites-available/zoneminder.conf
+    sudo a2ensite zoneminder
 
 Common configuration steps for Apache2:
 

--- a/distros/ubuntu2004/README.Debian
+++ b/distros/ubuntu2004/README.Debian
@@ -64,8 +64,8 @@ Apache can be configured as folder "/zm" using sample .conf:
 Alternatively Apache web site configuration template can be used to setup
 zoneminder as "http://zoneminder":
 
-    sudo cp -v /usr/share/doc/zoneminder/examples/apache.conf /etc/apache2/sites-available/
-    sudo a2ensite zoneminder.conf
+    sudo cp -v /usr/share/doc/zoneminder/examples/apache.conf /etc/apache2/sites-available/zoneminder.conf
+    sudo a2ensite zoneminder
 
 Common configuration steps for Apache2:
 


### PR DESCRIPTION
The `README.Debian` installation instructions when setting up as "http://zoneminder" used to result in the virtual server configuration at `/etc/apache2/sites-available/apache.conf`, so the `a2ensite` would fail.  This fix names the file `/etc/apache2/sites-available/zoneminder.conf` so that the subsequent `a2ensite` command succeeds.