### PR TITLE
Fix: When calling "debugFilter()", do not use the global variable "form", but get it from the page (filter.js)

### DIFF
--- a/web/skins/classic/views/js/filter.js
+++ b/web/skins/classic/views/js/filter.js
@@ -412,7 +412,8 @@ function delTerm( element ) {
   parseRows(rows);
 }
 
-function debugFilter() {
+function debugFilter(element) {
+  const form = element.form;
   getModal('filterdebug', $j(form).serialize());
 }
 


### PR DESCRIPTION
Closing issue #4415
Also, it is still necessary to put things in order with the formation of the global variable "form" in "CsrfMagic.end" I believe that the global variable "form" should not be formed in "CsrfMagic.end"