### PR TITLE
Fix: Don't assign "resize" listener when using Observer (zone.js)

### DIFF
--- a/web/skins/classic/views/js/zone.js
+++ b/web/skins/classic/views/js/zone.js
@@ -716,9 +716,11 @@ function initPage() {
     imageFeed.appendChild(zoneSVG);
   }
 
-  var ro = new ResizeObserver(drawZonePoints);
-  ro.observe(imageFeed);
-  window.addEventListener("resize", drawZonePoints, {passive: true});
+  if (imageFeed) {
+    (new ResizeObserver(drawZonePoints)).observe(imageFeed);
+  } else {
+    window.addEventListener("resize", drawZonePoints, {passive: true});
+  }
   drawZonePoints();
 
   // Manage the BACK button
@@ -744,7 +746,6 @@ function panZoomIn(el) {
 function panZoomOut(el) {
   zmPanZoom.zoomOut(el);
 }
-
 
 function Polygon_calcArea(coords) {
   var n_coords = coords.length;


### PR DESCRIPTION
Although the committees 
https://github.com/ZoneMinder/zoneminder/commit/10f1608f1d41743e7abaed3e1a8769acb49adb80 https://github.com/ZoneMinder/zoneminder/commit/a3ef67327973c89bc1b2e60c79eb6e8c21303d21 
and improved the situation, but more needs to be done.

Instead of #4655