### PR TITLE
Fix: Start/Stop when showing/hiding page on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1449,7 +1449,7 @@ document.onvisibilitychange = () => {
       if (monitorStream) {
         if (monitorStream.started) {
           prevStateStarted = 'played';
-           //Stop only if playing or paused.
+          //Stop only if playing or paused.
           monitorStream.kill();
         } else {
           prevStateStarted = false;

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1439,6 +1439,7 @@ function monitorsSetScale(id=null) {
 // Kick everything off
 $j( window ).on("load", initPage);
 
+var prevStateStarted = false;
 document.onvisibilitychange = () => {
   // Always clear it because the return to visibility might happen before timeout
   TimerHideShow = clearTimeout(TimerHideShow);
@@ -1446,12 +1447,19 @@ document.onvisibilitychange = () => {
     TimerHideShow = setTimeout(function() {
       //Stop monitor when closing or hiding page
       if (monitorStream) {
-        monitorStream.kill();
+        if (monitorStream.started) {
+          prevStateStarted = 'played';
+           //Stop only if playing or paused.
+          monitorStream.kill();
+        } else {
+          prevStateStarted = false;
+        }
       }
     }, 15*1000);
   } else {
     //Start monitor when show page
-    if (monitorStream && !monitorStream.started && (idle<ZM_WEB_VIEWING_TIMEOUT)) {
+    if (monitorStream && prevStateStarted == 'played' && (idle<ZM_WEB_VIEWING_TIMEOUT)) {
+      onPlay(); //Set the correct state of the player buttons.
       monitorStream.start();
     }
   }


### PR DESCRIPTION
When hiding a page:
Remember the current state of the stream.
If the stream was previously stopped - do nothing

When displaying a page:
Do not start playback if the stream was stopped before hiding the page. You cannot use "monitorStream.started", because when the stream is stopped it will always be "false"