### PR TITLE
Fix: URL parameters for RTSP2Web Type MSE due to which playback was unavailable & fix type HLS

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -287,7 +287,8 @@ function MonitorStream(monitorData) {
           });
           const mseUrl = rtsp2webModUrl;
           mseUrl.protocol = useSSL ? 'wss' : 'ws';
-          mseUrl.pathname = "/stream/" + this.id + "/channel/0/mse?uuid=" + this.id + "&channel=0";
+          mseUrl.pathname = "/stream/" + this.id + "/channel/0/mse";
+          mseUrl.search = "uuid=" + this.id + "&channel=0";
           startMsePlay(this, videoEl, mseUrl.href);
         } else if (this.RTSP2WebType == 'WebRTC') {
           const webrtcUrl = rtsp2webModUrl;

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -12,6 +12,9 @@ function MonitorStream(monitorData) {
   this.RTSP2WebEnabled = monitorData.RTSP2WebEnabled;
   this.RTSP2WebType = monitorData.RTSP2WebType;
   this.webrtc = null;
+  this.hls = null;
+  this.mse = null;
+  this.wsMSE = null;
   this.mseStreamingStarted = false;
   this.mseQueue = [];
   this.mseSourceBuffer = null;
@@ -272,9 +275,9 @@ function MonitorStream(monitorData) {
           }
           */
           if (Hls.isSupported()) {
-            const hls = new Hls();
-            hls.loadSource(hlsUrl.href);
-            hls.attachMedia(videoEl);
+            this.hls = new Hls();
+            this.hls.loadSource(hlsUrl.href);
+            this.hls.attachMedia(videoEl);
           } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
             videoEl.src = hlsUrl.href;
           }
@@ -349,6 +352,15 @@ function MonitorStream(monitorData) {
     if (this.webrtc) {
       this.webrtc.close();
       this.webrtc = null;
+    } else if (this.hls) {
+      this.hls.destroy();
+      this.hls = null;
+    } else if (this.wsMSE) {
+      this.mse.endOfStream();
+      this.wsMSE.close();
+      this.wsMSE = null;
+      this.mseStreamingStarted = false;
+      this.mseSourceBuffer = null;
     }
   };
 
@@ -683,6 +695,7 @@ function MonitorStream(monitorData) {
         } // end if have a new auth hash
       } // end if has state
     } else {
+      if (!this.started) return;
       console.error(respObj.message);
       // Try to reload the image stream.
       if (stream.src) {
@@ -1034,14 +1047,14 @@ function startRTSP2WebPlay(videoEl, url, stream) {
 }
 
 function startMsePlay(context, videoEl, url) {
-  const mse = new MediaSource();
-  mse.addEventListener('sourceopen', function() {
-    const ws = new WebSocket(url);
-    ws.binaryType = 'arraybuffer';
-    ws.onopen = function(event) {
+  context.mse = new MediaSource();
+  context.mse.addEventListener('sourceopen', function() {
+    context.wsMSE = new WebSocket(url);
+    context.wsMSE.binaryType = 'arraybuffer';
+    context.wsMSE.onopen = function(event) {
       console.log('Connect to ws');
     };
-    ws.onmessage = function(event) {
+    context.wsMSE.onmessage = function(event) {
       const data = new Uint8Array(event.data);
       if (data[0] === 9) {
         let mimeCodec;
@@ -1051,7 +1064,7 @@ function startMsePlay(context, videoEl, url) {
         } else {
           console.log("Browser too old. Doesn't support TextDecoder");
         }
-        context.mseSourceBuffer = mse.addSourceBuffer('video/mp4; codecs="' + mimeCodec + '"');
+        context.mseSourceBuffer = context.mse.addSourceBuffer('video/mp4; codecs="' + mimeCodec + '"');
         context.mseSourceBuffer.mode = 'segments';
         context.mseSourceBuffer.addEventListener('updateend', pushMsePacket, videoEl, context);
       } else {
@@ -1059,7 +1072,7 @@ function startMsePlay(context, videoEl, url) {
       }
     };
   }, false);
-  videoEl.src = window.URL.createObjectURL(mse);
+  videoEl.src = window.URL.createObjectURL(context.mse);
 }
 
 function pushMsePacket(videoEl, context) {


### PR DESCRIPTION
1. URL parameters for RTSP2Web Type MSE due to which playback was unavailable. 
You can't combine the path and search parameters in one line, because there may be problems, for example the "?" sign will be converted to "%3F" and the socket will not be created!

2. Merged with #4214

3, Correctly stop RTSP2Web Type HLS when executing "MonitorStream.stop()"