### PR TITLE
Fix: Show control buttons on hover only on the displayed stream on Montage page

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -687,7 +687,7 @@ function initPage() {
   //  $j('#zmMontageLayout').val(getCookie('zmMontageLayout'));
   //}
 
-  $j(".grid-monitor").hover(
+  $j(".monitorStream").hover(
       //Displaying "Scale" and other buttons at the top of the monitor image
       function() {
         const id = stringToNumber(this.id);


### PR DESCRIPTION
This will avoid unnecessary display of buttons when hovering over the "Monitor status" line if it is displayed "Outside bottom"