### PR TITLE
Fix: Incorrect 'streamMode' setting for Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -64,7 +64,7 @@ monitorData[monitorData.length] = {
   'monitorRefresh': '<?php echo $m->Refresh() ?>',
   'monitorStreamReplayBuffer': parseInt('<?php echo $m->StreamReplayBuffer() ?>'),
   'monitorControllable': <?php echo $m->Controllable()?'true':'false' ?>,
-  'streamMode': '<?php echo $monitor->getStreamMode(); ?>'
+  'streamMode': '<?php echo $m->getStreamMode(); ?>'
 };
 <?php
 } // end foreach monitor


### PR DESCRIPTION
We cycle through monitors and the current monitor in the loop is "$m"