### PR TITLE
feat: implement Config Requires field for dependent option disable

### DIFF
--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -388,6 +388,9 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   $opts.on('change', refresh);
+
+  // Apply initial state so dependents match current values on first render.
+  refresh();
 });
 </script>
 <?php


### PR DESCRIPTION
## Summary

- Wire up the long-dormant `Config.Requires` column (added in v0.9.13) so dependent options are disabled when their parent toggle is off
- PHP evaluates `Requires` on page render to set initial disabled state
- Inline JS (with CSP nonce) re-evaluates on any input change for live toggling without page reload
- Supports compound semicolon-separated AND conditions (e.g. `ZM_OPT_USE_AUTH=1;ZM_AUTH_RELAY=hashed`)
- Affects ~50 existing config entries across auth, images, logging, mail, upload, web, x10, and system categories

Fixes #4668

## Test plan

- [ ] Go to Options → Config tab, uncheck OPT_TRAINING → dependent fields disable immediately
- [ ] Options → Auth tab, uncheck OPT_USE_AUTH → AUTH_TYPE, AUTH_RELAY, AUTH_HASH_* all disable
- [ ] Options → Auth tab, check OPT_USE_AUTH but change AUTH_RELAY away from "hashed" → compound deps (AUTH_HASH_IPS, AUTH_HASH_SECRET, etc.) disable
- [ ] Options → Images tab, uncheck OPT_FFMPEG → all FFMPEG fields disable
- [ ] Options → Upload tab, uncheck OPT_UPLOAD → all UPLOAD fields disable
- [ ] Save with parent off, reload page → dependent fields still disabled on fresh render
- [ ] Verify no JS console errors, CSP not blocking the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)