### PR TITLE
Fix: In "src," use '_CameraDirectPrimary' instead of '_0' in "createGo2rtcStream" (skin.js).

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1441,7 +1441,8 @@ function createGo2rtcStream(container, src, mid, fallbackToMjpeg) {
     const url = new URL(src);
     url.protocol = (url.protocol === 'https:') ? 'wss:' : 'ws:';
     url.pathname += '/ws';
-    url.search = 'src=' + mid + '_0';
+    //url.search = 'src=' + mid + '_0';
+    url.search = 'src=' + mid + '_CameraDirectPrimary';
 
     const stream = document.createElement('video-stream');
     stream.style.cssText = 'width: 100%; height: 100%; display: block;';


### PR DESCRIPTION
Otherwise, we'll be able to get the stream.