### PR TITLE
Minor change on Zone settings page

### DIFF
--- a/web/skins/classic/css/base/views/zone.css
+++ b/web/skins/classic/css/base/views/zone.css
@@ -2,8 +2,8 @@
   margin: 2px;
 }
 #settingsPanel {
-	max-width: 600px;
-  width: 50%;
+  max-width: 600px;
+  width: 45%;
   float: right;
 }
 


### PR DESCRIPTION
Not a big deal and may only affect me or users who run ZoneMinder on a 1280x1024 monitor with the side menu, but it reduces the width of the settings from 50% to 45 percent so that the graphics and settings appear next to each other instead of on top of each other.

I'm OK if you reject this PR.  It just makes it easier to work with until we can do a more proper layout.