### PR TITLE
Fix: Avoid double monitor start when initializing a Montage page

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -537,16 +537,6 @@ function handleClick(evt) {
 function startMonitors() {
   for (let i = 0, length = monitors.length; i < length; i++) {
     const monitor = monitors[i];
-    // Why are we scaling here instead of in monitorstream?
-    const obj = document.getElementById('liveStream'+monitor.id);
-    if (obj.src) {
-      const url = new URL(obj.src);
-      let scale = parseInt(obj.clientWidth / monitor.width * 100);
-      if (scale > 100) scale = 100;
-      url.searchParams.set('scale', scale);
-      obj.src = url;
-    }
-
     const isOut = isOutOfViewport(monitor.getElement());
     if (!isOut.all) {
       monitor.start();
@@ -830,6 +820,7 @@ function initPage() {
 } // end initPage
 
 function on_scroll() {
+  if (!checkEndMonitorsPlaced()) return;
   for (let i = 0, length = monitors.length; i < length; i++) {
     const monitor = monitors[i];
 


### PR DESCRIPTION
1. Do not execute "on_scroll" until all monitors are positioned on the screen. Otherwise, the monitors will be started twice when the page is initialized. The first time is when on_scroll() is called from selectLayout(), the second time is started from startMonitors() after all monitors are positioned.

2. When executing startMonitors(), you cannot change the SRC attribute of the IMG tag before executing "monitor.start()", because in monitor.start() we have an assignment of this.img_onload. That is, the "onload" event can occur earlier (due to the SRC change) than we assign a function to it!

Scaling occurs in monitorStream