### PR TITLE
Fix: Broken ".sidebar-footer" style (sidebar.css)

### DIFF
--- a/web/skins/classic/css/base/sidebar.css
+++ b/web/skins/classic/css/base/sidebar.css
@@ -367,9 +367,9 @@ div:not(.chosen-container-active) > .chosen-drop {
 }
 
 .sidebar-main .sidebar-layout .sidebar-footer {
-  height: auto;
-  min-height: 0;
-  margin: 20px 0;
+  height: fit-content;
+  min-height: unset;
+  margin: 10px 0;
 }
 .layout-main .sidebar-main .footer-box {
   padding: 0;


### PR DESCRIPTION
When the browser window height was less than 600px, a scrollbar would appear, and the footer would overlap when the "Options" submenu was expanded.

Before:
![11](https://github.com/user-attachments/assets/b44c25b4-ca80-4c8d-9633-d4a504855e41)

After:
![22](https://github.com/user-attachments/assets/388effeb-4eeb-4008-9b65-48430246054b)




