### PR TITLE
fix: preserve maxfps when MonitorStream.start() rebuilds stream URL

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -590,6 +590,13 @@ function MonitorStream(monitorData) {
       if (-1 == src.search('mode=')) {
         src += '&mode=jpeg';
       }
+      // Preserve maxfps from the PHP-rendered src if present
+      if (-1 == src.search('maxfps=')) {
+        const match = stream.src.match(/maxfps=([^&]+)/);
+        if (match) {
+          src += '&maxfps='+match[1];
+        }
+      }
       if (stream.src != src) {
         //console.log("Setting src.src", stream.src, src);
         stream.src = '';


### PR DESCRIPTION
start() reconstructs the zms URL from url_to_zms, which only contains the monitor id. Parameters like auth, connkey, scale, and mode are carried over, but maxfps was dropped. This causes streams to start at the camera's native capture rate even when PHP rendered the initial <img src> with a maxfps value (e.g. from the montage Rate cookie).

Carry over maxfps from the existing src the same way the other parameters are preserved.