### PR TITLE
Fix: Vertically center the ".btn-term-remove-all" button in the sidebar filter (sidebar.css)

### DIFF
--- a/web/skins/classic/css/base/sidebar.css
+++ b/web/skins/classic/css/base/sidebar.css
@@ -317,6 +317,10 @@ body #sidebarMain .sub-menu-list {
   position: relative; /* Enable absolute positioning for child */
 }
 
+.extruder .extruder-content .controlHeader .chosen-choices {
+  padding-right: 30px;
+}
+
 .extruder .extruder-content .btn-term-remove-all {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
Before:
![11](https://github.com/user-attachments/assets/f388efb5-8816-4c0e-adeb-ca71e2046ad2)

After:
![33](https://github.com/user-attachments/assets/9b78dc7e-e832-4794-bb1a-ced80dfad03b)

