### PR TITLE
feat: detect MariaDB-native command names with fallback

### DIFF
--- a/scripts/zmcamtool.pl.in
+++ b/scripts/zmcamtool.pl.in
@@ -64,6 +64,7 @@ use bytes;
 @EXTRA_PERL_LIB@
 use ZoneMinder::Config qw(:all);
 use ZoneMinder::Logger qw(:all);
+use ZoneMinder::General qw(:all);
 use ZoneMinder::Database qw(:all);
 use DBI;
 use Getopt::Long;
@@ -344,7 +345,7 @@ sub importsql {
 sub exportsql {
 
   my ( $host, $port ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
-  my $command = 'mysqldump -t --skip-opt --compact -h'.$host;
+  my $command = findDbCommand('mysqldump').' -t --skip-opt --compact -h'.$host;
   $command .= ' -P'.$port if defined($port);
   if ( $dbUser ) {
     $command .= ' -u\''.$dbUser.'\'';

--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -416,7 +416,7 @@ if ( $version ) {
 
     if ( $response =~ /^[yY]$/ ) {
       my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ );
-      my $command = 'mysqldump';
+      my $command = findDbCommand('mysqldump');
       if ($super) {
         $command .= ' --defaults-file=/etc/mysql/debian.cnf';
       } elsif ($dbUser) {
@@ -1007,7 +1007,7 @@ sub patchDB {
   my $version = shift;
 
   my ( $host, $portOrSocket ) = ( $Config{ZM_DB_HOST} =~ /^([^:]+)(?::(.+))?$/ ) if $Config{ZM_DB_HOST};
-  my $command = 'mysql';
+  my $command = findDbCommand('mysql');
   if ($super) {
     $command .= ' --defaults-file=/etc/mysql/debian.cnf';
   } elsif ($dbUser) {


### PR DESCRIPTION
...  to MySQL legacy names

MariaDB is deprecating mysql-prefixed utility names (mysqldump, mysql) in favour of its own (mariadb-dump, mariadb). Add findDbCommand() to ZoneMinder::General that probes for the MariaDB-native binary first and falls back to the legacy name. Results are cached per-process. Update the three call sites in zmupdate.pl.in and zmcamtool.pl.in.

This resolves:
`mysqldump: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb-dump' instead`

While still allowing users to have a choice between mysql and maria.

There's one stray white-space Claude felt compelled to fix too :)
Thank you