### PR TITLE
Fix: Stop executing "streamQuery" if "zmsBroke" (event.js)

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -849,7 +849,11 @@ function streamSeek(offset) {
 }
 
 function streamQuery() {
-  streamReq({command: CMD_QUERY});
+  if (zmsBroke !== true) {
+    streamReq({command: CMD_QUERY});
+  } else {
+    clearInterval(streamCmdInterval);
+  }
 }
 
 function getEventResponse(respObj, respText) {


### PR DESCRIPTION
For example, we viewed an event, but it was then deleted or destroyed. Currently, queries will continue to run indefinitely.