### PR TITLE
Add more images to the build matrix, debian:sid, ubuntu:devel and 25:…

### DIFF
--- a/.github/workflows/build-native-packages-aarch64.yml
+++ b/.github/workflows/build-native-packages-aarch64.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ["debian:13", "debian:12", "ubuntu:22.04", "ubuntu:24.04"]
+        distro: ["debian:sid", "debian:13", "debian:12", "ubuntu:25.10", "ubuntu:devel", "ubuntu:24.04", "ubuntu:22.04"]
     runs-on: self-hosted
 
     container:

--- a/.github/workflows/build-native-packages.yml
+++ b/.github/workflows/build-native-packages.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ["debian:13", "debian:12", "ubuntu:22.04", "ubuntu:24.04"]
+        distro: ["debian:sid", "debian:13", "debian:12", "ubuntu:25.10", "ubuntu:devel", "ubuntu:24.04", "ubuntu:22.04"]
     container:
       image: ${{ matrix.distro }}
 


### PR DESCRIPTION
…10. Had no working option on 25.10 but to diy build 1.37, noble didn't install up.

Note happy for you to alter the list here, I believe you need to maintain the conf on zmrepo for the version to release name folder. But I saw questing is already in master just no builds and Sid was in proposed. Not sure how ubuntu:devel works it should be 26.04 Resolute Racoon, but I suspect it changes each time unlike Sid.