### PR TITLE
Fix ReferenceError in Janus onremotetrack handler

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1779,17 +1779,17 @@ async function attachVideo(monitorStream) {
       Janus.debug(" ::: Got a remote track :::");
       Janus.debug(track);
       if (track.kind ==="audio") {
-        let stream = new MediaStream();
+        const stream = new MediaStream();
         stream.addTrack(track.clone());
         if (document.getElementById("liveAudio" + id) == null) {
-          let audioElement = document.createElement('audio');
+          const audioElement = document.createElement('audio');
           audioElement.setAttribute("id", "liveAudio" + id);
           audioElement.controls = true;
           document.getElementById("imageFeed" + id).append(audioElement);
         }
         Janus.attachMediaStream(document.getElementById("liveAudio" + id), stream);
       } else {
-        let stream = new MediaStream();
+        const stream = new MediaStream();
         stream.addTrack(track.clone());
         Janus.attachMediaStream(document.getElementById("liveStream" + id), stream);
       }


### PR DESCRIPTION
MonitorStream.js assigns to undeclared variables (stream, audioElement) in onremotetrack(). In strict mode this triggers "ReferenceError: stream is not defined" and breaks Janus live playback. Declare variables with let to fix Janus live audio/video.