### PR TITLE
Display the "No Tag" filter label

### DIFF
--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1148,9 +1148,6 @@ class Filter extends ZM_Object {
         } else if ( $term['attr'] == 'Tags' ) {
           $selected = explode(',', $term['val']);
           // echo '<pre>selected: '; print_r($selected); echo '</pre>';
-          if (count($selected) == 1 and !$selected[0]) {
-            $selected = null;
-          }
           $options = ['id'=>'filterTags', 'class'=>'chosen chosen-auto-width', 'multiple'=>'multiple', 'data-placeholder'=>translate('All Tags')];
           if (isset($term['cookie'])) {
             $options['data-cookie'] = $term['cookie'];


### PR DESCRIPTION
When "LIST MATCHES" is pressed from the filters page from a filter that has the "No Tag" filter applied, show "No Tag" in the filter area on the events page.