### PR TITLE
Fix: For ".imageFeed svg.zones" apply z-index: 3 (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -1045,7 +1045,7 @@ a.flip {
   background: none;
 }
 .imageFeed svg.zones {
-  z-index: 100;
+  z-index: 3;
 }
 .colThumbnail img {
   border-radius: 4px;


### PR DESCRIPTION
On the Zones page, with the default player = go2rtc, a zone may not display due to the added <video-stream> tag due to "position: relative"
And zones should always be above all other elements. 
Possible fix #4648