### PR TITLE
Fix string interpolation and platform where 'ip' command (from iproute2) is unavailable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ mark_as_advanced(
   ZM_PATH_UNAME
   ZM_PATH_IP
   ZM_PATH_IFCONFIG
+  ZM_PATH_ROUTE
   ZM_CONFIG_DIR
   ZM_CONFIG_SUBDIR
   ZM_DETECT_SYSTEMD
@@ -198,6 +199,8 @@ set(ZM_PATH_IP "" CACHE PATH
   "Full path to compatible ip binary. Leave empty for automatic detection.")
 set(ZM_PATH_IFCONFIG "" CACHE PATH
   "Full path to compatible ifconfig binary. Leave empty for automatic detection.")
+set(ZM_PATH_ROUTE "" CACHE PATH
+  "Full path to compatible route binary. Leave empty for automatic detection.")
 set(ZM_CONFIG_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/zm" CACHE PATH
   "Location of ZoneMinder configuration, default system config directory")
 set(ZM_CONFIG_SUBDIR "${ZM_CONFIG_DIR}/conf.d" CACHE PATH
@@ -817,6 +820,17 @@ if(ZM_PATH_IFCONFIG STREQUAL "")
     mark_as_advanced(IFCONFIG_EXECUTABLE)
   else()
     message(WARNING "Unable to find a compatible ifconfig binary.")
+  endif()
+endif()
+
+# Find the path to an route compatible executable
+if(ZM_PATH_ROUTE STREQUAL "")
+  find_program(ROUTE_EXECUTABLE route)
+  if(ROUTE_EXECUTABLE)
+    set(ZM_PATH_ROUTE "${ROUTE_EXECUTABLE}")
+    mark_as_advanced(ROUTE_EXECUTABLE)
+  else()
+    message(WARNING "Unable to find a compatible route binary.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -848,17 +848,6 @@ if(ZM_PATH_PKEXEC STREQUAL "")
   endif()
 endif()
 
-# Find the path to an route compatible executable
-if(ZM_PATH_ROUTE STREQUAL "")
-  find_program(ROUTE_EXECUTABLE route)
-  if(ROUTE_EXECUTABLE)
-    set(ZM_PATH_ROUTE "${ROUTE_EXECUTABLE}")
-    mark_as_advanced(ROUTE_EXECUTABLE)
-  else()
-    message(WARNING "Unable to find a compatible route binary.")
-  endif()
-endif()
-
 # Some variables that zm expects
 set(ZM_PID "${ZM_RUNDIR}/zm.pid")
 set(ZM_CONFIG "${ZM_CONFIG_DIR}/zm.conf")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,8 @@ mark_as_advanced(
   ZM_PATH_UNAME
   ZM_PATH_IP
   ZM_PATH_IFCONFIG
-  ZM_PATH_ROUTE
+  ZM_PATH_NETSTAT
+  ZM_PATH_PKEXEC
   ZM_CONFIG_DIR
   ZM_CONFIG_SUBDIR
   ZM_DETECT_SYSTEMD
@@ -199,8 +200,10 @@ set(ZM_PATH_IP "" CACHE PATH
   "Full path to compatible ip binary. Leave empty for automatic detection.")
 set(ZM_PATH_IFCONFIG "" CACHE PATH
   "Full path to compatible ifconfig binary. Leave empty for automatic detection.")
-set(ZM_PATH_ROUTE "" CACHE PATH
-  "Full path to compatible route binary. Leave empty for automatic detection.")
+set(ZM_PATH_NETSTAT "" CACHE PATH
+  "Full path to compatible netstat binary. Leave empty for automatic detection.")
+set(ZM_PATH_PKEXEC "" CACHE PATH
+  "Full path to compatible pkexec binary. Leave empty for automatic detection.")
 set(ZM_CONFIG_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/zm" CACHE PATH
   "Location of ZoneMinder configuration, default system config directory")
 set(ZM_CONFIG_SUBDIR "${ZM_CONFIG_DIR}/conf.d" CACHE PATH
@@ -820,6 +823,28 @@ if(ZM_PATH_IFCONFIG STREQUAL "")
     mark_as_advanced(IFCONFIG_EXECUTABLE)
   else()
     message(WARNING "Unable to find a compatible ifconfig binary.")
+  endif()
+endif()
+
+# Find the path to an netstat compatible executable
+if(ZM_PATH_NETSTAT STREQUAL "")
+  find_program(NETSTAT_EXECUTABLE netstat)
+  if(NETSTAT_EXECUTABLE)
+    set(ZM_PATH_NETSTAT "${NETSTAT_EXECUTABLE}")
+    mark_as_advanced(NETSTAT_EXECUTABLE)
+  else()
+    message(WARNING "Unable to find a compatible netstat binary.")
+  endif()
+endif()
+
+# Find the path to an pkexec compatible executable
+if(ZM_PATH_PKEXEC STREQUAL "")
+  find_program(PKEXEC_EXECUTABLE pkexec)
+  if(PKEXEC_EXECUTABLE)
+    set(ZM_PATH_PKEXEC "${PKEXEC_EXECUTABLE}")
+    mark_as_advanced(PKEXEC_EXECUTABLE)
+  else()
+    message(WARNING "Unable to find a compatible pkexec binary.")
   endif()
 endif()
 

--- a/conf.d/01-system-paths.conf.in
+++ b/conf.d/01-system-paths.conf.in
@@ -70,6 +70,10 @@ ZM_PATH_IP="@ZM_PATH_IP@"
 # ZoneMinder will find the ifconfig binary automatically on most systems
 ZM_PATH_IFCONFIG="@ZM_PATH_IFCONFIG@"
 
+# Full path to optional route binary or just route to use PATH
+# ZoneMinder will find the route binary automatically on most systems
+ZM_PATH_ROUTE="@ZM_PATH_ROUTE@"
+
 #Full path to shutdown binary
 ZM_PATH_SHUTDOWN="@ZM_PATH_SHUTDOWN@"
 

--- a/conf.d/01-system-paths.conf.in
+++ b/conf.d/01-system-paths.conf.in
@@ -70,9 +70,13 @@ ZM_PATH_IP="@ZM_PATH_IP@"
 # ZoneMinder will find the ifconfig binary automatically on most systems
 ZM_PATH_IFCONFIG="@ZM_PATH_IFCONFIG@"
 
-# Full path to optional route binary or just route to use PATH
-# ZoneMinder will find the route binary automatically on most systems
-ZM_PATH_ROUTE="@ZM_PATH_ROUTE@"
+# Full path to optional netstat binary or just netstat to use PATH
+# ZoneMinder will find the netstat binary automatically on most systems
+ZM_PATH_NETSTAT="@ZM_PATH_NETSTAT@"
+
+# Full path to optional pkexec binary or just pkexec to use PATH
+# ZoneMinder will find the pkexec binary automatically on most systems
+ZM_PATH_PKEXEC="@ZM_PATH_PKEXEC@"
 
 #Full path to shutdown binary
 ZM_PATH_SHUTDOWN="@ZM_PATH_SHUTDOWN@"

--- a/distros/redhat/zoneminder.spec
+++ b/distros/redhat/zoneminder.spec
@@ -230,7 +230,8 @@ mv -f CxxUrl-%{CxxUrl_version} ./dep/CxxUrl
         -DZM_PATH_ARP_SCAN="/usr/sbin/arp-scan" \
         -DZM_PATH_IP="/usr/sbin/ip" \
         -DZM_PATH_IFCONFIG="/usr/sbin/ifconfig" \
-        -DZM_PATH_ROUTE="/usr/sbin/route" \
+        -DZM_PATH_NETSTAT="/usr/bin/netstat" \
+        -DZM_PATH_PKEXEC="/usr/bin/pkexec" \
         .
 
 %cmake_build

--- a/distros/redhat/zoneminder.spec
+++ b/distros/redhat/zoneminder.spec
@@ -230,6 +230,7 @@ mv -f CxxUrl-%{CxxUrl_version} ./dep/CxxUrl
         -DZM_PATH_ARP_SCAN="/usr/sbin/arp-scan" \
         -DZM_PATH_IP="/usr/sbin/ip" \
         -DZM_PATH_IFCONFIG="/usr/sbin/ifconfig" \
+        -DZM_PATH_ROUTE="/usr/sbin/route" \
         .
 
 %cmake_build

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2259,6 +2259,7 @@ function get_networks() {
             }
         }
         $routes = array();
+        $output = '';
         exec(ZM_PATH_IP.' route', $output, $status);
         if ($status) {
             $html_output = implode('<br/>', $output);
@@ -2276,44 +2277,32 @@ function get_networks() {
             } # end foreach line of output
         }
     } else if (defined('ZM_PATH_IFCONFIG') and ZM_PATH_IFCONFIG and file_exists(ZM_PATH_IFCONFIG)) {
-      $osname = strtolower(php_uname('s'));
-
       exec(ZM_PATH_IFCONFIG, $output, $status);
       if ($status) {
         $html_output = implode("\n", $output);
         ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
       } else {
-        exec('ifconfig', $output, $status);
+        array_walk($output, function($value, $key) use (&$interfaces) {
+          $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
+          ZM\Debug(print_r($matches, true));
+          if (($retval == 1) && (strlen($matches[3]) > 0) &&
+              (strpos($matches[3], "LOOPBACK") === false) && (strpos($matches[3], "RUNNING") !== false))
+          {
+            $interfaces[$matches[1]] = $matches[1];
+          }
+        });
 
-        if ($status) {
-          $html_output = implode("\n", $output);
-          ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
-        } else {
-          array_walk($output, function($value, $key) use (&$interfaces) {
-            $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
-            ZM\Debug(print_r($matches, true));
-            if (($retval == 1) && (strlen($matches[3]) > 0) &&
-                (strpos($matches[3], "LOOPBACK") === false) && (strpos($matches[3], "RUNNING") !== false))
-            {
-              $interfaces[$matches[1]] = $matches[1];
-            }
-          });
+        if (defined('ZM_PATH_NETSTAT') and ZM_PATH_NETSTAT and file_exists(ZM_PATH_NETSTAT)) {
+          $output = '';
+          // Get default route iface
+          exec(ZM_PATH_NETSTAT . " -r4 | grep '^default' | head -n 1 | awk '{print $4}'", $defaultIface, $status);
 
-          if (defined('ZM_PATH_ROUTE') and ZM_PATH_ROUTE and file_exists(ZM_PATH_ROUTE)) {
-            // Get default route iface
-            if (strcmp($osname, 'freebsd') == 0) {
-              exec(ZM_PATH_ROUTE . " get default | grep interface | awk '{print $2}'", $defaultIface, $status);
-            } else {
-              exec(ZM_PATH_ROUTE . " -n | grep '^0.0.0.0' | head -n 1 | awk '{print $8}'", $defaultIface, $status);
-            }
-
-            if ($status) {
-              $html_output = implode("\n", $output);
-              ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
-            } else {
-              if (isset($defaultIface) && isset($defaultIface[0])) {
-                $interfaces['default'] = $defaultIface[0];
-              }
+          if ($status) {
+            $html_output = implode("\n", $output);
+            ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
+          } else {
+            if (isset($defaultIface) && isset($defaultIface[0])) {
+              $interfaces['default'] = $defaultIface[0];
             }
           }
         }
@@ -2322,9 +2311,43 @@ function get_networks() {
     return $interfaces;
 }
 
-# Returns an array of subnets like 192.168.1.0/24 for a given interface.
-# Will ignore mdns networks.
+function parse_netstat_line(string $line) {
+  $line = trim($line);
+  $pattern = '/^(?:' .
+             '(\d{1,3}(?:\.\d{1,3}){3})\s+' .
+             '\d{1,3}(?:\.\d{1,3}){3}\s+' .
+             '\d{1,3}(?:\.\d{1,3}){3}\s+' .
+             '[A-Za-z]+\s+' .
+             '\d+\s+' .
+             '\d+\s+' .
+             '\d+\s+' .
+             '(\S+)' .
+             ')|(?:' .
+             '(\d{1,3}(?:\.\d{1,3}){3}\/\d{1,2})\s+' .
+             '\S+?\s*' .
+             '[A-Za-z]+\s+' .
+             '(\S+)' .
+             ')$/';
 
+  if (!preg_match($pattern, $line, $matches)) {
+    return null;
+  }
+
+  if (!empty($matches[1])) {
+    return [
+      'ip'      => $matches[1],
+      'iface'   => $matches[2],
+    ];
+  }
+
+  return [
+    'ip'  => $matches[3],
+    'iface' => $matches[4],
+  ];
+}
+
+# Returns an array of subnets like 192.168.1.0/24 (192.168.1.0 on some platforms) for a given interface.
+# Will ignore mdns networks.
 function get_subnets($interface) {
   $subnets = array();
   if (defined('ZM_PATH_IP') and ZM_PATH_IP and file_exists(ZM_PATH_IP)) {
@@ -2347,7 +2370,29 @@ function get_subnets($interface) {
         }
       } # end foreach line of output
     }
+  } else if (defined('ZM_PATH_NETSTAT') and ZM_PATH_NETSTAT and file_exists(ZM_PATH_NETSTAT)) {
+    exec(ZM_PATH_NETSTAT.' -r4', $output, $status);
+    if ( $status ) {
+      $html_output = implode('<br/>', $output);
+      ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
+    } else {
+      foreach ($output as $line) {
+        $netstat_match = parse_netstat_line($line);
+        if (null !== $netstat_match) {
+          if (($netstat_match['ip'] == '169.254.0.0/16') || ($netstat_match['ip'] == '169.254.0.0')) {
+            # Ignore mdns
+          } else if ($netstat_match['iface'] == $interface) {
+            $subnets[] = $netstat_match['ip'];
+          } else {
+            ZM\Debug("Wrong interface " . $netstat_match['iface'] . " != " . $interface);
+          }
+        } else {
+          ZM\Debug("Didn't match $line");
+        }
+      } # end foreach line of output
+    }
   }
+
   return $subnets;
 } # end function get_subnets($interface)
 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2250,7 +2250,7 @@ function get_networks() {
 	  } else {
 	    foreach ( $output as $line ) {
               if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
-                if ( strcmp($matches[1], 'lo') != 0 ) {
+                if ( $matches[1] == 'lo' ) {
                   $interfaces[$matches[1]] = $matches[1];
                 } else {
                   ZM\Debug("No match for $line");

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2276,44 +2276,48 @@ function get_networks() {
             } # end foreach line of output
         }
     } else if (defined('ZM_PATH_IFCONFIG') and ZM_PATH_IFCONFIG and file_exists(ZM_PATH_IFCONFIG)) {
-        $osname = strtolower(php_uname('s'));
+      $osname = strtolower(php_uname('s'));
 
-        exec(ZM_PATH_IFCONFIG, $output, $status);
+      exec(ZM_PATH_IFCONFIG, $output, $status);
+      if ($status) {
+        $html_output = implode("\n", $output);
+        ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+      } else {
+        exec('ifconfig', $output, $status);
+
         if ($status) {
-            $html_output = implode("\n", $output);
-            ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+          $html_output = implode("\n", $output);
+          ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
         } else {
-            exec('ifconfig', $output, $status);
+          array_walk($output, function($value, $key) use (&$interfaces) {
+            $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
+            ZM\Debug(print_r($matches, true));
+            if (($retval == 1) && (strlen($matches[3]) > 0) &&
+                (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
+            {
+              $interfaces[$matches[1]] = $matches[1];
+            }
+          });
+
+          if (defined('ZM_PATH_ROUTE') and ZM_PATH_ROUTE and file_exists(ZM_PATH_ROUTE)) {
+            // Get default route iface
+            if (strcmp($osname, 'freebsd') == 0) {
+              exec(ZM_PATH_ROUTE . " get default | grep interface | awk '{print $2}'", $defaultIface, $status);
+            } else {
+              exec(ZM_PATH_ROUTE . " -n | grep '^0.0.0.0' | head -n 1 | awk '{print $8}'", $defaultIface, $status);
+            }
 
             if ($status) {
-                $html_output = implode("\n", $output);
-                ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+              $html_output = implode("\n", $output);
+              ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
             } else {
-                array_walk($output, function($value, $key) use (&$interfaces) {
-                    $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
-                    ZM\Debug(print_r($matches, true));
-                    if (($retval == 1) && (strlen($matches[3]) > 0) &&
-                        (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
-                    {
-                        $interfaces[$matches[1]] = $matches[1];
-                    }
-                });
-
-                if (strcmp($osname, 'freebsd') == 0) {
-                    // Get default route iface
-                    exec("route get default | grep interface | awk '{print $2}'", $defaultIface, $status);
-
-                    if ($status) {
-                        $html_output = implode("\n", $output);
-                        ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
-                    } else {
-                        if (isset($defaultIface) && isset($defaultIface[0])) {
-	                    $interfaces['default'] = $defaultIface[0];
-                        }
-                    }
-                }
+              if (isset($defaultIface) && isset($defaultIface[0])) {
+                $interfaces['default'] = $defaultIface[0];
+              }
             }
+          }
         }
+      }
     }
     return $interfaces;
 }

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2250,10 +2250,10 @@ function get_networks() {
         } else {
             foreach ( $output as $line ) {
                 if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
-                    if ( $matches[1] == 'lo' ) {
+                    if ( $matches[1] != 'lo' ) {
                         $interfaces[$matches[1]] = $matches[1];
                     } else {
-                        ZM\Debug("No match for $line");
+                        ZM\Debug("Skipping loopback interface $line");
                     }
                 }
             }

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2293,7 +2293,7 @@ function get_networks() {
             $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
             ZM\Debug(print_r($matches, true));
             if (($retval == 1) && (strlen($matches[3]) > 0) &&
-                (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
+                (strpos($matches[3], "LOOPBACK") === false) && (strpos($matches[3], "RUNNING") !== false))
             {
               $interfaces[$matches[1]] = $matches[1];
             }

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2258,7 +2258,6 @@ function get_networks() {
                 }
             }
         }
-        $routes = array();
         $output = '';
         exec(ZM_PATH_IP.' route', $output, $status);
         if ($status) {

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2240,82 +2240,82 @@ function i18n() {
 }
 
 function get_networks() {
-  $interfaces = array();
+    $interfaces = array();
 
-  if (defined('ZM_PATH_IP') and ZM_PATH_IP and file_exists(ZM_PATH_IP)) {
-	  exec(ZM_PATH_IP.' link', $output, $status);
-	  if ( $status ) {
-	    $html_output = implode('<br/>', $output);
-	    ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
-	  } else {
-	    foreach ( $output as $line ) {
-              if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
-                if ( $matches[1] == 'lo' ) {
-                  $interfaces[$matches[1]] = $matches[1];
-                } else {
-                  ZM\Debug("No match for $line");
-                }
-              }
-	    }
-	  }
-	  $routes = array();
-	  exec(ZM_PATH_IP.' route', $output, $status);
-	  if ($status) {
-	    $html_output = implode('<br/>', $output);
-	    ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
-	  } else {
-	    foreach ($output as $line) {
-	      if ( preg_match('/^default via [.[:digit:]]+ dev ([[:alnum:]]+)/', $line, $matches) ) {
-                $interfaces['default'] = $matches[1];
-	      } else if ( preg_match('/^([.[:digit:]]+\/[[:digit:]]+) dev ([[:alnum:]]+)/', $line, $matches) ) {
-          $interfaces[$matches[2]] .= ' ' . $matches[1];
-          ZM\Debug("Matched $line: $matches[2] .= $matches[1]");
+    if (defined('ZM_PATH_IP') and ZM_PATH_IP and file_exists(ZM_PATH_IP)) {
+        exec(ZM_PATH_IP.' link', $output, $status);
+        if ( $status ) {
+            $html_output = implode('<br/>', $output);
+            ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
         } else {
-          ZM\Debug("Didn't match $line");
+            foreach ( $output as $line ) {
+                if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
+                    if ( $matches[1] == 'lo' ) {
+                        $interfaces[$matches[1]] = $matches[1];
+                    } else {
+                        ZM\Debug("No match for $line");
+                    }
+                }
+            }
         }
-      } # end foreach line of output
-	  }
-  } else if (defined('ZM_PATH_IFCONFIG') and ZM_PATH_IFCONFIG and file_exists(ZM_PATH_IFCONFIG)) {
-      $osname = strtolower(php_uname('s'));
+        $routes = array();
+        exec(ZM_PATH_IP.' route', $output, $status);
+        if ($status) {
+            $html_output = implode('<br/>', $output);
+            ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
+        } else {
+            foreach ($output as $line) {
+                if ( preg_match('/^default via [.[:digit:]]+ dev ([[:alnum:]]+)/', $line, $matches) ) {
+                    $interfaces['default'] = $matches[1];
+                } else if ( preg_match('/^([.[:digit:]]+\/[[:digit:]]+) dev ([[:alnum:]]+)/', $line, $matches) ) {
+                    $interfaces[$matches[2]] .= ' ' . $matches[1];
+                    ZM\Debug("Matched $line: $matches[2] .= $matches[1]");
+                } else {
+                    ZM\Debug("Didn't match $line");
+                }
+            } # end foreach line of output
+        }
+    } else if (defined('ZM_PATH_IFCONFIG') and ZM_PATH_IFCONFIG and file_exists(ZM_PATH_IFCONFIG)) {
+        $osname = strtolower(php_uname('s'));
 
-      exec(ZM_PATH_IFCONFIG, $output, $status);
-      if ($status) {
-	  $html_output = implode("\n", $output);
-	  ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
-      } else {
-	  exec('ifconfig', $output, $status);
+        exec(ZM_PATH_IFCONFIG, $output, $status);
+        if ($status) {
+            $html_output = implode("\n", $output);
+            ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+        } else {
+            exec('ifconfig', $output, $status);
 
-	  if ($status) {
-	      $html_output = implode("\n", $output);
-	      ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
-	  } else {
-	      array_walk($output, function($value, $key) use (&$interfaces) {
-		  $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
-		  ZM\Debug(print_r($matches, true));
-		  if (($retval == 1) && (strlen($matches[3]) > 0) &&
-		      (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
-		  {
-		      $interfaces[$matches[1]] = $matches[1];
-		  }
-	      });
+            if ($status) {
+                $html_output = implode("\n", $output);
+                ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+            } else {
+                array_walk($output, function($value, $key) use (&$interfaces) {
+                    $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
+                    ZM\Debug(print_r($matches, true));
+                    if (($retval == 1) && (strlen($matches[3]) > 0) &&
+                        (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
+                    {
+                        $interfaces[$matches[1]] = $matches[1];
+                    }
+                });
 
-	      if (strcmp($osname, 'freebsd') == 0) {
-		  // Get default route iface
-		  exec("route get default | grep interface | awk '{print $2}'", $defaultIface, $status);
+                if (strcmp($osname, 'freebsd') == 0) {
+                    // Get default route iface
+                    exec("route get default | grep interface | awk '{print $2}'", $defaultIface, $status);
 
-		  if ($status) {
-		      $html_output = implode("\n", $output);
-		      ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
-		  } else {
-		      if (isset($defaultIface) && isset($defaultIface[0])) {
-			  $interfaces['default'] = $defaultIface[0];
-		      }
-		  }
-	      }
-	  }
-      }
-  }
-  return $interfaces;
+                    if ($status) {
+                        $html_output = implode("\n", $output);
+                        ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
+                    } else {
+                        if (isset($defaultIface) && isset($defaultIface[0])) {
+	                    $interfaces['default'] = $defaultIface[0];
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $interfaces;
 }
 
 # Returns an array of subnets like 192.168.1.0/24 for a given interface.

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2249,13 +2249,13 @@ function get_networks() {
 	    ZM\Error("Unable to list network interfaces, status is '$status'. Output was:<br/><br/>$html_output");
 	  } else {
 	    foreach ( $output as $line ) {
-	      if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
-          if ( $matches[1] != 'lo' ) {
-            $interfaces[$matches[1]] = $matches[1];
-          } else {
-            ZM\Debug("No match for $line");
-          }
-        }
+              if ( preg_match('/^\d+: ([[:alnum:]]+):/', $line, $matches ) ) {
+                if ( strcmp($matches[1], 'lo') != 0 ) {
+                  $interfaces[$matches[1]] = $matches[1];
+                } else {
+                  ZM\Debug("No match for $line");
+                }
+              }
 	    }
 	  }
 	  $routes = array();
@@ -2266,7 +2266,7 @@ function get_networks() {
 	  } else {
 	    foreach ($output as $line) {
 	      if ( preg_match('/^default via [.[:digit:]]+ dev ([[:alnum:]]+)/', $line, $matches) ) {
-          $interfaces['default'] = $matches[1];
+                $interfaces['default'] = $matches[1];
 	      } else if ( preg_match('/^([.[:digit:]]+\/[[:digit:]]+) dev ([[:alnum:]]+)/', $line, $matches) ) {
           $interfaces[$matches[2]] .= ' ' . $matches[1];
           ZM\Debug("Matched $line: $matches[2] .= $matches[1]");
@@ -2276,21 +2276,44 @@ function get_networks() {
       } # end foreach line of output
 	  }
   } else if (defined('ZM_PATH_IFCONFIG') and ZM_PATH_IFCONFIG and file_exists(ZM_PATH_IFCONFIG)) {
-	  exec(ZM_PATH_IFCONFIG, $output, $status);
-	  if ($status) {
-	    $html_output = implode("\n", $output);
-	    ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
-	  } else {
-		  preg_match("/^([eth|enp][A-z0-9]*)\s+Link\s+encap:([A-z]*)\s+HWaddr\s+([A-z0-9:]*).*".
-			"inet addr:([0-9.]+).*Bcast:([0-9.]+).*Mask:([0-9.]+).*".
-			"MTU:([0-9.]+).*Metric:([0-9.]+).*".
-			"RX packets:([0-9.]+).*errors:([0-9.]+).*dropped:([0-9.]+).*overruns:([0-9.]+).*frame:([0-9.]+).*".
-			"TX packets:([0-9.]+).*errors:([0-9.]+).*dropped:([0-9.]+).*overruns:([0-9.]+).*carrier:([0-9.]+).*".
-			"RX bytes:([0-9.]+).*\((.*)\).*TX bytes:([0-9.]+).*\((.*)\)".
-			"/ims", implode("\n", $output), $regex);
+      $osname = strtolower(php_uname('s'));
 
-		  ZM\Debug(print_r( $regex,true));
+      exec(ZM_PATH_IFCONFIG, $output, $status);
+      if ($status) {
+	  $html_output = implode("\n", $output);
+	  ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+      } else {
+	  exec('ifconfig', $output, $status);
+
+	  if ($status) {
+	      $html_output = implode("\n", $output);
+	      ZM\Error("Unable to list network interfaces, status is '$status'. Output was:$html_output");
+	  } else {
+	      array_walk($output, function($value, $key) use (&$interfaces) {
+		  $retval = preg_match("/^([A-Za-z0-9]*):\s+flags=([0-9]*)<([A-Z,]*)>.*/ims", $value, $matches);
+		  ZM\Debug(print_r($matches, true));
+		  if (($retval == 1) && (strlen($matches[3]) > 0) &&
+		      (strpos($matches[3], "LOOPBACK") == false) && (strpos($matches[3], "RUNNING") != false))
+		  {
+		      $interfaces[$matches[1]] = $matches[1];
+		  }
+	      });
+
+	      if (strcmp($osname, 'freebsd') == 0) {
+		  // Get default route iface
+		  exec("route get default | grep interface | awk '{print $2}'", $defaultIface, $status);
+
+		  if ($status) {
+		      $html_output = implode("\n", $output);
+		      ZM\Error("Unable to get default ip route, status is '$status'. Output was:$html_output");
+		  } else {
+		      if (isset($defaultIface) && isset($defaultIface[0])) {
+			  $interfaces['default'] = $defaultIface[0];
+		      }
+		  }
+	      }
 	  }
+      }
   }
   return $interfaces;
 }

--- a/web/includes/monitor_probe.php
+++ b/web/includes/monitor_probe.php
@@ -833,7 +833,7 @@ function get_arp_scan_results($network) {
     ZM\Error('arp-scan compatible binary not found or not executable by the web user account. Verify ZM_PATH_ARP_SCAN points to a valid arp-scan tool.');
     return $results;
   }
-  $arp_scan_command = '/usr/bin/pkexec '.ZM_PATH_ARP_SCAN.' '.$network;
+  $arp_scan_command = ZM_PATH_PKEXEC.' '.ZM_PATH_ARP_SCAN.' '.$network;
   $result = exec(escapeshellcmd($arp_scan_command), $output, $status);
   if ($status) {
     ZM\Error("Unable to probe network cameras, command was $arp_scan_command, status is '$status' output: ".implode(PHP_EOL, $output));

--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -293,8 +293,8 @@ function get_arp_results() {
     ZM\Error('ARP compatible binary not found or not executable by the web user account. Verify ZM_PATH_ARP points to a valid arp tool.');
     return $results;
   }
-  if (count($result)==1) {
-    $arp_command .= ' -n';
+  if (count($result) == 1) {
+    $arp_command .= ' -na';
   }
 
   $result = exec(escapeshellcmd($arp_command), $output, $status);
@@ -321,7 +321,7 @@ function get_arp_scan_results($network) {
     ZM\Error('arp-scan compatible binary not found or not executable by the web user account. Verify ZM_PATH_ARP_SCAN points to a valid arp-scan tool.');
     return $results;
   }
-  $arp_scan_command = '/usr/bin/pkexec '.ZM_PATH_ARP_SCAN.' '.$network.' 2>&1';
+  $arp_scan_command = ZM_PATH_PKEXEC.' '.ZM_PATH_ARP_SCAN.' '.$network.' 2>&1';
   $result = exec(escapeshellcmd($arp_scan_command), $output, $status);
   if ($status) {
     ZM\Error("Unable to probe network cameras, command was $arp_scan_command, status is '$status' output: ".implode(PHP_EOL, $output));
@@ -353,10 +353,10 @@ function probeNetwork() {
   foreach ( dbFetchAll("SELECT `Id`, `Name`, `Path` FROM `Monitors` WHERE `Type` = 'Ffmpeg' ORDER BY `Path`") as $monitor ) {
     $url_parts = parse_url($monitor['Path']);
     if ($url_parts !== false) {
-      ZM\Debug("Ffmpeg monitor ${url_parts['host']} = ${monitor['Id']} ${monitor['Name']}");
+        ZM\Debug("Ffmpeg monitor " . $url_parts['host'] . " = " . $monitor['Id'] . " " . $monitor['Name']);
       $monitors[gethostbyname($url_parts['host'])] = $monitor;
     } else {
-      ZM\Debug("Unable to parse ${monitor['Path']}");
+        ZM\Debug("Unable to parse " . $monitor['Path']);
     }
   }
 
@@ -450,7 +450,7 @@ echo getNavBarHTML();
 <?php
 $interfaces = array('', 'select');
   $interfaces += get_networks();
-  $default_interface = $interfaces['default'];
+  $default_interface = isset($interfaces['default']) ? $interfaces['default'] : '';
   unset($interfaces['default']);
 
   echo htmlSelect('interface', $interfaces,

--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -185,7 +185,7 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
         <p><label for="interface"><?php echo translate('Interface') ?></label>
 <?php 
   $interfaces = get_networks();
-  $default_interface = $interfaces['default'];
+  $default_interface = isset($interfaces['default']) ? $interfaces['default'] : null;
   unset($interfaces['default']);
 
   echo htmlSelect('interface', $interfaces, 
@@ -238,10 +238,20 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
 
   $detprofiles = probeProfiles($monitor['Host'], $monitor['SOAP'], $_REQUEST['Username'], $_REQUEST['Password']);
   foreach ($detprofiles as $profile) {
-    $monitor = $camera['monitor'];
+     $monitor = $camera['monitor'];
 
-    $sourceString = "${profile['Name']} : ${profile['Encoding']}" .
-      " (${profile['Width']}x${profile['Height']} @ ${profile['MaxFPS']}fps ${profile['Transport']})";
+    if (PHP_VERSION_ID >= 80200) { // strings ${xxx} are depreated, use {$xxx} instead
+      eval(<<<'PHP'
+        $sourceString = "{$profile['Name']} : {$profile['Encoding']}" .
+          " ({$profile['Width']}x{$profile['Height']} @ {$profile['MaxFPS']}fps {$profile['Transport']})";
+        PHP);
+    } else {
+      eval(<<<'PHP'
+        $sourceString = "${profile['Name']} : ${profile['Encoding']}" .
+          " (${profile['Width']}x${profile['Height']} @ ${profile['MaxFPS']}fps ${profile['Transport']})";
+      PHP);
+    }
+
     // copy technical details
     $monitor['Width']  = $profile['Width'];
     $monitor['Height'] = $profile['Height'];

--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -238,19 +238,10 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
 
   $detprofiles = probeProfiles($monitor['Host'], $monitor['SOAP'], $_REQUEST['Username'], $_REQUEST['Password']);
   foreach ($detprofiles as $profile) {
-     $monitor = $camera['monitor'];
+    $monitor = $camera['monitor'];
 
-    if (PHP_VERSION_ID >= 80200) { // strings ${xxx} are depreated, use {$xxx} instead
-      eval(<<<'PHP'
-        $sourceString = "{$profile['Name']} : {$profile['Encoding']}" .
-          " ({$profile['Width']}x{$profile['Height']} @ {$profile['MaxFPS']}fps {$profile['Transport']})";
-        PHP);
-    } else {
-      eval(<<<'PHP'
-        $sourceString = "${profile['Name']} : ${profile['Encoding']}" .
-          " (${profile['Width']}x${profile['Height']} @ ${profile['MaxFPS']}fps ${profile['Transport']})";
-      PHP);
-    }
+    $sourceString = $profile['Name'] . ' : ' . $profile['Encoding'] .
+                    ' (' . $profile['Width'] . 'x' . $profile['Height'] . ' @ ' . $profile['MaxFPS'] . 'fps ' . $profile['Transport'] . ')';
 
     // copy technical details
     $monitor['Width']  = $profile['Width'];


### PR DESCRIPTION
 - as from PHP 8.2, ${var} string interpolation is deprecated. the fix looks a bit hackish, but it should parse the correct syntax only.
 - on FreeBSD, the 'ip' command is not available. Also, the old code that parse the 'ifconfig' output looks a bit weird (probably really outdated). The new code works on Linux (6.19.11 here) and FreeBSD. Also, to get the default route interface, I've added a FreeBSD only code section. Later I will add a ZM_PATH_ROUTE in cmake / conf, for now the command is hardcoded, I will also add Linux support for default route detection when 'ip' is not available (unlikely). now get_network() works on FreeBSD too, interfaces array is no more empty.