### PR TITLE
Fix: Check for existence of "this.webrtc" before checking "close" method (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -549,7 +549,7 @@ function MonitorStream(monitorData) {
           console.warn(e);
         }
       }
-      if (close in this.webrtc) this.webrtc.close();
+      if (this.webrtc && ('close' in this.webrtc)) this.webrtc.close();
       this.webrtc = null;
     } else if (-1 !== this.activePlayer.indexOf('rtsp2web')) {
       if (this.webrtc) {


### PR DESCRIPTION
In addition to #4407
Otherwise, there may be an error when switching start/stop quickly.