### PR TITLE
Feat: Material icons styles in a separate file from skin.css to material-icons.css

### DIFF
--- a/web/skins/classic/css/base/material-icons.css
+++ b/web/skins/classic/css/base/material-icons.css
@@ -1,0 +1,48 @@
+@font-face {
+  font-family: "Material Icons";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("../../../../fonts/material-icons.woff2") format("woff2"), url("../../../../fonts/material-icons.woff") format("woff");
+}
+.material-icons {
+  font-family: "Material Icons";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+  vertical-align: middle;
+  display: none;
+}
+
+.material-icons.md-8 { font-size: 8px; }
+.material-icons.md-10 { font-size: 10px; }
+.material-icons.md-12 { font-size: 12px; }
+.material-icons.md-14 { font-size: 14px; }
+.material-icons.md-16 { font-size: 16px; }
+.material-icons.md-18 { font-size: 18px; }
+.material-icons.md-20 { font-size: 20px; }
+.material-icons.md-22 { font-size: 22px; }
+.material-icons.md-24 { font-size: 24px; }
+.material-icons.md-26 { font-size: 26px; }
+.material-icons.md-28 { font-size: 28px; }
+.material-icons.md-30 { font-size: 30px; }
+.material-icons.md-32 { font-size: 32px; }
+.material-icons.md-34 { font-size: 34px; }
+.material-icons.md-36 { font-size: 36px; }
+.material-icons.md-38 { font-size: 38px; }
+.material-icons.md-40 { font-size: 40px; }
+
+button .material-icons {
+  font-size: 18px;
+}

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -28,51 +28,6 @@
   --alarmText: inherit;
 }
 
-@font-face {
-  font-family: "Material Icons";
-  font-style: normal;
-  font-weight: 400;
-  font-display: block;
-  src: url("../fonts/material-icons.woff2") format("woff2"), url("../fonts/material-icons.woff") format("woff");
-}
-.material-icons {
-  font-family: "Material Icons";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-  font-feature-settings: "liga";
-  vertical-align: middle;
-  display: none;
-}
-
-.material-icons.md-8 { font-size: 8px; }
-.material-icons.md-10 { font-size: 10px; }
-.material-icons.md-12 { font-size: 12px; }
-.material-icons.md-14 { font-size: 14px; }
-.material-icons.md-16 { font-size: 16px; }
-.material-icons.md-18 { font-size: 18px; }
-.material-icons.md-20 { font-size: 20px; }
-.material-icons.md-22 { font-size: 22px; }
-.material-icons.md-24 { font-size: 24px; }
-.material-icons.md-26 { font-size: 26px; }
-.material-icons.md-28 { font-size: 28px; }
-.material-icons.md-30 { font-size: 30px; }
-.material-icons.md-32 { font-size: 32px; }
-.material-icons.md-34 { font-size: 34px; }
-.material-icons.md-36 { font-size: 36px; }
-.material-icons.md-38 { font-size: 38px; }
-.material-icons.md-40 { font-size: 40px; }
-
 html,
 body {
   height: 100%;
@@ -1010,10 +965,6 @@ a.flip {
 }
 .search .form-control {
   font-size: 100%;
-}
-
-button .material-icons {
-  font-size: 18px;
 }
 
 /* input[type="search"]::-webkit-search-cancel-button {

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -64,6 +64,7 @@ if (defined('ZM_WEB_FAVICON')) {
   <link rel="shortcut icon" href="graphics/favicon.ico"/>
 ';
 }
+echo output_link_if_exists(array('css/base/material-icons.css'));
 echo output_cache_busted_stylesheet_links(array(
   'css/reset.css',
   'css/font-awesome.min.css',


### PR DESCRIPTION
This will allow us to load this style first.
That is, on a slow Internet channel or a slow browser, icons may load with a delay, which does not look nice.