### PR TITLE
Feat: Let's try using "flexbox" for #content (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -289,9 +289,15 @@ ul.tabList li.active a {
   text-align: center;
   clear: both;
 }
+
+#content.row{
+  flex-direction: row;
+}
+
 #content::backdrop {
   background-color: white;
 }
+
 body.sticky #content {
 /*
   flex: 1 1 auto;

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -280,6 +280,8 @@ ul.tabList li.active a {
 }
 
 #content {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   overflow: hidden auto;
   margin: 0 auto 0 auto;


### PR DESCRIPTION
This should eliminate a lot of layout issues and simplify CSS styles. Almost all recent browsers support this.

I tested a number of pages and had no problems.
But I can't guarantee 100% that nothing will break anywhere. "report_event_audit" page is now displayed correctly.