### PR TITLE
Change the "Mute" icon in the volume slider based on the volume level, not just when the "muted" attribute changes (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1029,7 +1029,7 @@ function MonitorStream(monitorData) {
       volumeSlider.setAttribute('data-volume', parseInt(audioStream.volume * 100));
       if (volumeSlider.allowSetValue) {
         volumeSlider.noUiSlider.set(audioStream.volume * 100);
-        if (audioStream.muted === true) {
+        if (audioStream.muted === true || audioStream.volume === 0) {
           this.changeStateIconMute('off');
           volumeSlider.classList.add('noUi-mute');
         } else {


### PR DESCRIPTION
Otherwise, when the system volume is set to 0, the "Mute" icon will have an incorrect status.