### PR TITLE
Fix: Broken channel switching (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -354,7 +354,7 @@ function MonitorStream(monitorData) {
         rtsp2webModUrl.username = '';
         rtsp2webModUrl.password = '';
         //.urlParts.length > 1 ? urlParts[1] : urlParts[0]; // drop the username and password for viewing
-        this.currentChannelStream = (!streamChannel || streamChannel == 'default') ? ((this.RTSP2WebStream == 'Secondary') ? 1 : 0) : streamChannel;
+        this.currentChannelStream = (streamChannel == 'default') ? ((this.RTSP2WebStream == 'Secondary') ? 1 : 0) : streamChannel;
         if (this.RTSP2WebType == 'HLS') {
           const hlsUrl = rtsp2webModUrl;
           hlsUrl.pathname = "/stream/" + this.id + "/channel/" + this.currentChannelStream + "/hls/live/index.m3u8";


### PR DESCRIPTION
You can't use "!streamChannel" in the condition, because "streamChannel = 0" will be true. That is, we have channel 0 and channel 1.
In this case, if you don't pass anything to the "MonitorStream.start" method, then the default channel specified in the monitor settings is used. If we want to use channel 0, we call it like this: MonitorStream.start(0)
If the first one, then like this:
MonitorStream.start(1)
If the default one from the monitor settings, then like this: MonitorStream.start()