### PR TITLE
Fix: Bootstrap-table info class ".fixed-table-loading" creates a scrollbar (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -1577,6 +1577,11 @@ video-stream {
 }
 */
 
+/* Fix bootstrap-table */
+.fixed-table-loading {
+  overflow: hidden;
+}
+
 /* +++ This block should always be located at the end! */
 .hidden {
     display: none;


### PR DESCRIPTION
If the event table is empty, a vertical scroll bar appears.

Before:
![1](https://github.com/user-attachments/assets/5c4b373e-b1ee-4a93-9d14-4a89e8d363de)

After:
![2](https://github.com/user-attachments/assets/d54c963e-dbaf-478c-bcd8-5b84e31773e8)
