### PR TITLE
Fix: For RTSP2Web type=HLS, receive tracks from the stream only at the start of playback, not MEDIA_ATTACHED (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -523,7 +523,7 @@ function MonitorStream(monitorData) {
           this.element.onplay = (event) => {
             getTracksFromStream(this); //HLS
           }
-					if (Hls.isSupported()) {
+          if (Hls.isSupported()) {
             this.hls = new Hls({
               maxBufferLength: 10,
               maxMaxBufferLength: 30,


### PR DESCRIPTION
Otherwise the stream will not be active yet.