### PR TITLE
Fix: Regexp for replacing index.php with $base_url (view_hls.php)

### DIFF
--- a/web/views/view_hls.php
+++ b/web/views/view_hls.php
@@ -66,8 +66,8 @@ $content = preg_replace(
 
 // Also fix the EXT-X-MAP URI
 $content = preg_replace(
-  '/URI="(index\.php)(.+)/m',
-  'URI="' . $base_url . '$2' . $auth_query . '"',
+  '/(.+URI=")(index\.php)([^"]+)(.+)/m',
+  '$1' . $base_url . '$3' . $auth_query . '$4',
   $content
 );
 

--- a/web/views/view_hls.php
+++ b/web/views/view_hls.php
@@ -59,15 +59,15 @@ $base_url = $Server->PathToIndex();
 
 // Replace bare URLs with full paths including auth
 $content = preg_replace(
-  '/^(index\.php\?.+)$/m',
-  $base_url . '?$1' . $auth_query,
+  '/^(index\.php)(.+)$/m',
+  $base_url . '$2' . $auth_query,
   $content
 );
 
 // Also fix the EXT-X-MAP URI
 $content = preg_replace(
-  '/URI="(index\.php\?[^"]+)"/m',
-  'URI="' . $base_url . '?$1' . $auth_query . '"',
+  '/URI="(index\.php)(.+)/m',
+  'URI="' . $base_url . '$2' . $auth_query . '"',
   $content
 );
 


### PR DESCRIPTION
With the previous expressions, this shouldn't work at all.
Partial fix for issue #4757
And a possible solution for issue №1 #4774