### PR TITLE
Add Tags to event search and return tag data with events

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -50,7 +50,22 @@ class EventsController extends AppController {
 
     $this->FilterComponent = $this->Components->load('Filter');
     $named_params = $this->request->params['named'];
+    $tag_filter_value = null;
+    $tag_filter_field = null;
     if ($named_params) {
+      if (isset($named_params['TagId'])) {
+        $tag_filter_value = $named_params['TagId'];
+        $tag_filter_field = 'Id';
+        unset($named_params['TagId']);
+      } else if (isset($named_params['Tag'])) {
+        $tag_filter_value = $named_params['Tag'];
+        $tag_filter_field = 'Name';
+        unset($named_params['Tag']);
+      } else if (isset($named_params['Tags'])) {
+        $tag_filter_value = $named_params['Tags'];
+        $tag_filter_field = 'Name';
+        unset($named_params['Tags']);
+      }
       # In 1.35.13 we renamed StartTime and EndTime to StartDateTime and EndDateTime.
       # This hack renames the query string params
       foreach ( $named_params as $k=>$v ) {
@@ -101,7 +116,21 @@ class EventsController extends AppController {
       #ZM\Debug(print_r($conditions, true));
 
     } else {
-      $conditions = $this->FilterComponent->buildFilter($_REQUEST);
+      $raw_params = $_REQUEST;
+      if (isset($raw_params['TagId'])) {
+        $tag_filter_value = $raw_params['TagId'];
+        $tag_filter_field = 'Id';
+        unset($raw_params['TagId']);
+      } else if (isset($raw_params['Tag'])) {
+        $tag_filter_value = $raw_params['Tag'];
+        $tag_filter_field = 'Name';
+        unset($raw_params['Tag']);
+      } else if (isset($raw_params['Tags'])) {
+        $tag_filter_value = $raw_params['Tags'];
+        $tag_filter_field = 'Name';
+        unset($raw_params['Tags']);
+      }
+      $conditions = $this->FilterComponent->buildFilter($raw_params);
     }
     $settings = array(
       // https://github.com/ZoneMinder/ZoneMinder/issues/995
@@ -118,6 +147,7 @@ class EventsController extends AppController {
       'paramType' => 'querystring',
     );
 
+    $settings['contain'] = array('Tag');
     if ( isset($conditions['GroupId']) ) {
       $settings['joins'] = array(
         array(
@@ -128,7 +158,34 @@ class EventsController extends AppController {
           ),
         ),
       );
-      $settings['contain'] = array('Group');
+      $settings['contain'][] = 'Group';
+    }
+    if ($tag_filter_value !== null) {
+      if (!isset($settings['joins'])) {
+        $settings['joins'] = array();
+      }
+      $settings['joins'][] = array(
+        'table' => 'Events_Tags',
+        'type' => 'inner',
+        'conditions' => array(
+          'Events_Tags.EventId = Event.Id'
+        ),
+      );
+      $settings['joins'][] = array(
+        'table' => 'Tags',
+        'type' => 'inner',
+        'conditions' => array(
+          'Tags.Id = Events_Tags.TagId'
+        ),
+      );
+      if ($tag_filter_field === 'Id') {
+        $tag_ids = is_array($tag_filter_value) ? $tag_filter_value : explode(',', $tag_filter_value);
+        $tag_ids = array_map('intval', $tag_ids);
+        $conditions[] = array('Tags.Id' => $tag_ids);
+      } else {
+        $conditions[] = array('Tags.Name' => $tag_filter_value);
+      }
+      $settings['group'] = 'Event.Id';
     }
     $settings['conditions'] = array($conditions, $mon_options);
 

--- a/web/api/app/Model/Event.php
+++ b/web/api/app/Model/Event.php
@@ -125,6 +125,7 @@ class Event extends AppModel {
   );
 
   public $actsAs = array(
+    'Containable',
     'CakePHP-Enum-Behavior.Enum' => array(
       'Orientation'     => array('ROTATE_0','ROTATE_90','ROTATE_180','ROTATE_270','FLIP_HORI','FLIP_VERT'),
       'Scheme'          => array('Deep','Medium','Shallow')


### PR DESCRIPTION
Isaac said in chat that Tags in API doesn't work, figured must have been related to Askers question about filtering event view by tags, so anyway I did this, can filter on Tag (single only) and TagID (single tag and multiple)