### PR TITLE
Fix: To search for the column 'Thumbnail' use the attribute 'data-field' instead of the internal text (Events page)

### DIFF
--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -508,7 +508,7 @@ function initPage() {
     });
 
     const thumb_ndx = $j('#eventTable tr th').filter(function() {
-      return $j(this).text().trim() == 'Thumbnail';
+      return $j(this).attr('data-field').toLowerCase().trim() == 'thumbnail';
     }).index();
     table.find('tr td:nth-child(' + (thumb_ndx+1) + ')').addClass('colThumbnail');
   });


### PR DESCRIPTION
The internal text will be equal to "Thumbnail" only if the English language is used without translation. In the case of translation, the internal text will be different !!!