### PR TITLE
Control RTCPeerConnection and video codec support, stop all monitors when closing the page, etc. (Monitor Stream)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1142,7 +1142,9 @@ const waitUntil = (condition) => {
 
 function startRTSP2WebPlay(videoEl, url, stream) {
   if (typeof RTCPeerConnection !== 'function') {
-    console.log(`Your browser does not support 'RTCPeerConnection'. Monitor '${stream.name}' ID=${stream.id} not started.`);
+    const msg = `Your browser does not support 'RTCPeerConnection'. Monitor '${stream.name}' ID=${stream.id} not started.`;
+    console.log(msg);
+    stream.getElement().before(document.createTextNode(msg));
     stream.RTSP2WebType = null; // Avoid repeated restarts.
     return;
   }

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -4,6 +4,7 @@ const streaming = [];
 
 function MonitorStream(monitorData) {
   this.id = monitorData.id;
+  this.name = monitorData.name;
   this.started = false;
   this.connKey = monitorData.connKey;
   this.url = monitorData.url;
@@ -22,6 +23,7 @@ function MonitorStream(monitorData) {
   this.streamStartTime = 0; // Initial point of flow start time. Used for flow lag time analysis.
   this.waitingStart;
   this.mseListenerSourceopenBind = null;
+  this.streamListenerBind = null;
   this.mseSourceBufferListenerUpdateendBind = null;
   this.mseStreamingStarted = false;
   this.mseQueue = [];
@@ -46,6 +48,7 @@ function MonitorStream(monitorData) {
   };
   this.ajaxQueue = null;
   this.type = monitorData.type;
+  this.capturing = monitorData.capturing;
   this.refresh = monitorData.refresh;
 
   this.buttons = {}; // index by name
@@ -240,6 +243,8 @@ function MonitorStream(monitorData) {
 
   this.start = function(streamChannel = 'default') {
     console.debug(`! ${dateTimeToISOLocal(new Date())} Stream for ID=${this.id} STARTED`);
+    this.streamListenerBind = streamListener.bind(null, this);
+
     if (this.janusEnabled) {
       let server;
       if (ZM_JANUS_PATH) {
@@ -261,6 +266,7 @@ function MonitorStream(monitorData) {
       attachVideo(parseInt(this.id), this.janusPin);
       this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);
       this.started = true;
+      this.streamListenerBind();
       return;
     }
     if (this.RTSP2WebEnabled) {
@@ -305,6 +311,7 @@ function MonitorStream(monitorData) {
         clearInterval(this.statusCmdTimer); // Fix for issues in Chromium when quickly hiding/showing a page. Doesn't clear statusCmdTimer when minimizing a page https://stackoverflow.com/questions/9501813/clearinterval-not-working
         this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);
         this.started = true;
+        this.streamListenerBind();
         return;
       } else {
         console.log("ZM_RTSP2WEB_PATH is empty. Go to Options->System and set ZM_RTSP2WEB_PATH accordingly.");
@@ -338,6 +345,7 @@ function MonitorStream(monitorData) {
     stream.onerror = this.img_onerror.bind(this);
     stream.onload = this.img_onload.bind(this);
     this.started = true;
+    this.streamListenerBind();
   }; // this.start
 
   this.stop = function() {
@@ -1133,6 +1141,12 @@ const waitUntil = (condition) => {
 };
 
 function startRTSP2WebPlay(videoEl, url, stream) {
+  if (typeof RTCPeerConnection !== 'function') {
+    console.log(`Your browser does not support 'RTCPeerConnection'. Monitor '${stream.name}' ID=${stream.id} not started.`);
+    stream.RTSP2WebType = null; // Avoid repeated restarts.
+    return;
+  }
+
   const mediaStream = new MediaStream();
   if (stream.webrtc) {
     stream.webrtc.close();
@@ -1218,14 +1232,16 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   webrtcSendChannel.onmessage = (event) => console.log(event.data);
 }
 
+function streamListener(stream) {
+  window.addEventListener('beforeunload', function(event) {
+    stream.kill();
+  });
+}
+
 function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE = new WebSocket(url);
   context.wsMSE.binaryType = 'arraybuffer';
 
-  window.addEventListener('beforeunload', function(event) {
-    this.started = false;
-    context.closeWebSocket();
-  });
   context.wsMSE.onopen = function(event) {
     console.log(`Connect to ws for a video object ID=${context.id}`);
   };
@@ -1252,8 +1268,9 @@ function mseListenerSourceopen(context, videoEl, url) {
       if (MediaSource.isTypeSupported('video/mp4; codecs="' + mimeCodec + '"')) {
         console.log(`For a video object ID=${context.id} codec used: ${mimeCodec}`);
       } else {
-        console.log(`For a video object ID=${context.id} codec '${mimeCodec}' not supported.`);
+        console.log(`For a video object ID=${context.id} codec '${mimeCodec}' not supported. Monitor '${context.name}' ID=${context.id} not starting.`);
         context.stop();
+        context.RTSP2WebType = null; // Avoid repeated restarts
         return;
       }
 

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1268,7 +1268,9 @@ function mseListenerSourceopen(context, videoEl, url) {
       if (MediaSource.isTypeSupported('video/mp4; codecs="' + mimeCodec + '"')) {
         console.log(`For a video object ID=${context.id} codec used: ${mimeCodec}`);
       } else {
-        console.log(`For a video object ID=${context.id} codec '${mimeCodec}' not supported. Monitor '${context.name}' ID=${context.id} not starting.`);
+        const msg = `For a video object ID=${context.id} codec '${mimeCodec}' not supported. Monitor '${context.name}' ID=${context.id} not starting.`;
+        console.log(msg);
+        context.getElement().before(document.createTextNode(msg));
         context.stop();
         context.RTSP2WebType = null; // Avoid repeated restarts
         return;

--- a/web/skins/classic/views/js/cycle.js.php
+++ b/web/skins/classic/views/js/cycle.js.php
@@ -16,12 +16,14 @@ foreach ( $monitors as $monitor ) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
+  'name': '<?php echo $monitor->Name() ?>',
   'connKey': '<?php echo $monitor->connKey() ?>',
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,
   'url': '<?php echo $monitor->UrlToIndex() ?>',
   'onclick': function(){window.location.assign( '?view=watch&mid=<?php echo $monitor->Id() ?>' );},
   'type': '<?php echo $monitor->Type() ?>',
+  'capturing': '<?php echo $monitor->Capturing() ?>',
   'refresh': '<?php echo $monitor->Refresh() ?>',
   'RTSP2WebEnabled': <?php echo $monitor->RTSP2WebEnabled() ?>,
   'RTSP2WebType': '<?php echo $monitor->RTSP2WebType() ?>',

--- a/web/skins/classic/views/js/montage.js.php
+++ b/web/skins/classic/views/js/montage.js.php
@@ -21,6 +21,7 @@ foreach ( $monitors as $monitor ) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
+  'name': '<?php echo $monitor->Name() ?>',
   'server_id': '<?php echo $monitor->ServerId() ?>',
   'connKey': '<?php echo $monitor->connKey() ?>',
   'width': <?php echo $monitor->ViewWidth() ?>,
@@ -35,6 +36,7 @@ monitorData[monitorData.length] = {
   'url_to_snapshot': '<?php echo $monitor->UrlToZMS(ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '').'&mode=single' ?>',
   'onclick': function(){window.location.assign( '?view=watch&mid=<?php echo $monitor->Id() ?>' );},
   'type': '<?php echo $monitor->Type() ?>',
+  'capturing': '<?php echo $monitor->Capturing() ?>',
   'refresh': '<?php echo $monitor->Refresh() ?>',
   'janus_pin': '<?php echo $monitor->Janus_Pin() ?>'
 };

--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -43,6 +43,7 @@ foreach ($monitors as $m) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $m->Id() ?>,
+  'name': '<?php echo $m->Name() ?>',
   'server_id': '<?php echo $m->ServerId() ?>',
   'connKey': <?php echo $m->connKey() ?>,
   'width': <?php echo $m->ViewWidth() ?>,
@@ -55,6 +56,7 @@ monitorData[monitorData.length] = {
   'url': '<?php echo $m->UrlToIndex(ZM_MIN_STREAMING_PORT ? ($m->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'onclick': function(){window.location.assign( '?view=watch&mid=<?php echo $m->Id() ?>' );},
   'type': '<?php echo $m->Type() ?>',
+  'capturing': '<?php echo $m->Capturing() ?>',
   'refresh': '<?php echo $m->Refresh() ?>',
   'janus_pin': '<?php echo $m->Janus_Pin() ?>',
   'streamHTML': '<?php echo str_replace(array("\r\n", "\r", "\n"), '', $monitorsExtraData[$m->Id()]['StreamHTML']) ?>',

--- a/web/skins/classic/views/js/zone.js.php
+++ b/web/skins/classic/views/js/zone.js.php
@@ -67,6 +67,7 @@ var monitorArea = <?php echo $monitor->ViewWidth() * $monitor->ViewHeight() ?>;
 var monitorData = new Array();
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
+  'name': '<?php echo $monitor->Name() ?>',
   'connKey': <?php echo $monitor->connKey() ?>,
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,
@@ -77,6 +78,7 @@ monitorData[monitorData.length] = {
   'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'url_to_zms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'type': '<?php echo $monitor->Type() ?>',
+  'capturing': '<?php echo $monitor->Capturing() ?>',
   'refresh': '<?php echo $monitor->Refresh() ?>',
   'janus_pin': '<?php echo $monitor->Janus_Pin() ?>'
 };

--- a/web/skins/classic/views/js/zones.js.php
+++ b/web/skins/classic/views/js/zones.js.php
@@ -11,6 +11,7 @@ var monitorData = new Array();
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
+  'name': '<?php echo $monitor->Name() ?>',
   'connKey': <?php echo $monitor->connKey() ?>,
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,
@@ -21,6 +22,7 @@ monitorData[monitorData.length] = {
   'url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'url_to_zms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'type': '<?php echo $monitor->Type() ?>',
+  'capturing': '<?php echo $monitor->Capturing() ?>',
   'refresh': '<?php echo $monitor->Refresh() ?>',
   'janus_pin': '<?php echo $monitor->Janus_Pin() ?>'
 };


### PR DESCRIPTION
Added this.name and this.capturing to monitor stream this.capturing is not used yet.

If the browser does not support "RTCPeerConnection", then warn in the console, avoid errors and repeated restarts

When closing the page, not only close the Web socket for MSE, but also stop all monitors. This is more correct, since it will allow you to avoid a number of errors when closing the page.

If the codec is not supported by the browser - there is no point in performing repeated restarts. Just stop.