### PR TITLE
Fix: Allow using any character from the "letter" category in the name of the downloaded event archive on Events page

### DIFF
--- a/web/ajax/event.php
+++ b/web/ajax/event.php
@@ -113,7 +113,7 @@ if ( canView('Events') or canView('Snapshots') ) {
     $exportFileName = isset($_REQUEST['exportFileName']) ? $_REQUEST['exportFileName'] : '';
 
     if (!$exportFileName) $exportFileName = 'Export'.(isset($_REQUEST['connkey'])?$_REQUEST['connkey']:'');
-    $exportFileName = preg_replace('/[^\p{L}\p{N}\-\.\(\):]/u', '', $exportFileName);
+    $exportFileName = preg_replace('/[^\p{L}\p{N}\-\.\(\)]/u', '', $exportFileName);
 
     $exportIds = [];
     if (!empty($_REQUEST['eids'])) {


### PR DESCRIPTION
This change will allow the use of any national Unicode alphabet in the file name. 
We also allow any numeric character and the characters "-", ".", "(", ")" 

The ":" character is prohibited in file names in Windows, so we're excluding it from the list of allowed characters.