### PR TITLE
Silent refresh bootstrapTable on Console page

### DIFF
--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -390,9 +390,7 @@ function selectMonitor(element) {
 function reloadWindow() {
   // Use table refresh instead of full page reload
   if (table && table.length) {
-    const scrollPosition = table.bootstrapTable('getScrollPosition');
     table.bootstrapTable('refresh', {silent: true, reinit: false});
-    table.bootstrapTable('scrollTo', scrollPosition);
   } else {
     window.location.replace(thisUrl);
   }


### PR DESCRIPTION
- The table refresh message will not appear briefly. The table will not "flicker."
~~-  Scrolling will attempt to return to the position it was in before the refresh.~~