### PR TITLE
Fix: Check the "players" variable (MonitorStream.js).

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -553,7 +553,7 @@ function MonitorStream(monitorData) {
         this.statusCmdTimer = setInterval(this.statusCmdQuery.bind(this), statusRefreshTimeout);
         this.started = true;
         this.streamListenerBind();
-        this.updateStreamInfo(players ? players[this.activePlayer] : 'RTSP2Web ' + this.RTSP2WebType, 'loading');
+        this.updateStreamInfo((typeof players !== "undefined" && players) ? players[this.activePlayer] : 'RTSP2Web ' + this.RTSP2WebType, 'loading');
         return;
       } else {
         console.log("ZM_RTSP2WEB_PATH is empty. Go to Options->System and set ZM_RTSP2WEB_PATH accordingly.");


### PR DESCRIPTION
After adding the "players" variable, the "players is not defined" issue appears on various pages.

There's currently an error on the Zones page.
Yes, ideally, the variable should be added in *.js.php files on various pages. The absence of the variable has no significant impact, other than incomplete display of information. The current error disrupts all JavaScript.
This PR prevents the disruption of all JavaScript code on the page.