### PR TITLE
Fix: Read from 'zmWatchMuted' cookies instead of 'zmWatchMute' on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -836,7 +836,7 @@ function streamStart(monitor = null) {
   monitorStream.setPlayer($j('#player').val());
   monitorStream.setBottomElement(document.getElementById('bottomBlock'));
   const cookieMuted = getCookie('zmWatchMuted');
-  monitorStream.controlMute((cookieMuted === null || cookieMuted === 'true') ? 'on' : 'off'); // default to muted
+  monitorStream.muted = (cookieMuted === null || cookieMuted === 'true') ? true : false; // default to muted
   monitorStream.manageAvailablePlayers();
   setChannelStream();
   // Start the fps and status updates. give a random delay so that we don't assault the server


### PR DESCRIPTION
Because we store 'zmWatchMuted' in cookies, not 'zmWatchMute'

~~We can pass 'on' or 'off' to the "controlMute" function, but we store a Boolean value in cookies, so we need to convert it. Also, if there's no cookie, getCookie will return "null," but for us, that doesn't equal "false."~~

When starting a stream on the Watch page, don't execute controlMute(), as this will cause the icon to be displayed before the stream actually starts playing.
We'll just set the "muted" property for the stream.
We'll manage the icon later.