### PR TITLE
Fix default All zone creation to account for monitor rotation

### DIFF
--- a/web/includes/actions/monitor.php
+++ b/web/includes/actions/monitor.php
@@ -261,16 +261,25 @@ if ($action == 'save') {
 
       if ( $monitor->insert($changes) ) {
         $mid = $monitor->Id();
-        $zoneArea = $newMonitor['Width'] * $newMonitor['Height'];
+        // Adjust zone dimensions if monitor has rotation applied
+        $zoneWidth = $newMonitor['Width'];
+        $zoneHeight = $newMonitor['Height'];
+        if (isset($newMonitor['Orientation']) &&
+            ($newMonitor['Orientation'] == 'ROTATE_90' || $newMonitor['Orientation'] == 'ROTATE_270')) {
+          // Swap dimensions for 90/270 degree rotations
+          $zoneWidth = $newMonitor['Height'];
+          $zoneHeight = $newMonitor['Width'];
+        }
+        $zoneArea = $zoneWidth * $zoneHeight;
         $zone = new ZM\Zone();
         if (!$zone->save(['MonitorId'=>$monitor->Id(), 'Name'=>'All', 'Coords'=>
           sprintf( '%d,%d %d,%d %d,%d %d,%d', 0, 0,
-            $newMonitor['Width']-1,
+            $zoneWidth-1,
             0,
-            $newMonitor['Width']-1,
-            $newMonitor['Height']-1,
+            $zoneWidth-1,
+            $zoneHeight-1,
             0,
-            $newMonitor['Height']-1),
+            $zoneHeight-1),
           'Area'=>$zoneArea,
           'MinAlarmPixels'=>intval(($zoneArea*.05)/100),
           'MaxAlarmPixels'=>intval(($zoneArea*75)/100),


### PR DESCRIPTION
When creating a new monitor with Orientation set to ROTATE_90 or ROTATE_270, the default "All" zone dimensions are now correctly swapped to match the rotated image dimensions. This prevents zm_zone.cpp from reporting that zones extend outside of image dimensions and having to fix them at runtime.

Fixes issue where monitors created with Rotate Right or Rotate Left would generate warnings like:
"Zone 1/All for monitor X extends outside of image dimensions, (0,0), (3839,2159) != (2160,3840), fixing"

Also you can see it when you look at the All zone below, the zone is wrong orientation and extends beyond image range. Editing the zone will bring it back to a square.

<img width="500" height="490" alt="image" src="https://github.com/user-attachments/assets/21f3da8a-99cf-49dc-8a4c-dad949e86af9" />
