### PR TITLE
Fix: When changing the stream channel, you also need to call monitorsSetScale() on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1318,6 +1318,7 @@ function monitorChangeStreamChannel() {
     setTimeout(function() {
       monitorStream.start(streamChannel);
       onPlay();
+      monitorsSetScale(monitorId);
     }, 300);
   }
 }


### PR DESCRIPTION
Otherwise, the image may not be the correct size if the aspect ratio of the primary and secondary streams differs.