### PR TITLE
Fix: When changing the player and after starting the stream (hiding - displaying the page), you also need to call monitorsSetScale() on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1489,8 +1489,10 @@ document.onvisibilitychange = () => {
   } else {
     //Start monitor when show page
     if (monitorStream && prevStateStarted == 'played' && !idleTimeoutTriggered) {
+      prevStateStarted = false;
       onPlay(); //Set the correct state of the player buttons.
       monitorStream.start(monitorStream.currentChannelStream);
+      monitorsSetScale(monitorId);
     }
   }
 };


### PR DESCRIPTION
Otherwise, there may be problems with the image if we were viewing using "ZMS MJPEG" and then switched, for example, to the Go2RTC secondary channel and we have different image proportions for "ZMS MJPEG" always using the primary channel and Go2RTC using the secondary channel