### PR TITLE
Prevent the scrollbar from appearing when displaying table column visibility settings (options.css)

### DIFF
--- a/web/skins/classic/css/base/views/options.css
+++ b/web/skins/classic/css/base/views/options.css
@@ -66,7 +66,7 @@ body.sticky #options {
   max-height: 100%;
   display: flex;
   flex-direction: column;
-  /*height: calc(100% - 50px);*/ /* It's bad, but it's temporary */
+  height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
 }
@@ -190,7 +190,7 @@ textarea.form-control-sm {
 
 body.sticky .wrapper-scroll-table {
   width: 100%;
-  height: auto;
+  height: 100%;
   overflow-x: hidden; 
   overflow-y: auto; 
 }


### PR DESCRIPTION
For example, on the Servers page when there are only a few servers in the table.

**Before:**
<img width="1321" height="639" alt="Before" src="https://github.com/user-attachments/assets/ca96ef04-e7fc-444f-ac49-26ef824a9618" />

**After**:
<img width="1319" height="638" alt="After" src="https://github.com/user-attachments/assets/4b87fc7a-1169-45af-a22d-2119421c85ba" />

