### PR TITLE
Align the thumbnail on the Console page horizontally to the center of the table cell

### DIFF
--- a/web/skins/classic/css/base/views/console.css
+++ b/web/skins/classic/css/base/views/console.css
@@ -193,6 +193,14 @@ body.sticky #monitorList thead {
   position: relative;
 }
 
+div.colThumbnail {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: center;
+  min-width: 100%;
+}
+
 /* Make the boot-strap table monitor list scrollable instead of content div */
 #content {
   display: flex;


### PR DESCRIPTION
If the thumbnail width is smaller than the table cell width, it looks unsightly.

Before:
<img width="416" height="147" alt="1122_before" src="https://github.com/user-attachments/assets/52e56e38-65b7-467a-b0ad-9ed70d2bddd0" />


After:
<img width="407" height="151" alt="1122_after" src="https://github.com/user-attachments/assets/bbd47487-f2d0-4fbc-b991-43221312ed95" />
