### PR TITLE
Fix: Allow scrolling for #contentForm (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -636,6 +636,11 @@ body.sticky #page {
     margin-bottom: 0;
 }
 
+#contentForm {
+    width: 100%;
+    overflow: auto;
+}
+
 #footer {
     width: 96%;
     margin: 8px auto;


### PR DESCRIPTION
This will affect many pages, for example:
stats, zones, bandwidth, onvifprobe, add_monitors, export, controlcap, privacy, monitorprobe, monitors, filter, monitor, user
I checked all these pages and they did not get worse.

But pages like "add_monitors", "export", "monitor" require additional layout correction for relatively narrow screens.
Perhaps it is worth reviewing from 
"/skins/classic/css/base/views/add_monitors.css"
```
#contentForm {
  height: 100%;
}
```
&&
"web/skins/classic/css/base/views/user.css"
```
#contentForm {
  overflow: auto;
  height: 100%;
}
```
and moving to "skin.css"