### PR TITLE
Move tag next/prev buttons to the left

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -1164,6 +1164,7 @@ a.flip {
   margin-right: 8px;
   display: inline-block;
   flex-grow: 2;
+  order: 3;
 }
 
 .tag-dropdown-content {

--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -1137,6 +1137,7 @@ a.flip {
   margin: 4px;
   display: flex;
   align-items: center;
+  order: 2;
 }
 
 .tag-text {

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -273,11 +273,6 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
     </div>
 <?php if ( $Event->Id() ) { ?>
     <div class="tags-container">
-      <div class="tag-dropdown">
-        <!-- input type has to be "search" (not "text") so that the Enter button (not Next) works on mobile Chrome browser. -->
-        <input type="search" id="tagInput" class="tag-input" placeholder="Add tag" data-role="tagsinput">
-        <div class="tag-dropdown-content"></div>
-      </div>
       <button type="button" id="tagPrevBtn" title="<?php echo translate('Apply the last tag, then play the previous event') ?>" class="inactive" data-on-click-true="tagAndPrev">
         <i class="material-icons md-18" 
           style="-moz-transform: scaleX(-1);
@@ -291,6 +286,11 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
       <button type="button" id="tagNextBtn" title="<?php echo translate('Apply the last tag, then play the next event') ?>" class="inactive" data-on-click-true="tagAndNext">
         <i class="material-icons md-18">label</i>
       </button>
+      <div class="tag-dropdown">
+        <!-- input type has to be "search" (not "text") so that the Enter button (not Next) works on mobile Chrome browser. -->
+        <input type="search" id="tagInput" class="tag-input" placeholder="Add tag" data-role="tagsinput">
+        <div class="tag-dropdown-content"></div>
+      </div>
     </div>
 <!-- BEGIN VIDEO CONTENT ROW -->
     <div id="inner-content">

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -273,6 +273,11 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
     </div>
 <?php if ( $Event->Id() ) { ?>
     <div class="tags-container">
+      <div class="tag-dropdown">
+        <!-- input type has to be "search" (not "text") so that the Enter button (not Next) works on mobile Chrome browser. -->
+        <input type="search" id="tagInput" class="tag-input" placeholder="Add tag" data-role="tagsinput">
+        <div class="tag-dropdown-content"></div>
+      </div>
       <button type="button" id="tagPrevBtn" title="<?php echo translate('Apply the last tag, then play the previous event') ?>" class="inactive" data-on-click-true="tagAndPrev">
         <i class="material-icons md-18" 
           style="-moz-transform: scaleX(-1);
@@ -286,11 +291,6 @@ if ( $Event->Id() and !file_exists($Event->Path()) )
       <button type="button" id="tagNextBtn" title="<?php echo translate('Apply the last tag, then play the next event') ?>" class="inactive" data-on-click-true="tagAndNext">
         <i class="material-icons md-18">label</i>
       </button>
-      <div class="tag-dropdown">
-        <!-- input type has to be "search" (not "text") so that the Enter button (not Next) works on mobile Chrome browser. -->
-        <input type="search" id="tagInput" class="tag-input" placeholder="Add tag" data-role="tagsinput">
-        <div class="tag-dropdown-content"></div>
-      </div>
     </div>
 <!-- BEGIN VIDEO CONTENT ROW -->
     <div id="inner-content">


### PR DESCRIPTION
Move the tag next/prev buttons to the left so that you don't have to move your mouse cursor all the way across the screen when clicking between the dropdown and these two buttons.  This is especially noticeable on wide screen monitors.