### PR TITLE
Fix ONVIF PropertyOperation handling according to spec

### DIFF
--- a/src/zm_monitor_onvif.h
+++ b/src/zm_monitor_onvif.h
@@ -67,6 +67,7 @@ class ONVIF {
   std::string subscription_timeout;  // Default "PT60S"
   
   // Helper methods
+  bool interpret_alarm_value(const std::string &value);  // Interpret alarm value from various formats
   bool parse_event_message(wsnt__NotificationMessageHolderType *msg, std::string &topic, std::string &value, std::string &operation);
   bool matches_topic_filter(const std::string &topic, const std::string &filter);
   void parse_onvif_options();  // Parse options from parent->onvif_options


### PR DESCRIPTION
Properly implement ONVIF PropertyOperation handling according to the ONVIF Profile T Specification. This fixes issues where alarms were incorrectly triggered or cleared due to misinterpretation of event messages.

Changes:
- Add interpret_alarm_value() helper to handle various value formats including "000", "0", "false", "true", etc.
- Implement proper PropertyOperation handling:
  * "Deleted" - alarm has ended, clear it
  * "Initialized" - current state at subscription (sync, don't trigger)
  * "Changed" - actual state transition (trigger alarm on/off)
- Remove premature alarm clearing on empty PullMessages responses
- Add comprehensive comments explaining ONVIF spec compliance

The root cause was that the parser was extracting different values from the same XML after commit 3f6495644. The new parser prioritizes SimpleItem Value attributes which may contain camera-specific values like "000". By properly interpreting PropertyOperation, we now correctly handle all ONVIF-compliant cameras regardless of their value format.

Fixes issues where events incorrectly went to ALERT state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)