### PR TITLE
Fix: Don't handle on_scroll() if idleTimeoutTriggered trigger is fired on Montage page

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -836,7 +836,7 @@ function initPage() {
 } // end initPage
 
 function on_scroll() {
-  if (!monitorInitComplete) return;
+  if (!monitorInitComplete || idleTimeoutTriggered) return;
   for (let i = 0, length = monitors.length; i < length; i++) {
     const monitor = monitors[i];
 


### PR DESCRIPTION
Otherwise, stopped monitors will be started while the modal window is still displayed:

> "Are you still watching?
> Video paused. Continue watching?"

but scrolling has occurred and the user has not answered the question.