### PR TITLE
Fix: Set the bottom margin for the #events table to 10px on Watch page

### DIFF
--- a/web/skins/classic/css/base/views/watch.css
+++ b/web/skins/classic/css/base/views/watch.css
@@ -129,7 +129,7 @@
 
 
 #events {
-    margin: 0 auto;
+    margin: 0 auto 10px;
 }
 
 #eventList {


### PR DESCRIPTION
Otherwise, the bottom of the table doesn't look nice.