### PR TITLE
Fix: Set color for <pre> tag in dark theme (skin.css)

### DIFF
--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -57,6 +57,10 @@ th {
     color: #10a4e8;
 }
 
+pre {
+    color: #dddddd;
+}
+
 img.normal {
     border: #cccccc solid 1px;
 }


### PR DESCRIPTION
This tag isn't currently used, but when debugging, its color is set to the background color.