### PR TITLE
fix: Change ffmpeg errors to warnings for incomplete.mp4

### DIFF
--- a/src/zm_ffmpeg_input.cpp
+++ b/src/zm_ffmpeg_input.cpp
@@ -44,8 +44,13 @@ int FFmpeg_Input::Open(const char *filepath) {
   /** Open the input file to read from it. */
   error = avformat_open_input(&input_format_context, filepath, nullptr, nullptr);
   if ( error < 0 ) {
-    Error("Could not open input file '%s' (error '%s')",
-          filepath, av_make_error_string(error).c_str());
+    if (std::string(filepath).find("incomplete") != std::string::npos) {
+      Warning("Could not open input file '%s' (error '%s')",
+              filepath, av_make_error_string(error).c_str());
+    } else {
+      Error("Could not open input file '%s' (error '%s')",
+            filepath, av_make_error_string(error).c_str());
+    }
     input_format_context = nullptr;
     return error;
   }

--- a/web/views/image.php
+++ b/web/views/image.php
@@ -425,7 +425,7 @@ if ( empty($_REQUEST['path']) ) {
       }
       if (!file_exists($file_path)) {
         header('HTTP/1.0 404 Not Found');
-        ZM\Error("Can't create frame images from video because there is no video file for this event at (".$Event->Path().'/'.$Event->DefaultVideo() );
+        ZM\Warning("Can't create frame images from video because there is no video file for this event at (".$Event->Path().'/'.$Event->DefaultVideo() );
         return;
       }
       if ( !is_executable(ZM_PATH_FFMPEG) ) {
@@ -444,11 +444,16 @@ if ( empty($_REQUEST['path']) ) {
       ZM\Debug("Command: $command, retval: $retval, output: " . implode("\n", $output));
       if ( ! file_exists($path) ) {
         header('HTTP/1.0 404 Not Found');
-        ZM\Error('Can\'t create frame images from video for this event '.$Event->DefaultVideo().'
+        $message = 'Can\'t create frame images from video for this event '.$Event->DefaultVideo().'
 
 Command was: '.$command.'
 
-Output was: '.implode(PHP_EOL,$output) );
+Output was: '.implode(PHP_EOL,$output);
+        if (str_contains($Event->DefaultVideo(), 'incomplete')) {
+          ZM\Warning($message);
+        } else {
+          ZM\Error($message);
+        }
         return;
       }
       # Generating an image file will use up more disk space, so update the Event record.


### PR DESCRIPTION
When watching events live (especially at a speed greater than 1x), many times ffpeg errors are generated relative to incomplete.mp4.  These are not harmful and should not be identified as errors.  This PR changes them from Errors to Warnings to avoid clutter in the logs.