### PR TITLE
Fix: When executing monitorChangeStreamChannel(), always write the new channel to the cookie and to monitorStream.currentChannelStream on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -1351,10 +1351,11 @@ function panZoomEventPanzoomchange(event) {
 }
 
 function monitorChangeStreamChannel() {
+  const streamChannel = $j('#streamChannel').val();
+  monitorStream.currentChannelStream = streamChannel;
+  setCookie('zmStreamChannel', streamChannel);
   if ((monitorStream.activePlayer) && (-1 !== monitorStream.activePlayer.indexOf('go2rtc') || -1 !== monitorStream.activePlayer.indexOf('rtsp2web'))) {
     streamCmdStop(true);
-    const streamChannel = $j('#streamChannel').val();
-    setCookie('zmStreamChannel', streamChannel);
     setTimeout(function() {
       monitorStream.start(streamChannel);
       onPlay();


### PR DESCRIPTION
This will allow "monitorStream.start()" to be executed correctly if the stream was stopped when the channel was switched.