### PR TITLE
Fix: Changed text color to darker for disabled item in "select" list for dark skin "skin.css"

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -261,6 +261,10 @@ li.search-choice {
 .chosen-container-active .chosen-choices li.search-field input[type=text] {
   color: inherit !important;
 }
+
+.chosen-container .chosen-results li.disabled-result {
+  color: #888;
+}
 /* end chosen override */
 
 .modal-content {


### PR DESCRIPTION
Otherwise, on a dark background there is very little difference between the item being on and off.