### PR TITLE
Fix: When panZoom is enabled, disable default handling of clicks on images on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -481,7 +481,7 @@ function handleClick(event) {
   }
 
   if (panZoomEnabled) {
-    //event.preventDefault();
+    event.preventDefault();
     //We are looking for an object with an ID, because there may be another element in the button.
     const obj = targetId ? event.target : event.target.parentElement;
     if (!obj) {


### PR DESCRIPTION
This will prevent the "pause" switch from triggering when clicking on an image