### PR TITLE
Changed "Use old menu view" to "Use Top menu" (functions.php)

### DIFF
--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -284,7 +284,7 @@ function buildSidebarMenu() {
               </a>
             </li>
             <li class="menu-header hidden-for-collapsed" style="padding-top: 20px">
-              <label for="useOldMenuView" class="control-label text-md-right">' . translate("USE OLD MENU VIEW") . '</label>
+              <label for="useOldMenuView" class="control-label text-md-right">' . translate("USE TOP MENU") . '</label>
               <input type="checkbox" name="useOldMenuView" id="useOldMenuView" value="1"' . ( $useOldMenuView ? ' checked="checked"' : '') . '/>
             </li>
           </ul>
@@ -930,7 +930,7 @@ function getNavBrandHTML() {
   if ($useOldMenuView) {
     $result .= '
       <div id="blockUseOldMenuView" style="display: flex;">
-        <label style="font-size: 14px; color: white;" for="useOldMenuView" class="control-label text-md-right">' . translate("Use old menu view") . '</label>
+        <label style="font-size: 14px; color: white;" for="useOldMenuView" class="control-label text-md-right">' . translate("Use Top menu") . '</label>
         <input type="checkbox" name="useOldMenuView" id="useOldMenuView" value="1"' . ( $useOldMenuView ? ' checked="checked"' : '') . '/>
       </div>
     '.PHP_EOL;


### PR DESCRIPTION
Later I will make a switch in options->web and remove the switch from main UI

Making a "Top and Left menu" switch will be a bit problematic, because both menus use the same element IDs. This may affect the correct operation of both menus. Previously, it was not implied that both menus would be used at the same time.
I suggest stopping at the "Top Menu OR Left Menu" switch for now.
In the future, it is probably worth making a new top menu, but it is also necessary to decide what will be in it. It seems pointless to me to duplicate the left menu items in the top menu. Different menus should have different items.

Isaac, what are your thoughts?