### PR TITLE
Fix: In the selectLayout() function, execute on_scroll() with a delay (Montage page)

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -203,7 +203,7 @@ function selectLayout(new_layout_id) {
   changeMonitorStatusPosition(); //!!! After loading the saved layer, you must execute.
   monitorsSetScale();
   */
-  on_scroll();
+  setTimeout(on_scroll, 100);
   setCookie('zmMontageLayout', layout_id);
 } // end function selectLayout(element)
 


### PR DESCRIPTION
This is necessary for rebuilding the DOM. Otherwise, not all monitors that were hidden and stopped will start.