### PR TITLE
Fix deprecated AVCodecContext::channel_layout to use ch_layout

### DIFF
--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -854,9 +854,17 @@ bool VideoStore::setup_resampler() {
 
   Debug(2, "Got something other than AAC (%s)", audio_in_codec->name);
 
-#if LIBAVCODEC_VERSION_CHECK(59, 24, 100, 24, 100)
-#else
   // Some formats (i.e. WAV) do not produce the proper channel layout
+#if LIBAVCODEC_VERSION_CHECK(59, 24, 100, 24, 100)
+  // channel_layout is deprecated need to use ch_layout
+  // based on changes to ffmpeg/doc/examples/transcoding.c
+  if (audio_in_ctx->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+    char buf[64];
+    av_channel_layout_default(&audio_in_ctx->ch_layout, audio_in_ctx->ch_layout.nb_channels);
+    ret = av_channel_layout_describe(&audio_in_ctx->ch_layout, buf, sizeof(buf));
+    Info( "Setting input channel layout fron unspecified to default ret=%d describe=%s)", ret, buf);
+  }
+#else
   if (audio_in_ctx->channel_layout == 0) {
     Debug(2, "Setting input channel layout to mono");
     // Perhaps we should not be modifying the audio_in_ctx....


### PR DESCRIPTION
Moving from ubuntu jammy with libavcodec 58.134.100 to ubuntu noble with libavcodec 60.31.102 broke the ability to capture events using some cameras whose audio streams did not use the AAC codec. This fixes the problem by using the newer AvCodecContext::ch_layout.

For more details, see forum post: https://forums.zoneminder.com/viewtopic.php?t=33900