### PR TITLE
Fix: Use addEventListener 'beforeunload' instead of window.onbeforeunload (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1213,10 +1213,10 @@ function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE = new WebSocket(url);
   context.wsMSE.binaryType = 'arraybuffer';
 
-  window.onbeforeunload = function() {
+  window.addEventListener('beforeunload', function (event) {
     this.started = false;
     context.closeWebSocket();
-  };
+  });
   context.wsMSE.onopen = function(event) {
     console.log(`Connect to ws for a video object ID=${context.id}`);
   };

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1213,7 +1213,7 @@ function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE = new WebSocket(url);
   context.wsMSE.binaryType = 'arraybuffer';
 
-  window.addEventListener('beforeunload', function (event) {
+  window.addEventListener('beforeunload', function(event) {
     this.started = false;
     context.closeWebSocket();
   });


### PR DESCRIPTION
Because there can be multiple "beforeunload" event handlers on one page and they all must be executed.