### PR TITLE
Update skin.css

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -995,7 +995,6 @@ a.flip {
 
 .tags-container {
   display: flex;
-  flex-wrap: wrap;
   border: 1px solid;
   border-color: #ccc;
   border-radius: 4px;


### PR DESCRIPTION
Better experience on mobile with a narrow display.  Keeps the tags field from jumping from a single line to two lines after entering a tag.