### PR TITLE
Fix: Start auto Play when using videojs on Event page

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1253,8 +1253,18 @@ var doubleClickOnStream = function(event, touchEvent) {
 
   if (target) {
     if (document.fullscreenElement) {
+      if (getCookie('zmEventStats') && eventStats) {
+        eventStats.toggle(true);
+        wrapperEventVideo.removeClass('col-sm-12').addClass('col-sm-8');
+        changeScale();
+      }
       closeFullscreen();
     } else {
+      if (getCookie('zmEventStats') && eventStats) {
+        eventStats.toggle(false);
+        wrapperEventVideo.removeClass('col-sm-8').addClass('col-sm-12');
+        changeScale();
+      }
       openFullscreen(target);
     }
     if (isMobile()) {

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1253,18 +1253,8 @@ var doubleClickOnStream = function(event, touchEvent) {
 
   if (target) {
     if (document.fullscreenElement) {
-      if (getCookie('zmEventStats') && eventStats) {
-        eventStats.toggle(true);
-        wrapperEventVideo.removeClass('col-sm-12').addClass('col-sm-8');
-        changeScale();
-      }
       closeFullscreen();
     } else {
-      if (getCookie('zmEventStats') && eventStats) {
-        eventStats.toggle(false);
-        wrapperEventVideo.removeClass('col-sm-8').addClass('col-sm-12');
-        changeScale();
-      }
       openFullscreen(target);
     }
     if (isMobile()) {

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -331,7 +331,7 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
 <?php
 if ($video_tag) {
 ?>
-                  <video autoplay id="videoobj" class="video-js vjs-default-skin"
+                  <video muted autoplay id="videoobj" class="video-js vjs-default-skin"
                     style="transform: matrix(1, 0, 0, 1, 0, 0);"
                    <?php echo $scale ? 'width="'.reScale($Event->Width(), $scale).'"' : '' ?>
                    <?php echo $scale ? 'height="'.reScale($Event->Height(), $scale).'"' : '' ?>

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1364,7 +1364,8 @@ function initPage() {
     addVideoTimingTrack(vid, LabelFormat, eventData.MonitorName, eventData.Length, eventData.StartDateTime);
     //$j('.vjs-progress-control').append('<div id="alarmCues" class="alarmCues"></div>');//add a place for videojs only on first load
     vid.on('ended', vjsReplay);
-    vid.on('play', playClicked);
+    //vid.on('play', playClicked);
+    vid.on('play', streamPlay); // We have autoplay enabled in the <video> tag, so re-running vid.play() is not required.
     vid.on('pause', pauseClicked);
     vid.on('click', function(event) {
       handleClick(event);
@@ -1391,6 +1392,12 @@ function initPage() {
     if (rate > 0) {
       // rate should be 100 = 1x, etc.
       vid.playbackRate(rate/100);
+    }
+
+    if (performance.getEntriesByType("navigation")[0].type == "navigate" && document.referrer) {
+      vid.muted(false);
+    } else if (performance.getEntriesByType("navigation")[0].type == "reload") {
+      // We're not doing anything yet.
     }
   } else {
     streamCmdInterval = setInterval(streamQuery, streamTimeout); //Timeout is refresh rate for progressBox and time display

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1394,9 +1394,10 @@ function initPage() {
       vid.playbackRate(rate/100);
     }
 
-    if (performance.getEntriesByType("navigation")[0].type == "navigate" && document.referrer) {
+    const navigationType = performance.getEntriesByType("navigation")[0].type;
+    if (navigationType == "navigate" && document.referrer) {
       vid.muted(false);
-    } else if (performance.getEntriesByType("navigation")[0].type == "reload") {
+    } else if (navigationType == "reload") {
       // We're not doing anything yet.
     }
   } else {


### PR DESCRIPTION
It is necessary to add the "muted" attribute to the "video" tag
Otherwise, the browser policy prohibits starting auto Play.
But the browser policy allows auto Play to start if the user has performed some actions on the page.
Therefore, when clicking on an event from the list, you can allow Audio to be turned on, which is what we do in event.js
That is, the final algorithm is as follows:
1. When clicking **links** on events, playback will start with sound (as it was before)
2. When refreshing the page (Ctrl+F5 || Ctrl+R || pasting a link into the browser line), playback will start without sound (previously, playback did not start at all and there was an error in the browser console)
3. When the "onplay" event is triggered for the "vid" object, you should not execute "vid.play()", since we use the "autoplay" attribute for the "video" tag, which could lead to unpredictable consequences.
This algorithm is fully compliant with browser policies.

Also, this PR actually hides the standard "Play" button of the "videojs" player, since playback always starts automatically.
Closed https://forums.zoneminder.com/viewtopic.php?t=33839&sid=f06098a69ceed3de64de4a8fe5b873b5

I tried to implement something similar in #4007 but then I abandoned it. Now it seems to have worked out.