### PR TITLE
Fix: Correct stop of go2rtc. It is required to close the stream, not just disconnect (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -549,6 +549,8 @@ function MonitorStream(monitorData) {
           console.warn(e);
         }
       }
+      if (close in this.webrtc) this.webrtc.close();
+      this.webrtc = null;
     } else if (-1 !== this.activePlayer.indexOf('rtsp2web')) {
       if (this.webrtc) {
         if (this.webrtc.close) this.webrtc.close();


### PR DESCRIPTION
Otherwise, the stream may remain alive and there will be problems when switching players and parasitic network traffic is possible.