### PR TITLE
perf: skip FFmpeg video probe for JPEG-based event streams

### DIFF
--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -391,7 +391,10 @@ bool EventStream::loadEventData(uint64_t event_id) {
   }
   mysql_free_result(result);
 
-  if (!event_data->video_file.empty()) {
+  // Only open FFmpeg input when JPEG frames are not available on disk.
+  // avformat_find_stream_info() probes several seconds of video and costs 2-5s,
+  // which is wasted when sendFrame() reads JPEG files directly.
+  if (!event_data->video_file.empty() && !(event_data->SaveJPEGs & 1)) {
     std::string filepath = event_data->path + "/" + event_data->video_file;
     Debug(1, "Loading video file from %s", filepath.c_str());
     delete ffmpeg_input;


### PR DESCRIPTION
Alright. this was the change I was hunting for... this saves me a few seconds in waiting for the event playback to load before video playback starts. All my frames are stored as jpegs. Next or Previous loads were so slow :)

When SaveJPEGs is enabled, sendFrame() reads JPEG files directly from disk and never touches the FFmpeg input. However, loadEventData() unconditionally called FFmpeg_Input::Open() on the event video file, which runs avformat_find_stream_info() — a 2-5 second probe that was pure overhead for JPEG-based streaming.

Gate the Open() call on !(SaveJPEGs & 1) so the expensive probe is only performed when frame extraction from the video container is actually needed.