### PR TITLE
fix: correct App::uses package path in CameraModel

### DIFF
--- a/web/api/app/Model/CameraModel.php
+++ b/web/api/app/Model/CameraModel.php
@@ -1,5 +1,5 @@
 <?php
-App::uses('AppModel', 'CameraModel');
+App::uses('AppModel', 'Model');
 /**
  * Model CameraModel
  *


### PR DESCRIPTION
App::uses('AppModel', 'CameraModel') tells CakePHP to look for AppModel in a non-existent 'CameraModel' package. The correct second argument is 'Model', which points to app/Model/AppModel.php where the base class actually lives.

This was likely a copy-paste error — every other model in the codebase correctly uses App::uses('AppModel', 'Model'). The bug may go unnoticed when another model loads AppModel first via CakePHP's autoloader, but causes a fatal error if CameraModel is the first model resolved in a request (e.g. hitting the camera models API endpoint directly).