### PR TITLE
Fix: Event page. When switching fullscreen mode by double-clicking on an image, take into account the "eventStats" block

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1253,8 +1253,18 @@ var doubleClickOnStream = function(event, touchEvent) {
 
   if (target) {
     if (document.fullscreenElement) {
+      if (getCookie('zmEventStats') && eventStats) {
+        eventStats.toggle(true);
+        wrapperEventVideo.removeClass('col-sm-12').addClass('col-sm-8');
+        changeScale();
+      }
       closeFullscreen();
     } else {
+      if (getCookie('zmEventStats') && eventStats) {
+        eventStats.toggle(false);
+        wrapperEventVideo.removeClass('col-sm-8').addClass('col-sm-12');
+        changeScale();
+      }
       openFullscreen(target);
     }
     if (isMobile()) {


### PR DESCRIPTION
Otherwise, when switching to full-screen mode with the "eventStats" block displayed, empty black spaces remain on the right and left.