### PR TITLE
[release-1.36] Fix building against FFmpeg 8.0

### DIFF
--- a/src/zm_ffmpeg.cpp
+++ b/src/zm_ffmpeg.cpp
@@ -605,10 +605,11 @@ int zm_send_frame_receive_packet(AVCodecContext *ctx, AVFrame *frame, AVPacket *
 
 void zm_free_codec(AVCodecContext **ctx) {
   if (*ctx) {
-    avcodec_close(*ctx);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
     // We allocate and copy in newer ffmpeg, so need to free it
     avcodec_free_context(ctx);
+#else
+    avcodec_close(*ctx);
 #endif
     *ctx = NULL;
   } // end if 

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -595,16 +595,18 @@ int FfmpegCamera::Close() {
   mCanCapture = false;
 
   if ( mVideoCodecContext ) {
-    avcodec_close(mVideoCodecContext);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
     avcodec_free_context(&mVideoCodecContext);
+#else
+    avcodec_close(mVideoCodecContext);
 #endif
     mVideoCodecContext = nullptr;  // Freed by av_close_input_file
   }
   if ( mAudioCodecContext ) {
-    avcodec_close(mAudioCodecContext);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
     avcodec_free_context(&mAudioCodecContext);
+#else
+    avcodec_close(mAudioCodecContext);
 #endif
     mAudioCodecContext = nullptr;  // Freed by av_close_input_file
   }

--- a/src/zm_ffmpeg_input.cpp
+++ b/src/zm_ffmpeg_input.cpp
@@ -143,10 +143,11 @@ int FFmpeg_Input::Open(const char *filepath) {
 int FFmpeg_Input::Close( ) {
   if (streams) {
     for (unsigned int i = 0; i < input_format_context->nb_streams; i += 1) {
-      avcodec_close(streams[i].context);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
       avcodec_free_context(&streams[i].context);
       streams[i].context = nullptr;
+#else
+      avcodec_close(streams[i].context);
 #endif
     }
     delete[] streams;

--- a/src/zm_mpeg.cpp
+++ b/src/zm_mpeg.cpp
@@ -498,7 +498,11 @@ VideoStream::~VideoStream( ) {
 	}
 	/* close each codec */
 	if ( ost ) {
+#if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
+		avcodec_free_context ( &codec_context );
+#else
 		avcodec_close( codec_context );
+#endif
 		av_free( opicture->data[0] );
 		av_frame_free( &opicture );
 		if ( tmp_opicture ) {

--- a/src/zm_remote_camera_rtsp.cpp
+++ b/src/zm_remote_camera_rtsp.cpp
@@ -84,7 +84,11 @@ RemoteCameraRtsp::RemoteCameraRtsp(
 RemoteCameraRtsp::~RemoteCameraRtsp() {
 
   if ( mVideoCodecContext ) {
+#if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
+     avcodec_free_context(&mVideoCodecContext);
+#else
      avcodec_close(mVideoCodecContext);
+#endif
      mVideoCodecContext = nullptr; // Freed by avformat_free_context in the destructor of RtspThread class
   }
   // Is allocated in RTSPThread and is free there as well

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -751,9 +751,12 @@ VideoStore::~VideoStore() {
   if (video_out_stream) {
     video_in_ctx = nullptr;
 
-    avcodec_close(video_out_ctx);
+#if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
     Debug(3, "Freeing video_out_ctx");
     avcodec_free_context(&video_out_ctx);
+#else
+    avcodec_close(video_out_ctx);
+#endif
     if (hw_device_ctx) {
       Debug(3, "Freeing hw_device_ctx");
       av_buffer_unref(&hw_device_ctx);
@@ -770,9 +773,10 @@ VideoStore::~VideoStore() {
 
     if (audio_out_ctx) {
       Debug(4, "Success closing audio_out_ctx");
-      avcodec_close(audio_out_ctx);
 #if LIBAVCODEC_VERSION_CHECK(57, 64, 0, 64, 0)
       avcodec_free_context(&audio_out_ctx);
+#else
+      avcodec_close(audio_out_ctx);
 #endif
     }
 


### PR DESCRIPTION
`avcodec_close()` is now removed in FFmpeg 8.0, so #ifdef its calls everywhere. This commit is a minimal amount of changes which allow 1.36 series to build against FFmpeg 8.0, as opposed to cherry-picking commits on the master branch which remove older supports for older FFmpeg versions.

Most call sites have ifdef'ed call to `avcodec_free_context()`. In such case, hitch-hike it and put `avcodec_close()` in the else case as `avcodec_free_context()` calls (the equivalent of) `avcodec_close()` internally.

zm_videostore.cpp has un-ifdef'ed `avcodec_free_context()` together with `avcodec_close()` for some reason, so add the corresponding ifdef.

Calls at zm_mpeg.cpp and zm_remote_camera_rtsp.cpp has never been ported to `avcodec_free_context()`, so they're ported. The comment in zm_remote_camera_rtsp.cpp makes me unsure if this porting is correct, but I essentially followed commit 8822710 [^1] on the master branch, so either both are correct, or both are incorrect. 😅

[^1] Commit 8822710 ("Removing avcodec_close, avcodec_free_context is
     replacement and been around since 2014, so should be no reason to
     version test.")