### PR TITLE
Fix: With "bfcache," always refresh the page without analyzing the content height.

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2096,7 +2096,7 @@ function initPageGeneral() {
     }
   });
 
-  function addListenerGlobalBeforeunload(event) { 
+  function addListenerGlobalBeforeunload(event) {
     //window.removeEventListener('beforeunload', addListenerGlobalBeforeunload);
     //event.preventDefault();
     if (navbar_type == 'left') {


### PR DESCRIPTION
Because in addition to Firefox, the problem occurs on some Linux (Chromium) and Android (Chrome) devices.

Closed #4319 & #4470

We will also no longer hide the expand/collapse button for the left menu during page animation, as the button code was previously moved to a different location.

