### PR TITLE
Fix(event): Avoid error applying tag before tags are loaded

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1779,7 +1779,7 @@ function formatTag(tag) {
 }
 
 function addTag(tag) {
-  if (tag.Name.trim() !== '' && !isDup(tag.Name)) {
+  if (tag?.Name.trim() !== '' && !isDup(tag?.Name)) {
     $j.getJSON(thisUrl + '?request=event&action=addtag&tid=' + tag.Id + '&id=' + eventData.Id)
         .done(function(data) {
           formatTag(tag);


### PR DESCRIPTION
Avoids an error condition that can occur when first loading an event and the available tags have not yet been loaded and one of the buttons in the tag field is pressed to apply the last tag and move to the next/previous event.