### PR TITLE
Fix: Don't clear the screen when animations are off

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2532,7 +2532,7 @@ function initPageGeneral() {
         mainContentJ.css({flex: "0 1 auto"});
       }
       if (typeof ZM_WEB_ANIMATIONS === 'undefined' || !ZM_WEB_ANIMATIONS) {
-        mainContentJ.css({display: "none"});
+        // mainContentJ.css({display: "none"});
       } else {
         mainContentJ.animate({height: 0}, 300, function rollupBeforeunloadPage() {
           mainContentJ.css({display: "none"});


### PR DESCRIPTION
When animations are off, there is no reason to blank the screen when switching between events.  Before this fix, when applying tags with the prev/next buttons in the tag input, the screen would clear before the user can see the name of the tag being displayed.

It also appeared as a disruptive flash between events.

With this fix, the user experience is smoother.