### PR TITLE
Fix: Color of some buttons & input[type='checkbox'], input[type='radio'] on a dark skin (skin.css)

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -157,7 +157,7 @@ fieldset {
     border-bottom: 1px solid #000000;
 }
 
-input, textarea, select, button, .btn-primary, .btn-normal, .btn-normal:link {
+input, textarea, select, button, .btn-primary, .btn-normal, .btn-normal:link, input[type='checkbox'], input[type='radio'] {
   background-color: rgb(68,68,68);
   border-color: var(--gray);
   color: #dddddd;


### PR DESCRIPTION
**Before:**
![1](https://github.com/user-attachments/assets/b3361b40-ab5e-47ca-bc66-90ec79a5bfe7)


**After:**
![2](https://github.com/user-attachments/assets/06ef0275-8f41-4c23-8c66-381ffb13bb08)
![3](https://github.com/user-attachments/assets/b45e058f-47ec-4b42-a10b-8931f87f9bbc)
