### PR TITLE
Feat: Added support for selecting Primary or Secondary stream for RTSP2Web to Frontend

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -82,7 +82,7 @@ std::string load_monitor_sql =
   "SELECT `Id`, `Name`, `Deleted`, `ServerId`, `StorageId`, `Type`, "
   "`Capturing`+0, `Analysing`+0, `AnalysisSource`+0, `AnalysisImage`+0, "
   "`Recording`+0, `RecordingSource`+0, `Decoding`+0, "
-  "`RTSP2WebEnabled`, `RTSP2WebType`, "
+  "`RTSP2WebEnabled`, `RTSP2WebType`, `RTSP2WebStream`, "
   "`JanusEnabled`, `JanusAudioEnabled`, `Janus_Profile_Override`, "
   "`Janus_Use_RTSP_Restream`, `Janus_RTSP_User`, `Janus_RTSP_Session_Timeout`, "
   "`LinkedMonitors`, `EventStartCommand`, `EventEndCommand`, `AnalysisFPSLimit`,"

--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -197,6 +197,17 @@ class Monitor extends ZM_Object {
 
   protected static $table = 'Monitors';
 
+  protected static $RTSP2WebStream = null;
+  public static function getRTSP2WebStream() {
+    if (!isset($RTSP2WebStream)) {
+      $RTSP2WebStream = array(
+        'Primary'   => translate('Primary'),
+        'Secondary' => translate('Secondary'),
+      );
+    }
+    return $RTSP2WebStream;
+  }
+
   protected $defaults = array(
     'Id' => null,
     'Name' => array('type'=>'text','filter_regexp'=>'/[^\w\-\.\(\)\:\/ ]/', 'default'=>'Monitor'),
@@ -217,6 +228,7 @@ class Monitor extends ZM_Object {
     'Decoding'  => 'Always',
     'RTSP2WebEnabled'   => array('type'=>'integer','default'=>0),
     'RTSP2WebType'   => 'HLS',
+    'RTSP2WebStream'   => 'Primary',
     'JanusEnabled'   => array('type'=>'boolean','default'=>0),
     'JanusAudioEnabled'   => array('type'=>'boolean','default'=>0),
     'Janus_Profile_Override'   => '',

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -11,6 +11,7 @@ function MonitorStream(monitorData) {
   this.height = monitorData.height;
   this.RTSP2WebEnabled = monitorData.RTSP2WebEnabled;
   this.RTSP2WebType = monitorData.RTSP2WebType;
+  this.RTSP2WebStream = monitorData.RTSP2WebStream;
   this.webrtc = null;
   this.hls = null;
   this.mse = null;
@@ -264,9 +265,10 @@ function MonitorStream(monitorData) {
         rtsp2webModUrl.username = '';
         rtsp2webModUrl.password = '';
         //.urlParts.length > 1 ? urlParts[1] : urlParts[0]; // drop the username and password for viewing
+        const RTSP2WebChannel = (this.RTSP2WebStream == 'Secondary') ? 1 : 0;
         if (this.RTSP2WebType == 'HLS') {
           const hlsUrl = rtsp2webModUrl;
-          hlsUrl.pathname = "/stream/" + this.id + "/channel/0/hls/live/index.m3u8";
+          hlsUrl.pathname = "/stream/" + this.id + "/channel/" + RTSP2WebChannel + "/hls/live/index.m3u8";
           /*
           if (useSSL) {
             hlsUrl = "https://" + rtsp2webModUrl + "/stream/" + this.id + "/channel/0/hls/live/index.m3u8";
@@ -290,12 +292,12 @@ function MonitorStream(monitorData) {
           });
           const mseUrl = rtsp2webModUrl;
           mseUrl.protocol = useSSL ? 'wss' : 'ws';
-          mseUrl.pathname = "/stream/" + this.id + "/channel/0/mse";
+          mseUrl.pathname = "/stream/" + this.id + "/channel/" + RTSP2WebChannel + "/mse";
           mseUrl.search = "uuid=" + this.id + "&channel=0";
           startMsePlay(this, videoEl, mseUrl.href);
         } else if (this.RTSP2WebType == 'WebRTC') {
           const webrtcUrl = rtsp2webModUrl;
-          webrtcUrl.pathname = "/stream/" + this.id + "/channel/0/webrtc";
+          webrtcUrl.pathname = "/stream/" + this.id + "/channel/" + RTSP2WebChannel + "/webrtc";
           startRTSP2WebPlay(videoEl, webrtcUrl.href, this);
         }
         this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);

--- a/web/skins/classic/views/js/cycle.js.php
+++ b/web/skins/classic/views/js/cycle.js.php
@@ -25,6 +25,7 @@ monitorData[monitorData.length] = {
   'refresh': '<?php echo $monitor->Refresh() ?>',
   'RTSP2WebEnabled': <?php echo $monitor->RTSP2WebEnabled() ?>,
   'RTSP2WebType': '<?php echo $monitor->RTSP2WebType() ?>',
+  'RTSP2WebStream': '<?php echo $monitor->RTSP2WebStream() ?>',
   'janusEnabled': <?php echo $monitor->JanusEnabled() ?>,
   'janus_pin': '<?php echo $monitor->Janus_Pin() ?>'
 };

--- a/web/skins/classic/views/js/monitor.js
+++ b/web/skins/classic/views/js/monitor.js
@@ -313,6 +313,28 @@ function initPage() {
     }
   }
 
+  //Manage the RTSP2Web settings div
+  const RTSP2WebEnabled = form.elements['newMonitor[RTSP2WebEnabled]'];
+  if (RTSP2WebEnabled) {
+    if (RTSP2WebEnabled.checked) {
+      document.getElementById("RTSP2WebType").hidden = false;
+      document.getElementById("RTSP2WebStream").hidden = false;
+    } else {
+      document.getElementById("RTSP2WebType").hidden = true;
+      document.getElementById("RTSP2WebStream").hidden = true;
+    }
+
+    RTSP2WebEnabled.addEventListener('change', function() {
+      if (this.checked) {
+        document.getElementById("RTSP2WebType").hidden = false;
+        document.getElementById("RTSP2WebStream").hidden = false;
+      } else {
+        document.getElementById("RTSP2WebType").hidden = true;
+        document.getElementById("RTSP2WebStream").hidden = true;
+      }
+    });
+  }
+
   // Amcrest API controller
   const ONVIF_Event_Listener = form.elements['newMonitor[ONVIF_Event_Listener]'];
   if (ONVIF_Event_Listener) {

--- a/web/skins/classic/views/js/montage.js.php
+++ b/web/skins/classic/views/js/montage.js.php
@@ -27,6 +27,7 @@ monitorData[monitorData.length] = {
   'height':<?php echo $monitor->ViewHeight() ?>,
   'RTSP2WebEnabled':<?php echo $monitor->RTSP2WebEnabled() ?>,
   'RTSP2WebType':'<?php echo $monitor->RTSP2WebType() ?>',
+  'RTSP2WebStream':'<?php echo $monitor->RTSP2WebStream() ?>',
   'janusEnabled':<?php echo $monitor->JanusEnabled() ?>,
   'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'url_to_zms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',

--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -49,6 +49,7 @@ monitorData[monitorData.length] = {
   'height':<?php echo $m->ViewHeight() ?>,
   'RTSP2WebEnabled':<?php echo $m->RTSP2WebEnabled() ?>,
   'RTSP2WebType':'<?php echo $m->RTSP2WebType() ?>',
+  'RTSP2WebStream':'<?php echo $m->RTSP2WebStream() ?>',
   'janusEnabled':<?php echo $m->JanusEnabled() ?>,
   'url': '<?php echo $m->UrlToIndex(ZM_MIN_STREAMING_PORT ? ($m->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'onclick': function(){window.location.assign( '?view=watch&mid=<?php echo $m->Id() ?>' );},

--- a/web/skins/classic/views/js/zone.js.php
+++ b/web/skins/classic/views/js/zone.js.php
@@ -73,6 +73,7 @@ monitorData[monitorData.length] = {
   'janusEnabled':<?php echo $monitor->JanusEnabled() ?>,
   'RTSP2WebEnabled': <?php echo $monitor->RTSP2WebEnabled() ?>,
   'RTSP2WebType': '<?php echo $monitor->RTSP2WebType() ?>',
+  'RTSP2WebStream': '<?php echo $monitor->RTSP2WebStream() ?>',
   'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'url_to_zms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'type': '<?php echo $monitor->Type() ?>',

--- a/web/skins/classic/views/js/zones.js.php
+++ b/web/skins/classic/views/js/zones.js.php
@@ -17,6 +17,7 @@ monitorData[monitorData.length] = {
   'janusEnabled':<?php echo $monitor->JanusEnabled() ?>,
   'RTSP2WebEnabled': <?php echo $monitor->RTSP2WebEnabled() ?>,
   'RTSP2WebType': '<?php echo $monitor->RTSP2WebType() ?>',
+  'RTSP2WebStream': '<?php echo $monitor->RTSP2WebStream() ?>',
   'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'url_to_zms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'type': '<?php echo $monitor->Type() ?>',

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -1225,9 +1225,13 @@ echo htmlSelect('newMonitor[OutputContainer]', $videowriter_containers, $monitor
     echo '<div class="form-text">'.$OLANG['FUNCTION_RTSP2WEB_ENABLED']['Help'].'</div>';
   }
 ?>
-            <li>
+            <li id="RTSP2WebType">
               <label><?php echo translate('RTSP2Web Type') ?> <?php echo $monitor->RTSP2WebType() ?> </label>
               <?php echo htmlSelect('newMonitor[RTSP2WebType]', $RTSP2WebTypes, $monitor->RTSP2WebType()); ?>
+            </li>
+            <li id="RTSP2WebStream">
+              <label><?php echo translate('Stream source') ?> </label>
+              <?php echo htmlSelect('newMonitor[RTSP2WebStream]', ZM\Monitor::getRTSP2WebStream(), $monitor->RTSP2WebStream()); ?>
             </li>
             <li id="FunctionJanusEnabled">
               <label><?php echo translate('Janus Live Stream') ?></label>


### PR DESCRIPTION
@connortechnology

1, In addition to this PR, you need to run the command for SQL:
```ALTER TABLE `Monitors` ADD `RTSP2WebStream` enum('Primary','Secondary') NOT NULL DEFAULT 'Primary' AFTER `RTSP2WebType`;```

2. Also, you need to fix the error: https://github.com/ZoneMinder/zoneminder/issues/4222#issuecomment-2676213068