### PR TITLE
feat(header): Chevron right for collapsed - chevron down for expanded

### DIFF
--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -310,7 +310,7 @@ function getNormalNavBarHTML($running, $user, $bandwidth_options, $view, $skin) 
   </nav><!-- End First Navbar -->
 
   <nav class="navbar navbar-expand-md justify-content-center" id="navbar-two"
-<?php echo ( isset($_COOKIE['zmHeaderFlip']) and $_COOKIE['zmHeaderFlip'] == 'down' ) ? 'style="display:none;"' : '' ?>
+<?php echo ( isset($_COOKIE['zmHeaderFlip']) and $_COOKIE['zmHeaderFlip'] == 'hidden' ) ? 'style="display:none;"' : '' ?>
 >
     <div class="container-fluid" id="panel">
 <?php
@@ -889,7 +889,7 @@ function getMapHTML($view) {
 function getHeaderFlipHTML() {
   $result = '';
   
-  $header = ( isset($_COOKIE['zmHeaderFlip']) and $_COOKIE['zmHeaderFlip'] == 'down') ? 'down' : 'up';
+  $header = ( isset($_COOKIE['zmHeaderFlip']) and $_COOKIE['zmHeaderFlip'] == 'shown') ? 'down' : 'right';
   $result .= '<li id="getHeaderFlipHTML" class="nav-item dropdown"><a class="nav-link" href="#"><i id="flip" class="material-icons md-18" style="display: inline-block;">keyboard_arrow_' .$header. '</i></a></li>'.PHP_EOL;
   
   return $result;

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -301,12 +301,12 @@ if ( currentView != 'none' && currentView != 'login' ) {
     function navbarTwoFlip() {
       $j("#navbar-two").slideToggle("slow");
       const flip = $j("#flip");
-      if ( flip.html() == 'keyboard_arrow_up' ) {
-        flip.html('keyboard_arrow_down');
-        setCookie('zmHeaderFlip', 'down');
+      if ( flip.html() == 'keyboard_arrow_down' ) {
+        flip.html('keyboard_arrow_right');
+        setCookie('zmHeaderFlip', 'hidden');
       } else {
-        flip.html('keyboard_arrow_up');
-        setCookie('zmHeaderFlip', 'up');
+        flip.html('keyboard_arrow_down');
+        setCookie('zmHeaderFlip', 'shown');
       }
     }
 


### PR DESCRIPTION
Simple change to make the chevrons easier to understand when the main-header-nav is collapsed or expanded.

The right chevron indicates collapsed.
The down chevron indicates expanded.

(Reference: https://stackoverflow.com/questions/18325779/bootstrap-3-collapse-show-state-with-chevron-icon)