### PR TITLE
I returned the old "this.controlMute" function in MonitorStream.js

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -914,7 +914,7 @@ function MonitorStream(monitorData) {
       iconMute.innerHTML = (volume == 'on')? 'volume_up' : 'volume_off';
     }
     return iconMute;
-  }
+  };
 
   /*
   * volume: on || off
@@ -929,7 +929,7 @@ function MonitorStream(monitorData) {
       }
     }
     return volumeSlider;
-  }
+  };
 
   /*
   * mode: switch, on, off
@@ -938,7 +938,7 @@ function MonitorStream(monitorData) {
     const mid = this.id;
     let volumeSlider;
     const audioStream = this.getAudioStream(mid);
-    if (!audioStream){
+    if (!audioStream) {
       console.log(`No audiostream! in controlMute for monitor ID=${mid}`);
       return;
     }


### PR DESCRIPTION
It's not entirely clear why it was necessary to change the "this.controlMute" function in the commit.https://github.com/ZoneMinder/zoneminder/commit/f796fa913fe3bedbd13c707dfacc8c649ed1018f

After this change, the "volumeSlider" and "iconMute" styling sometimes doesn't work correctly.

The old code was 99.9% debugged and worked without any issues.

It's also unclear why "this.muted" was added? After all, we already had "audioStream.muted." Now we're probably getting duplicates.

@connortechnology I propose to discuss here an issue that occurs when using my code. I will try to solve it (if it actually occurs...). With this PR, all my monitors start with the sound muted on the Montage page.