### PR TITLE
API: Support multiple Event IDs in TagsController index

### DIFF
--- a/web/api/app/Controller/TagsController.php
+++ b/web/api/app/Controller/TagsController.php
@@ -48,12 +48,18 @@ class TagsController extends AppController {
     );
 
     if (isset($conditions['Events.Id'])) {
-      $find_array['joins'][]   = [ 
+      // Support comma-separated Event IDs for querying tags across multiple events
+      $event_id_value = $conditions['Events.Id'];
+      if (!is_array($event_id_value) && strpos($event_id_value, ',') !== false) {
+        $conditions['Events.Id'] = array_map('intval', explode(',', $event_id_value));
+      }
+
+      $find_array['joins'][]   = [
           'table' => 'Events_Tags',
           'type'  => 'inner',
           'conditions' => ['Events_Tags.TagId = Tag.Id'],
       ];
-      $find_array['joins'][]   = [ 
+      $find_array['joins'][]   = [
           'table' => 'Events',
           'type'  => 'inner',
           'conditions' => ['Events.Id = Events_Tags.EventId'],


### PR DESCRIPTION
## Summary

- Add support for comma-separated Event IDs in the Tags API endpoint
- Enables efficient retrieval of tags for multiple events in a single API call

**Before:** `/api/tags/index/Events.Id:123,456.json` treated `123,456` as a single string value (failed)

**After:** `/api/tags/index/Events.Id:123,456.json` properly splits into `[123, 456]` for SQL `IN` clause

## Changes

In `TagsController::index()`, when `Events.Id` is set, check if it contains comma-separated values and convert to an integer array:

```php
$event_id_value = $conditions['Events.Id'];
if (!is_array($event_id_value) && strpos($event_id_value, ',') !== false) {
  $conditions['Events.Id'] = array_map('intval', explode(',', $event_id_value));
}
```

This approach mirrors how `EventsController` handles multiple Tag IDs.

## Test plan

- [ ] Verify single Event ID still works: `/api/tags/index/Events.Id:123.json`
- [ ] Verify multiple Event IDs now work: `/api/tags/index/Events.Id:123,456,789.json`
- [ ] Verify array values are sanitized to integers (injection prevention)

Fixes #4567

🤖 Generated with [Claude Code](https://claude.com/claude-code)