### PR TITLE
fix(build): remove git pull from do_debian_package.sh

### DIFF
--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -119,8 +119,6 @@ if [ ! -d "${GITHUB_FORK}_zoneminder_release" ]; then
   if [ -d "${GITHUB_FORK}_ZoneMinder.git" ]; then
     echo "Using local clone ${GITHUB_FORK}_ZoneMinder.git to pull from."
     cd "${GITHUB_FORK}_ZoneMinder.git"
-    echo "git pull..."
-    git pull
     cd ../
 
     echo "git clone ${GITHUB_FORK}_ZoneMinder.git ${GITHUB_FORK}_zoneminder_release"
@@ -176,8 +174,6 @@ if [ $? -ne 0 ]; then
   echo "Failed to switch to branch."
   exit 1;
 fi;
-echo "git pull..."
-git pull
 # Grab the ZoneMinder version from the contents of the version file
 VERSION=$(cat "$(find . -maxdepth 1 -name 'version' -o -name 'version.txt')")
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
## Summary

- Remove two `git pull` calls from `utils/do_debian_package.sh`

## Problem

The script has a local-clone code path: when `${GITHUB_FORK}_ZoneMinder.git` exists locally, it clones from that directory instead of fetching from GitHub. However, it then runs `git pull` twice — once in the local `.git` bare repo and once in the release checkout. This overwrites any local commits with whatever is on the remote, silently discarding local changes.

This defeats the purpose of the local-clone path. If you have local commits you want to build (e.g. testing a patch before submitting), the build script throws them away.

## Fix

Remove both `git pull` calls. The script already clones from the local repo — it should build whatever is there. Users who want the latest remote can `git pull` manually before running the build script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)