### PR TITLE
Fix wrong package name in User.pm

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/User.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/User.pm
@@ -19,7 +19,7 @@
 #
 # ==========================================================================
  
-package ZoneMinder::Frame;
+package ZoneMinder::User;
 
 use 5.006;
 use strict;


### PR DESCRIPTION
## Summary

- `User.pm` declares `package ZoneMinder::Frame` instead of `package ZoneMinder::User`, clobbering the Frame package namespace and making the User ORM class unusable
- One-line fix: change the package declaration to `ZoneMinder::User`

Fixes #4581

## Test plan

- [ ] Verify `require ZoneMinder::User; ZoneMinder::User->find_one(Username => 'admin')` returns the correct user row
- [ ] Verify `require ZoneMinder::Frame; ZoneMinder::Frame->find_one(EventId => $eid)` still works correctly (no namespace collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)