### PR TITLE
Fix: More correct switching of stream channels for RTSP2Web and Go2RTC with saving the selection in cookies on Watch page

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -100,6 +100,46 @@ function MonitorStream(monitorData) {
     return this.player = p;
   };
 
+  this.manageAvailablePlayersOptions = function(action, opt) {
+    const titleOption = "The player is disabled in the monitor settings."
+    if (action == 'disable') {
+      opt.setAttribute('disabled', '');
+      opt.setAttribute('title', titleOption);
+    } else if (action == 'enable') {
+      opt.removeAttribute('disabled');
+      opt.removeAttribute('title');
+    }
+  }
+
+  this.manageAvailablePlayers = function() {
+    const selectPlayers = document.querySelector('[id="player"][name="codec"]');
+    const opts = selectPlayers.options;
+
+    for (var opt, j = 0; opt = opts[j]; j++) {
+      if (-1 !== opt.value.indexOf('go2rtc')) {
+        if (this.Go2RTCEnabled) {
+          this.manageAvailablePlayersOptions('enable', opt);
+        } else {
+          this.manageAvailablePlayersOptions('disable', opt);
+        }
+      } else if (-1 !== opt.value.indexOf('rtsp2web')) {
+        if (this.RTSP2WebEnabled) {
+          this.manageAvailablePlayersOptions('enable', opt);
+        } else {
+          this.manageAvailablePlayersOptions('disable', opt);
+        }
+      }
+    }
+    if (selectPlayers.options[selectPlayers.selectedIndex].value == '') {
+      // Perhaps "Auto" is left from the previous monitor, we will change it according to the cookies.
+      selectPlayers.value = getCookie('zmWatchPlayer');
+    }
+    if (selectPlayers.options[selectPlayers.selectedIndex].disabled) {
+      // Selected player is not available for the current monitor
+      selectPlayers.value = ''; // Auto
+    }
+  }
+
   this.element = null;
   this.getElement = function() {
     if (this.element) return this.element;

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -102,10 +102,9 @@ function MonitorStream(monitorData) {
   };
 
   this.manageAvailablePlayersOptions = function(action, opt) {
-    const titleOption = "The player is disabled in the monitor settings.";
     if (action == 'disable') {
       opt.setAttribute('disabled', '');
-      opt.setAttribute('title', titleOption);
+      opt.setAttribute('title', playerDisabledInMonitorSettings);
     } else if (action == 'enable') {
       opt.removeAttribute('disabled');
       opt.removeAttribute('title');

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -83,6 +83,7 @@ function MonitorStream(monitorData) {
   };
 
   this.player = '';
+  this.activePlayer = ''; // Variants: go2rtc, janus, rtsp2web_hls, rtsp2web_mse, rtsp2web_webrtc, zms. Relevant for this.player = ''/Auto
   this.setPlayer = function(p) {
     if (-1 != p.indexOf('go2rtc')) {
 
@@ -138,6 +139,7 @@ function MonitorStream(monitorData) {
       // Selected player is not available for the current monitor
       selectPlayers.value = ''; // Auto
     }
+    this.player = selectPlayers.value
   };
 
   this.element = null;
@@ -351,6 +353,7 @@ function MonitorStream(monitorData) {
 
         $j('#volumeControls').show();
         if (typeof observerMontage !== 'undefined') observerMontage.observe(stream);
+        this.activePlayer = 'go2rtc';
         return;
       } else {
         alert("ZM_GO2RTC_PATH is empty. Go to Options->System and set ZM_GO2RTC_PATH accordingly.");
@@ -379,6 +382,7 @@ function MonitorStream(monitorData) {
       this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);
       this.started = true;
       this.streamListenerBind();
+      this.activePlayer = 'janus';
       return;
     }
 
@@ -423,16 +427,19 @@ function MonitorStream(monitorData) {
           } else if (stream.canPlayType('application/vnd.apple.mpegurl')) {
             stream.src = hlsUrl.href;
           }
+          this.activePlayer = 'rtsp2web_hls';
         } else if (this.RTSP2WebType == 'MSE') {
           const mseUrl = rtsp2webModUrl;
           mseUrl.protocol = useSSL ? 'wss' : 'ws';
           mseUrl.pathname = "/stream/" + this.id + "/channel/" + this.currentChannelStream + "/mse";
           mseUrl.search = "uuid=" + this.id + "&channel=" + this.currentChannelStream + "";
           startMsePlay(this, stream, mseUrl.href);
+          this.activePlayer = 'rtsp2web_mse';
         } else if (this.RTSP2WebType == 'WebRTC') {
           const webrtcUrl = rtsp2webModUrl;
           webrtcUrl.pathname = "/stream/" + this.id + "/channel/" + this.currentChannelStream + "/webrtc";
           startRTSP2WebPlay(stream, webrtcUrl.href, this);
+          this.activePlayer = 'rtsp2web_webrtc';
         }
         clearInterval(this.statusCmdTimer); // Fix for issues in Chromium when quickly hiding/showing a page. Doesn't clear statusCmdTimer when minimizing a page https://stackoverflow.com/questions/9501813/clearinterval-not-working
         this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);
@@ -482,6 +489,7 @@ function MonitorStream(monitorData) {
     stream.onload = this.img_onload.bind(this);
     this.started = true;
     this.streamListenerBind();
+    this.activePlayer = 'zms';
   }; // this.start
 
   this.stop = function() {

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -139,7 +139,7 @@ function MonitorStream(monitorData) {
       // Selected player is not available for the current monitor
       selectPlayers.value = ''; // Auto
     }
-    this.player = selectPlayers.value
+    this.player = selectPlayers.value;
   };
 
   this.element = null;

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -267,7 +267,7 @@ function MonitorStream(monitorData) {
   * streamChannel = 0 || Primary; 1 || Secondary.
   */
   this.start = function(streamChannel = 'default') {
-    if (streamChannel === null || streamChannel === '') streamChannel = 'default';
+    if (streamChannel === null || streamChannel === '' || currentView == 'montage') streamChannel = 'default';
     if (!['default', 0, 1].includes(streamChannel)) {
       streamChannel = (streamChannel.toLowerCase() == 'primary') ? 0 : 1;
     }
@@ -288,7 +288,7 @@ function MonitorStream(monitorData) {
         stream.background = true; // We do not use the document hiding/showing analysis from "video-rtc.js", because we have our own analysis
         const Go2RTCModUrl = url;
         const webrtcUrl = Go2RTCModUrl;
-        this.currentChannelStream = (streamChannel == 'default') ? 0 : streamChannel;
+        this.currentChannelStream = (streamChannel == 'default') ? ((this.RTSP2WebStream == 'Secondary') ? 1 : 0) : streamChannel;
         webrtcUrl.protocol = (url.protocol=='https:') ? 'wss:' : 'ws';
         webrtcUrl.pathname += "/ws";
         //webrtcUrl.search = 'src='+this.id;

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -263,7 +263,14 @@ function MonitorStream(monitorData) {
     }
   }; // setStreamScale
 
+  /*
+  * streamChannel = 0 || Primary; 1 || Secondary.
+  */
   this.start = function(streamChannel = 'default') {
+    if (streamChannel === null || streamChannel === '') streamChannel = 'default';
+    if (!['default', 0, 1].includes(streamChannel)) {
+      streamChannel = (streamChannel.toLowerCase() == 'primary') ? 0 : 1;
+    }
     this.streamListenerBind = streamListener.bind(null, this);
 
     console.log('start', this.Go2RTCEnabled, (!this.player), (-1 != this.player.indexOf('go2rtc')), ((!this.player) || (-1 != this.player.indexOf('go2rtc'))));

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -101,7 +101,7 @@ function MonitorStream(monitorData) {
   };
 
   this.manageAvailablePlayersOptions = function(action, opt) {
-    const titleOption = "The player is disabled in the monitor settings."
+    const titleOption = "The player is disabled in the monitor settings.";
     if (action == 'disable') {
       opt.setAttribute('disabled', '');
       opt.setAttribute('title', titleOption);
@@ -109,7 +109,7 @@ function MonitorStream(monitorData) {
       opt.removeAttribute('disabled');
       opt.removeAttribute('title');
     }
-  }
+  };
 
   this.manageAvailablePlayers = function() {
     const selectPlayers = document.querySelector('[id="player"][name="codec"]');
@@ -138,7 +138,7 @@ function MonitorStream(monitorData) {
       // Selected player is not available for the current monitor
       selectPlayers.value = ''; // Auto
     }
-  }
+  };
 
   this.element = null;
   this.getElement = function() {

--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -487,6 +487,7 @@ $SLANG = array(
     'Pixels'                => 'pixels',
     'PlayAll'               => 'Play All',
     'PlayCycle'             => 'Play Cycle',
+    'PlayerDisabledInMonitorSettings'  => 'The player is disabled in the monitor settings.',
     'PleaseWait'            => 'Please Wait',
     'PostEventImageBuffer'  => 'Post Event Image Count',
     'PreEventImageBuffer'   => 'Pre Event Image Count',

--- a/web/lang/ru_ru.php
+++ b/web/lang/ru_ru.php
@@ -832,7 +832,7 @@ $SLANG = array(
     'ZoomIn'               => 'Приблизить',
     'ZoomOut'              => 'Отдалить',
 // *********07-2022************************************ 
-    'Storage'		   => 'Хранилище',
+    'Storage'              => 'Хранилище',
     'Back'                 => 'Вернуться',
     'ParentGroup'          => 'Родительская группа',
     'FilterUnarchiveEvents' => 'Разархивировать все совпадения',
@@ -847,6 +847,7 @@ $SLANG = array(
     'PreviousMonitor'      => 'Предыдущий монитор',
     'PauseCycle'           => 'Приостановить цикл',
     'PlayCycle'            => 'Запуск цикла',
+    'PlayerDisabledInMonitorSettings'  => 'Этот плеер отключен в настройках монитора.',
     'NextMonitor'          => 'Следующий монитор',
     'Server'               => 'Сервер',
     'Servers'              => 'Сервера',

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1081,7 +1081,7 @@ function manageShutdownBtns(element) {
 }
 
 /* Controls the availability of options for selection*/
-function manageRTSP2WebChannelStream() {
+function manageChannelStream() {
   let select = null;
   let secondPath_ = null;
   if (currentView == 'watch') {
@@ -1721,7 +1721,7 @@ function findPos(obj, foundScrollLeft, foundScrollTop) {
 /* Handling <input> change */
 function handleChangeInputTag(evt) {
   // Managing availability of channel stream selection
-  manageRTSP2WebChannelStream();
+  manageChannelStream();
 }
 
 /* Handling a mouse click */

--- a/web/skins/classic/js/skin.js.php
+++ b/web/skins/classic/js/skin.js.php
@@ -36,6 +36,7 @@ const exportProgressString = '<?php echo addslashes(translate('Exporting')) ?>';
 const exportFailedString = '<?php echo translate('ExportFailed') ?>';
 const exportSucceededString = '<?php echo translate('ExportSucceeded') ?>';
 const cancelString = '<?php echo translate('Cancel') ?>';
+const playerDisabledInMonitorSettings = '<?php echo translate('PlayerDisabledInMonitorSettings') ?>';
 <?php
 /* We can't trust PHP_SELF on a path like /index.php/"%3E%3Cimg src=x onerror=prompt('1');%3E which
    will still load index.php but will include the arbitrary payload after `.php/`. To mitigate this,

--- a/web/skins/classic/views/js/monitor.js
+++ b/web/skins/classic/views/js/monitor.js
@@ -376,22 +376,39 @@ function initPage() {
 
   //Manage the RTSP2Web settings div
   const RTSP2WebEnabled = form.elements['newMonitor[RTSP2WebEnabled]'];
-  if (RTSP2WebEnabled) {
-    if (RTSP2WebEnabled.checked) {
-      document.getElementById("RTSP2WebType").hidden = false;
+  const Go2RTCEnabled = form.elements['newMonitor[Go2RTCEnabled]'];
+  if (RTSP2WebEnabled || Go2RTCEnabled) {
+    if (Go2RTCEnabled.checked || RTSP2WebEnabled.checked) {
       document.getElementById("RTSP2WebStream").hidden = false;
     } else {
-      document.getElementById("RTSP2WebType").hidden = true;
       document.getElementById("RTSP2WebStream").hidden = true;
     }
 
-    RTSP2WebEnabled.addEventListener('change', function() {
-      if (this.checked) {
-        document.getElementById("RTSP2WebType").hidden = false;
+    if (RTSP2WebEnabled.checked) {
+      document.getElementById("RTSP2WebType").hidden = false;
+    } else {
+      document.getElementById("RTSP2WebType").hidden = true;
+    }
+
+    Go2RTCEnabled.addEventListener('change', function() {
+      if (this.checked || RTSP2WebEnabled.checked) {
         document.getElementById("RTSP2WebStream").hidden = false;
       } else {
-        document.getElementById("RTSP2WebType").hidden = true;
         document.getElementById("RTSP2WebStream").hidden = true;
+      }
+    });
+
+    RTSP2WebEnabled.addEventListener('change', function() {
+      if (this.checked || Go2RTCEnabled.checked) {
+        document.getElementById("RTSP2WebStream").hidden = false;
+      } else {
+        document.getElementById("RTSP2WebStream").hidden = true;
+      }
+
+      if (this.checked) {
+        document.getElementById("RTSP2WebType").hidden = false;
+      } else {
+        document.getElementById("RTSP2WebType").hidden = true;
       }
     });
   }

--- a/web/skins/classic/views/js/monitor.js
+++ b/web/skins/classic/views/js/monitor.js
@@ -497,7 +497,7 @@ function initPage() {
   // Setup the thumbnail video animation
   if (!isMobile()) initThumbAnimation();
 
-  manageRTSP2WebChannelStream();
+  manageChannelStream();
 } // end function initPage()
 
 function saveMonitorData(href = '') {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -943,6 +943,7 @@ function manageStreamQualityVisibility() {
     streamChannel.classList.add("hidden-shift");
     rateControl.classList.remove("hidden-shift");
   }
+  applyChosen();
 }
 
 function applyMonitorControllable() {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -917,8 +917,7 @@ function setChannelStream() {
   manageChannelStream();
 
   if (-1 === monitorStream.activePlayer.indexOf('zms')) {
-    let streamChannelValue = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream && currentMonitor.SecondPath
-);
+    let streamChannelValue = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream && currentMonitor.SecondPath);
     // When switching monitors, cookies may store a channel from the previous monitor that the current monitor does not have.
     streamChannel.value = streamChannelValue; // This will be easier than checking for a disabled option by going through the options. That is, we set the required option and if it is disabled, then we select the 'Primary' channel
 

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -918,7 +918,7 @@ function manageStreamQualityVisibility() {
   const rateControl = document.getElementById('rateControl');
 
   if ((monitorStream.player) && (-1 !== monitorStream.player.indexOf('go2rtc') || -1 !== monitorStream.player.indexOf('rtsp2web'))) {
-    let streamChannelValue = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream)
+    let streamChannelValue = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream);
     // When switching monitors, cookies may store a channel from the previous monitor that the current monitor does not have.
     if (streamChannel.options[streamChannel.selectedIndex].disabled) {
       streamChannelValue = 'Primary';

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -836,6 +836,9 @@ function streamStart(monitor = null) {
 
   monitorStream.setPlayer(player);
   monitorStream.setBottomElement(document.getElementById('dvrControls'));
+  // Managing the visibility of elements
+  manageStreamQualityVisibility();
+
   // Start the fps and status updates. give a random delay so that we don't assault the server
   //monitorStream.setScale($j('#scale').val(), $j('#width').val(), $j('#height').val());
   //monitorsSetScale(monitorId);
@@ -861,9 +864,6 @@ function streamStart(monitor = null) {
     forceAlmBtn.prop('title', forceAlmBtn.prop('title') + ': disabled because cannot edit Monitors');
     enableAlmBtn.prop('title', enableAlmBtn.prop('title') + ': disabled because cannot edit Monitors');
   }
-
-  // Managing the visibility of elements
-  manageStreamQualityVisibility();
 }
 
 function streamReStart(oldId, newId) {
@@ -905,22 +905,27 @@ function streamReStart(oldId, newId) {
 
   table.bootstrapTable('destroy');
   applyMonitorControllable();
+  manageChannelStream();
   streamPrepareStart(currentMonitor);
   zmPanZoom.init();
   zmPanZoom.init({objString: '.imageFeed', disablePan: true, contain: 'inside', additional: true});
-  manageRTSP2WebChannelStream();
-  manageStreamQualityVisibility();
   //document.getElementById('monitor').classList.remove('hidden-shift');
 }
 
 function manageStreamQualityVisibility() {
   const streamQuality = document.getElementById('streamQuality');
+  const streamChannel = document.getElementById('streamChannel');
   const rateControl = document.getElementById('rateControl');
 
   if ((monitorStream.player) && (-1 !== monitorStream.player.indexOf('go2rtc') || -1 !== monitorStream.player.indexOf('rtsp2web'))) {
+    let streamChannelValue = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream)
+    // When switching monitors, cookies may store a channel from the previous monitor that the current monitor does not have.
+    if (streamChannel.options[streamChannel.selectedIndex].disabled) {
+      streamChannelValue = 'Primary';
+    }
     streamChannel.classList.remove("hidden-shift");
     streamQuality.classList.add("hidden-shift");
-    streamChannel.value = (getCookie('zmStreamChannel') || currentMonitor.RTSP2WebStream);
+    streamChannel.value = streamChannelValue;
     rateControl.classList.add("hidden-shift");
   } else {
     streamQuality.classList.remove("hidden-shift");
@@ -1094,8 +1099,7 @@ function initPage() {
     alert("No monitor found for id "+monitorId);
   }
 
-
-  manageRTSP2WebChannelStream();
+  manageChannelStream();
 } // initPage
 
 function watchFullscreen() {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1329,14 +1329,16 @@ function changePlayer() {
   console.log('setting to ', $j('#player').val());
   monitorStream.setPlayer($j('#player').val());
   setChannelStream();
-  streamCmdPlay(true);
-  manageStreamQualityVisibility();
-  return;
+  setTimeout(function() {
+    streamCmdPlay(true);
+    manageStreamQualityVisibility();
+  }, 300);
+  /*return;
 
   setTimeout(function() {
     monitorStream.start();
     onPlay();
-  }, 300);
+  }, 300);*/
 }
 
 function monitorsSetScale(id=null) {

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -175,7 +175,6 @@ if ( !isset($scales[$scale])) {
 $options['scale'] = 0; //Somewhere something is spoiled because of this...
 
 $streamQualitySelected = '0';
-# TODO input validation on streamquality
 if (isset($_REQUEST['streamQuality'])) {
   $streamQualitySelected = $_REQUEST['streamQuality'];
 } else if (isset($_COOKIE['zmStreamQuality'])) {
@@ -183,6 +182,17 @@ if (isset($_REQUEST['streamQuality'])) {
 } else if (isset($_SESSION['zmStreamQuality']) ) {
   $streamQualitySelected = $_SESSION['zmStreamQuality'];
 }
+$streamQualitySelected = validHtmlStr($streamQualitySelected);
+
+$streamChannelSelected = $monitor->RTSP2WebStream();
+if (isset($_REQUEST['streamChannel'])) {
+  $streamChannelSelected = $_REQUEST['streamChannel'];
+} else if (isset($_COOKIE['zmStreamChannel'])) {
+  $streamChannelSelected = $_COOKIE['zmStreamChannel'];
+} else if (isset($_SESSION['zmStreamChannel']) ) {
+  $streamChannelSelected = $_SESSION['zmStreamChannel'];
+}
+$streamChannelSelected = validHtmlStr($streamChannelSelected);
 
 if (isset($_REQUEST['width'])) {
   $options['width'] = validInt($_REQUEST['width']); 
@@ -293,7 +303,7 @@ echo htmlSelect('changeRate', $maxfps_options, $options['maxfps']);
         <span id="streamQualityControl">
           <label for="streamQuality"><?php echo translate('Stream quality') ?></label>
           <?php
-              echo htmlSelect('streamChannel', ZM\Monitor::getRTSP2WebStreamOptions(), $monitor->RTSP2WebStream(), array('data-on-change'=>'monitorChangeStreamChannel','id'=>'streamChannel'));
+              echo htmlSelect('streamChannel', ZM\Monitor::getRTSP2WebStreamOptions(), $streamChannelSelected, array('data-on-change'=>'monitorChangeStreamChannel','id'=>'streamChannel'));
               echo htmlSelect('streamQuality', $streamQuality, $streamQualitySelected, array('data-on-change'=>'changeStreamQuality','id'=>'streamQuality'));
           ?>
         </span>

--- a/web/skins/classic/views/watch.php
+++ b/web/skins/classic/views/watch.php
@@ -311,20 +311,13 @@ echo htmlSelect('changeRate', $maxfps_options, $options['maxfps']);
           <label for="player"><?php echo translate('Player') ?></label>
 <?php 
               $players = [''=>translate('Auto'), 'zms'=>'ZMS MJPEG'];
-              if ($monitor->Go2RTCEnabled()) {
-                $players['go2rtc'] = 'Go2RTC Auto';
-                $players['go2rtc_webrtc'] = 'Go2RTC WEBRTC';
-                $players['go2rtc_mse'] = 'Go2RTC MSE';
-                $players['go2rtc_hls'] = 'Go2RTC HLS';
-              }
-
-              if ($monitor->RTSP2WebEnabled()) {
-                $players = array_merge($players,[
-                  'rtsp2web_webrtc' => 'RTSP2Web WEBRTC',
-                  'rtsp2web_mse' => 'RTSP2Web MSE',
-                  'rtsp2web_hls' => 'RTSP2Web HLS',
-                ]);
-              } #
+              $players['go2rtc'] = 'Go2RTC Auto';
+              $players['go2rtc_webrtc'] = 'Go2RTC WEBRTC';
+              $players['go2rtc_mse'] = 'Go2RTC MSE';
+              $players['go2rtc_hls'] = 'Go2RTC HLS';
+              $players['rtsp2web_webrtc'] = 'RTSP2Web WEBRTC';
+              $players['rtsp2web_mse'] = 'RTSP2Web MSE';
+              $players['rtsp2web_hls'] = 'RTSP2Web HLS';
               $player = ''; # Auto
               if (isset($_REQUEST['player']) and isset($players[$_REQUEST['player']])) {
                 $player = validHtmlStr($_REQUEST['player']);


### PR DESCRIPTION
Now the selected channel is saved in cookies.
But the saved channel is applied to any monitor, not to a specific one. Let it be like this for now. It's better than what's happening now with the collapse....
Later, a new solution will need to be developed.
You can also pass the channel in the browser line via `streamChannel=0 или streamChannel=secondary`

The "RTSP2WebStream" setting is now visible for both RTSP2Web and Go2RTC
Probably, in the future it is necessary to rename "RTSP2WebStream" for example to "StreamSource"

Closed #4373 #4381