### PR TITLE
Fix: IMPORTANT! Wait for user inactivity (watch.js)

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -7,7 +7,7 @@ var sidebarView = $j('#sidebar');
 var sidebarControls = $j('#ptzControls');
 var wrapperMonitor = $j('#wrapperMonitor');
 var filterQuery = '&filter[Query][terms][0][attr]=MonitorId&filter[Query][terms][0][op]=%3d&filter[Query][terms][0][val]='+monitorId;
-var idle = 0;
+var idleTimeoutTriggered = false; /* Timer ZM_WEB_VIEWING_TIMEOUT has been triggered */
 var monitorStream = false; /* Stream is not started */
 var currentMonitor;
 
@@ -1038,6 +1038,7 @@ function initPage() {
       document.onkeydown = resetTimer;
 
       function stopPlayback() {
+        idleTimeoutTriggered = true;
         streamCmdStop(true);
         const cycle_was = cycle;
         cyclePause();
@@ -1060,6 +1061,7 @@ function initPage() {
 
       function resetTimer() {
         clearTimeout(time);
+        idleTimeoutTriggered = false;
         time = setTimeout(stopPlayback, ZM_WEB_VIEWING_TIMEOUT * 1000);
       }
     };
@@ -1489,7 +1491,7 @@ document.onvisibilitychange = () => {
     }, 15*1000);
   } else {
     //Start monitor when show page
-    if (monitorStream && prevStateStarted == 'played' && (idle<ZM_WEB_VIEWING_TIMEOUT)) {
+    if (monitorStream && prevStateStarted == 'played' && !idleTimeoutTriggered) {
       onPlay(); //Set the correct state of the player buttons.
       monitorStream.start();
     }


### PR DESCRIPTION
Replaced "Idle" variable with "idleTimeoutTriggered" because "Idle" is no longer a counter after https://github.com/ZoneMinder/zoneminder/commit/862f3cb62bf33507d90499b5244443fcd0d19989 idleTimeoutTriggered changes the status and is analyzed when the user is idle