### PR TITLE
Fix: Instead of switch "( $max_aspect_ratio )" use a formula for recalculation aspect ratio on Timeline page

### DIFF
--- a/web/skins/classic/css/base/views/timeline.css.php
+++ b/web/skins/classic/css/base/views/timeline.css.php
@@ -30,6 +30,9 @@
 .imageHeight {
 <?php
 switch ( $max_aspect_ratio ) {
+  case 0.56: // 1080x1920, 1520x2688
+  case 0.57:
+    echo 'padding-top: 176%;'; break;
   case null:
   case 1:
     echo 'padding-top: 100%;'; break;
@@ -43,7 +46,8 @@ switch ( $max_aspect_ratio ) {
     echo 'padding-top: 66.66%'; break;
   case 1.6: // 8:5
     echo 'padding-top: 62.5%'; break;
-  case 1.78: // 16:9
+  case 1.77: // 16:9
+  case 1.78:
    echo 'padding-top: 56.25%;'; break;
   default:
     ZM\Error("Unknown aspect ratio $max_aspect_ratio");

--- a/web/skins/classic/css/base/views/timeline.css.php
+++ b/web/skins/classic/css/base/views/timeline.css.php
@@ -29,6 +29,8 @@
 
 .imageHeight {
 <?php
+echo 'padding-top: ' . round(100/$max_aspect_ratio, 2) . '%;';
+/*
 switch ( $max_aspect_ratio ) {
   case 0.56: // 1080x1920, 1520x2688
   case 0.57:
@@ -53,6 +55,7 @@ switch ( $max_aspect_ratio ) {
     ZM\Error("Unknown aspect ratio $max_aspect_ratio");
     echo 'padding-top: 100%;';
 }
+*/
 ?>
 }
 


### PR DESCRIPTION
In general, we need to somehow calculate the values ​​through a formula.
But I still haven't figured out which formula to use....