### PR TITLE
Fix: Don't limit #topPanel to "min-height", it will distort the layout on Timeline page

### DIFF
--- a/web/skins/classic/css/base/views/timeline.css
+++ b/web/skins/classic/css/base/views/timeline.css
@@ -36,7 +36,7 @@
 
 #topPanel {
     position: relative;
-    min-height: 220px;
+    /*min-height: 220px;*/
     margin: 4px auto 6px;
     display: block;
     width: 100%;


### PR DESCRIPTION


In addition to #4306