### PR TITLE
Fix ONVIF password URL encoding in camera configuration

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2422,6 +2422,11 @@ function extract_auth_values_from_url($url) {
   $username = substr( $url, $protocolPrefixPos+3, $fieldsSeparatorPos-($protocolPrefixPos+3) );
   $password = substr( $url, $fieldsSeparatorPos+1, $authSeparatorPos-$fieldsSeparatorPos-1 );
 
+  // URL decode the credentials since they may contain encoded special characters
+  // from ONVIF probe or manual URL entry
+  $username = urldecode($username);
+  $password = urldecode($password);
+
   return array( $username, $password );
 }
 


### PR DESCRIPTION
When adding cameras via ONVIF probe, passwords containing special characters (like parentheses, slashes, etc.) were being stored in the database in URL-encoded form instead of plain text. This caused authentication failures when the encoded password was used.

The issue was in extract_auth_values_from_url() which extracted credentials from the stream URI but didn't decode them. Since the ONVIF probe process double-encodes passwords (to survive POST encoding), and monitor.php decodes once, the extracted password still remained URL-encoded.

The fix adds urldecode() to both username and password after extraction, ensuring they're stored in their original form in the database.

Example: Password "pass)word" was being stored as "pass%29word"