### PR TITLE
Fix: Run ".setPlayer" (set the default monitor player) when starting monitor on the Montage page

### DIFF
--- a/web/skins/classic/views/js/montage.js
+++ b/web/skins/classic/views/js/montage.js
@@ -483,6 +483,7 @@ function startMonitors() {
     const monitor = monitors[i];
     const isOut = isOutOfViewport(monitor.getElement());
     if (!isOut.all) {
+      monitor.setPlayer(monitor.player);
       monitor.start();
     }
     if ((monitor.type == 'WebSite') && (monitor.refresh > 0)) {
@@ -678,6 +679,7 @@ function initPage() {
                   for (let i=0, length = monitors.length; i < length; i++) {
                     const monitor = monitors[i];
                     if ((!isOutOfViewport(monitor.getElement()).all) && !monitor.started) {
+                      monitor.setPlayer(monitor.player);
                       monitor.start();
                     }
                   }
@@ -1069,6 +1071,7 @@ document.onvisibilitychange = () => {
 
         const isOut = isOutOfViewport(monitor.getElement());
         if ((!isOut.all) && !monitor.started) {
+          monitor.setPlayer(monitor.player);
           monitor.start();
         }
       } // end foreach monitor


### PR DESCRIPTION
Otherwise ".RTSP2WebType" will be undefined and will be displayed as "null" on the Montage page. (montage.js)