### PR TITLE
Eliminate Event_Summaries / bucket-table deadlocks (zmstats, zmaudit, Event::delete, zmDbDo retry)

### DIFF
--- a/db/triggers.sql
+++ b/db/triggers.sql
@@ -116,9 +116,21 @@ FOR EACH ROW
 
 drop procedure if exists update_storage_stats//
 
+/* ============================================================================
+ * Lock-acquisition order for the Events update/delete triggers (and for the
+ * scripts that touch the same tables). InnoDB X-locks the matched Events row
+ * during WHERE evaluation, before either BEFORE or AFTER trigger bodies fire,
+ * so the order is the same regardless of trigger timing:
+ *   Events[Id] -> Events_Hour/Day/Week/Month[EventId] -> Event_Summaries[MonitorId]
+ * zmstats.pl prune+resync follows the matching prefix (bucket DELETEs then
+ * UPDATE Event_Summaries) and crucially does NOT pre-lock Event_Summaries —
+ * pre-locking ES would invert against the trigger body order and reintroduce
+ * deadlocks against filter / zma writers. The bucket update/delete triggers
+ * also propagate into Event_Summaries[MonitorId] in the same direction.
+ * ============================================================================ */
 drop trigger if exists event_update_trigger//
 
-CREATE TRIGGER event_update_trigger AFTER UPDATE ON Events 
+CREATE TRIGGER event_update_trigger AFTER UPDATE ON Events
 FOR EACH ROW
 BEGIN
   declare diff BIGINT default 0;

--- a/db/triggers.sql
+++ b/db/triggers.sql
@@ -127,7 +127,7 @@ drop procedure if exists update_storage_stats//
  * Writers that follow this order (and must continue to):
  *   - event_update_trigger (AFTER UPDATE on Events)
  *   - event_delete_trigger (BEFORE DELETE on Events)
- *   - src/zm_event.cpp Event::createNotification path: INSERT Events, then
+ *   - The Event::Event constructor in src/zm_event.cpp: INSERT Events, then
  *     INSERT Events_Hour/Day/Week/Month, then INSERT/UPDATE Event_Summaries
  *     (event_insert_trigger is commented out below; zmc does it directly)
  *   - The bucket update/delete triggers cascade into Event_Summaries in the

--- a/db/triggers.sql
+++ b/db/triggers.sql
@@ -117,16 +117,27 @@ FOR EACH ROW
 drop procedure if exists update_storage_stats//
 
 /* ============================================================================
- * Lock-acquisition order for the Events update/delete triggers (and for the
- * scripts that touch the same tables). InnoDB X-locks the matched Events row
- * during WHERE evaluation, before either BEFORE or AFTER trigger bodies fire,
- * so the order is the same regardless of trigger timing:
+ * Canonical lock-acquisition order for every writer that touches Events,
+ * the bucket tables, and Event_Summaries. InnoDB X-locks the matched Events
+ * row during WHERE evaluation, before either BEFORE or AFTER trigger bodies
+ * fire, so the order is the same regardless of trigger timing:
+ *
  *   Events[Id] -> Events_Hour/Day/Week/Month[EventId] -> Event_Summaries[MonitorId]
- * zmstats.pl prune+resync follows the matching prefix (bucket DELETEs then
- * UPDATE Event_Summaries) and crucially does NOT pre-lock Event_Summaries —
- * pre-locking ES would invert against the trigger body order and reintroduce
- * deadlocks against filter / zma writers. The bucket update/delete triggers
- * also propagate into Event_Summaries[MonitorId] in the same direction.
+ *
+ * Writers that follow this order (and must continue to):
+ *   - event_update_trigger (AFTER UPDATE on Events)
+ *   - event_delete_trigger (BEFORE DELETE on Events)
+ *   - src/zm_event.cpp Event::createNotification path: INSERT Events, then
+ *     INSERT Events_Hour/Day/Week/Month, then INSERT/UPDATE Event_Summaries
+ *     (event_insert_trigger is commented out below; zmc does it directly)
+ *   - The bucket update/delete triggers cascade into Event_Summaries in the
+ *     same direction
+ *   - zmstats.pl prune+resync (bucket DELETEs then UPDATE Event_Summaries)
+ *   - zmaudit.pl resync (bucket SELECTs then UPDATE Event_Summaries)
+ *
+ * Crucially: do NOT pre-lock Event_Summaries before touching the bucket
+ * tables — that inverts the order and reintroduces the deadlock cycle
+ * against zma/filter/zmc writers.
  * ============================================================================ */
 drop trigger if exists event_update_trigger//
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -263,15 +263,28 @@ sub _sql_with_bind_values {
 }
 
 # Basic execution of $dbh->do but with some pretty logging of the sql on error.
+# Auto-retries on deadlock (errno 1213) only when AutoCommit is on, since
+# inside a caller-managed transaction the caller has to rebuild the whole TX.
 sub zmDbDo {
-	my $sql = shift;
-  my $rows = $dbh->do($sql, undef, @_);
-	if ( ! defined $rows ) {
-		Error('Failed '._sql_with_bind_values($sql, @_).' : '.$dbh->errstr());
-  } elsif ( ZoneMinder::Logger::logLevel() > INFO ) {
+  my $sql = shift;
+  my @params = @_;
+  my $max_attempts = $dbh->{AutoCommit} ? 5 : 1;
+  my $rows;
+  for ( my $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+    $rows = $dbh->do($sql, undef, @params);
+    last if defined $rows;
+    if ( ($dbh->err() // 0) == 1213 and $attempt < $max_attempts ) {
+      Debug("Deadlock on '"._sql_with_bind_values($sql, @params)."' attempt $attempt/$max_attempts, retrying");
+      select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
+      next;
+    }
+    Error('Failed '._sql_with_bind_values($sql, @params).' : '.$dbh->errstr());
+    last;
+  }
+  if ( defined $rows and ZoneMinder::Logger::logLevel() > INFO ) {
     ($rows) = $rows =~ /^(.*)$/; # de-taint
-    Debug('Succeeded '._sql_with_bind_values($sql, @_)." : $rows rows affected");
-	}
+    Debug('Succeeded '._sql_with_bind_values($sql, @params)." : $rows rows affected");
+  }
   return $rows;
 }
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -291,7 +291,11 @@ sub zmDbDo {
     Error('Failed '._sql_with_bind_values($sql, @params).' : '.$dbh->errstr());
     last;
   }
-  if ( defined $rows and ZoneMinder::Logger::logLevel() > INFO ) {
+  # Skip the success Debug when we're inside a caller-managed transaction:
+  # ZoneMinder::Logger->logPrint INSERTs into Logs on this same $dbh, which
+  # would add an extra write to a TX that's trying to be lock-minimal and
+  # could change $dbh->err / $dbh->errstr the caller will later inspect.
+  if ( defined $rows and $dbh->{AutoCommit} and ZoneMinder::Logger::logLevel() > INFO ) {
     ($rows) = $rows =~ /^(.*)$/; # de-taint
     Debug('Succeeded '._sql_with_bind_values($sql, @params)." : $rows rows affected");
   }

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -274,10 +274,17 @@ sub zmDbDo {
   for ( my $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
     $rows = $dbh->do($sql, undef, @params);
     last if defined $rows;
-    if ( ($dbh->err() // 0) == 1213 and $attempt < $max_attempts ) { # 1213 = ER_LOCK_DEADLOCK
+    my $err_code = $dbh->err() // 0;
+    if ( $err_code == 1213 and $attempt < $max_attempts ) { # 1213 = ER_LOCK_DEADLOCK
       Debug("Deadlock on '"._sql_with_bind_values($sql, @params)."' attempt $attempt/$max_attempts, retrying");
       select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
       next;
+    }
+    if ( $err_code == 1213 and !$dbh->{AutoCommit} ) {
+      # Caller-managed TX owns the retry loop; don't pollute logs with a
+      # misleading "Failed ... Deadlock found" Error before they roll back.
+      Debug('Deadlock in caller-managed TX on '._sql_with_bind_values($sql, @params).'; deferring to caller');
+      last;
     }
     Error('Failed '._sql_with_bind_values($sql, @params).' : '.$dbh->errstr());
     last;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -274,17 +274,19 @@ sub zmDbDo {
   for ( my $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
     $rows = $dbh->do($sql, undef, @params);
     last if defined $rows;
+
+    # In a caller-managed transaction, never issue ANY logging here that can
+    # write to the Logs table: ZoneMinder::Logger->logPrint INSERTs into
+    # Logs using the same $dbh, which would clear $dbh->err / $dbh->errstr
+    # before the caller reads them for rollback/retry. Bail silently — the
+    # caller owns the retry loop and is responsible for logging.
+    last if !$dbh->{AutoCommit};
+
     my $err_code = $dbh->err() // 0;
     if ( $err_code == 1213 and $attempt < $max_attempts ) { # 1213 = ER_LOCK_DEADLOCK
       Debug("Deadlock on '"._sql_with_bind_values($sql, @params)."' attempt $attempt/$max_attempts, retrying");
       select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
       next;
-    }
-    if ( $err_code == 1213 and !$dbh->{AutoCommit} ) {
-      # Caller-managed TX owns the retry loop; don't pollute logs with a
-      # misleading "Failed ... Deadlock found" Error before they roll back.
-      Debug('Deadlock in caller-managed TX on '._sql_with_bind_values($sql, @params).'; deferring to caller');
-      last;
     }
     Error('Failed '._sql_with_bind_values($sql, @params).' : '.$dbh->errstr());
     last;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -263,8 +263,9 @@ sub _sql_with_bind_values {
 }
 
 # Basic execution of $dbh->do but with some pretty logging of the sql on error.
-# Auto-retries on deadlock (errno 1213) only when AutoCommit is on, since
-# inside a caller-managed transaction the caller has to rebuild the whole TX.
+# Auto-retries on deadlock (MariaDB ER_LOCK_DEADLOCK = 1213) only when
+# AutoCommit is on, since inside a caller-managed transaction the caller has
+# to rebuild the whole TX.
 sub zmDbDo {
   my $sql = shift;
   my @params = @_;
@@ -273,7 +274,7 @@ sub zmDbDo {
   for ( my $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
     $rows = $dbh->do($sql, undef, @params);
     last if defined $rows;
-    if ( ($dbh->err() // 0) == 1213 and $attempt < $max_attempts ) {
+    if ( ($dbh->err() // 0) == 1213 and $attempt < $max_attempts ) { # 1213 = ER_LOCK_DEADLOCK
       Debug("Deadlock on '"._sql_with_bind_values($sql, @params)."' attempt $attempt/$max_attempts, retrying");
       select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
       next;

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -395,28 +395,59 @@ sub delete {
 
     my $in_transaction = $ZoneMinder::Database::dbh->{AutoCommit} ? 0 : 1;
 
-    $ZoneMinder::Database::dbh->begin_work() if ! $in_transaction;
+    # event_delete_trigger fires BEFORE DELETE on Events; after the
+    # accompanying triggers.sql change, event_update_trigger now also fires
+    # BEFORE UPDATE. That gives every Events writer the same lock acquisition
+    # order: buckets[Id] -> Event_Summaries[MonitorId] -> Events[Id] (the
+    # outer DML row last). zmstats.pl runs at the same RC isolation and takes
+    # bucket-row X-locks first, then UPDATE Event_Summaries, which is the
+    # same prefix order — so no cycle is possible across filter / zma /
+    # zmstats. Do NOT pre-lock Event_Summaries here: that puts ES before
+    # buckets and re-introduces the inversion against zma's UPDATE path.
+    #
+    # READ COMMITTED drops the next-key/gap locks that two concurrent filter
+    # workers deleting adjacent EventIds in the bucket tables would otherwise
+    # take. SET TRANSACTION applies to the next transaction only, so it has
+    # to be re-issued before each begin_work (and is skipped when the caller
+    # is managing the TX).
+    #
+    # Retry on errno 1213 only when we own the TX; if the caller is managing
+    # one, bail and let them decide.
+    my $attempt = 0;
+    my $max_attempts = 5;
+    while (1) {
+      $attempt++;
+      if (!$in_transaction) {
+        ZoneMinder::Database::zmDbDo('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+        $ZoneMinder::Database::dbh->begin_work();
+      }
 
-    # Going to delete in order of least value to greatest value. Stats is least and references Frames
-    ZoneMinder::Database::zmDbDo('DELETE FROM Stats WHERE EventId=?', $$event{Id});
-    if ( $ZoneMinder::Database::dbh->errstr() ) {
-      $ZoneMinder::Database::dbh->commit() if ! $in_transaction;
-      return;
-    }
-    ZoneMinder::Database::zmDbDo('DELETE FROM Event_Data WHERE EventId=?', $$event{Id});
-    if ( $ZoneMinder::Database::dbh->errstr() ) {
-      $ZoneMinder::Database::dbh->commit() if ! $in_transaction;
-      return;
-    }
-    ZoneMinder::Database::zmDbDo('DELETE FROM Frames WHERE EventId=?', $$event{Id});
-    if ( $ZoneMinder::Database::dbh->errstr() ) {
-      $ZoneMinder::Database::dbh->commit() if ! $in_transaction;
-      return;
-    }
+      # Order: Stats -> Event_Data -> Frames -> Events (least to greatest reference depth)
+      my $err = 0;
+      foreach my $stmt (
+        ['DELETE FROM Stats WHERE EventId=?',      $$event{Id}],
+        ['DELETE FROM Event_Data WHERE EventId=?', $$event{Id}],
+        ['DELETE FROM Frames WHERE EventId=?',     $$event{Id}],
+        ['DELETE FROM Events WHERE Id=?',          $$event{Id}],
+      ) {
+        my ($sql, @bind) = @$stmt;
+        ZoneMinder::Database::zmDbDo($sql, @bind);
+        $err = $ZoneMinder::Database::dbh->err() // 0;
+        last if $err;
+      }
 
-    # Do it individually to avoid locking up the table for new events
-    ZoneMinder::Database::zmDbDo('DELETE FROM Events WHERE Id=?', $$event{Id});
-    $ZoneMinder::Database::dbh->commit() if ! $in_transaction;
+      if (!$err) {
+        $ZoneMinder::Database::dbh->commit() if !$in_transaction;
+        last;
+      }
+
+      $ZoneMinder::Database::dbh->rollback() if !$in_transaction;
+      if ($in_transaction or $err != 1213 or $attempt >= $max_attempts) {
+        return;
+      }
+      Debug("Deadlock deleting event $$event{Id} attempt $attempt/$max_attempts, retrying");
+      select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
+    }
 
     my $storage = $event->Storage();
     if ($event->DiskSpace() and $storage->Id()) {

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -420,7 +420,11 @@ sub delete {
     while (1) {
       $attempt++;
       if (!$in_transaction) {
-        ZoneMinder::Database::zmDbDo('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+        # Use $dbh->do directly, NOT zmDbDo: zmDbDo's success Debug would
+        # write to the Logs table on this same $dbh, and that INSERT would
+        # become the "next transaction" that consumes the isolation level
+        # directive — silently dropping our delete TX back to the default.
+        $ZoneMinder::Database::dbh->do('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
         $ZoneMinder::Database::dbh->begin_work();
       }
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -427,14 +427,13 @@ sub delete {
       # Order: Stats -> Event_Data -> Frames -> Events (least to greatest reference depth)
       my $err = 0;
       my $errstr = '';
-      foreach my $stmt (
-        ['DELETE FROM Stats WHERE EventId=?',      $$event{Id}],
-        ['DELETE FROM Event_Data WHERE EventId=?', $$event{Id}],
-        ['DELETE FROM Frames WHERE EventId=?',     $$event{Id}],
-        ['DELETE FROM Events WHERE Id=?',          $$event{Id}],
+      foreach my $sql (
+        'DELETE FROM Stats WHERE EventId=?',
+        'DELETE FROM Event_Data WHERE EventId=?',
+        'DELETE FROM Frames WHERE EventId=?',
+        'DELETE FROM Events WHERE Id=?',
       ) {
-        my ($sql, @bind) = @$stmt;
-        ZoneMinder::Database::zmDbDo($sql, @bind);
+        ZoneMinder::Database::zmDbDo($sql, $$event{Id});
         $err = $ZoneMinder::Database::dbh->err() // 0;
         if ($err) {
           # Capture before rollback, which can clear errstr on some drivers.

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -413,8 +413,8 @@ sub delete {
     # to be re-issued before each begin_work (and is skipped when the caller
     # is managing the TX).
     #
-    # Retry on errno 1213 only when we own the TX; if the caller is managing
-    # one, bail and let them decide.
+    # Retry on deadlock (MariaDB ER_LOCK_DEADLOCK = 1213) only when we own
+    # the TX; if the caller is managing one, bail and let them decide.
     my $attempt = 0;
     my $max_attempts = 5;
     while (1) {
@@ -444,7 +444,7 @@ sub delete {
       }
 
       $ZoneMinder::Database::dbh->rollback() if !$in_transaction;
-      if ($in_transaction or $err != 1213 or $attempt >= $max_attempts) {
+      if ($in_transaction or $err != 1213 or $attempt >= $max_attempts) { # 1213 = ER_LOCK_DEADLOCK
         return;
       }
       Debug("Deadlock deleting event $$event{Id} attempt $attempt/$max_attempts, retrying");

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -395,15 +395,17 @@ sub delete {
 
     my $in_transaction = $ZoneMinder::Database::dbh->{AutoCommit} ? 0 : 1;
 
-    # event_delete_trigger fires BEFORE DELETE on Events; after the
-    # accompanying triggers.sql change, event_update_trigger now also fires
-    # BEFORE UPDATE. That gives every Events writer the same lock acquisition
-    # order: buckets[Id] -> Event_Summaries[MonitorId] -> Events[Id] (the
-    # outer DML row last). zmstats.pl runs at the same RC isolation and takes
-    # bucket-row X-locks first, then UPDATE Event_Summaries, which is the
-    # same prefix order — so no cycle is possible across filter / zma /
-    # zmstats. Do NOT pre-lock Event_Summaries here: that puts ES before
-    # buckets and re-introduces the inversion against zma's UPDATE path.
+    # InnoDB X-locks the matched Events row during WHERE evaluation, before
+    # either BEFORE or AFTER trigger bodies fire, so the lock acquisition
+    # order is the same regardless of trigger timing:
+    #   Events[Id] -> Events_Hour/Day/Week/Month[EventId] -> Event_Summaries[MonitorId]
+    # event_delete_trigger (BEFORE DELETE on Events) and event_update_trigger
+    # (AFTER UPDATE on Events) both propagate into the bucket tables, whose
+    # own triggers then UPDATE Event_Summaries — that's the canonical chain.
+    # zmstats.pl prune+resync follows the matching prefix (bucket DELETEs
+    # then UPDATE Event_Summaries) and crucially does NOT pre-lock
+    # Event_Summaries: that would put ES before buckets and re-introduce the
+    # inversion against zma's UPDATE path.
     #
     # READ COMMITTED drops the next-key/gap locks that two concurrent filter
     # workers deleting adjacent EventIds in the bucket tables would otherwise

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -426,6 +426,7 @@ sub delete {
 
       # Order: Stats -> Event_Data -> Frames -> Events (least to greatest reference depth)
       my $err = 0;
+      my $errstr = '';
       foreach my $stmt (
         ['DELETE FROM Stats WHERE EventId=?',      $$event{Id}],
         ['DELETE FROM Event_Data WHERE EventId=?', $$event{Id}],
@@ -435,7 +436,11 @@ sub delete {
         my ($sql, @bind) = @$stmt;
         ZoneMinder::Database::zmDbDo($sql, @bind);
         $err = $ZoneMinder::Database::dbh->err() // 0;
-        last if $err;
+        if ($err) {
+          # Capture before rollback, which can clear errstr on some drivers.
+          $errstr = $ZoneMinder::Database::dbh->errstr() // '';
+          last;
+        }
       }
 
       if (!$err) {
@@ -445,6 +450,11 @@ sub delete {
 
       $ZoneMinder::Database::dbh->rollback() if !$in_transaction;
       if ($in_transaction or $err != 1213 or $attempt >= $max_attempts) { # 1213 = ER_LOCK_DEADLOCK
+        # Surface the final failure ourselves — zmDbDo suppresses its Error
+        # log on 1213 inside a caller-managed TX (we own the retry), and the
+        # exhausted-retries case would otherwise return silently.
+        Error("Failed deleting event $$event{Id} after $attempt attempt(s): err=$err $errstr")
+          if $err;
         return;
       }
       Debug("Deadlock deleting event $$event{Id} attempt $attempt/$max_attempts, retrying");

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -926,64 +926,119 @@ FROM `Frames` WHERE `EventId`=?';
   } # end if ZM_LOG_AUDIT_DATABASE_LIMIT
   $loop = $continuous;
 
-  my $eventcounts_sql = '
-  UPDATE `Event_Summaries` SET
-  `TotalEvents`=(SELECT COUNT(`Id`) FROM `Events` WHERE `MonitorId`=`Event_Summaries`.`MonitorId`),
-  `TotalEventDiskSpace`=(SELECT SUM(`DiskSpace`) FROM `Events` WHERE `MonitorId`=`Event_Summaries`.`MonitorId` AND `DiskSpace` IS NOT NULL),
-  `ArchivedEvents`=(SELECT COUNT(`Id`) FROM `Events` WHERE `MonitorId`=`Event_Summaries`.`MonitorId` AND `Archived`=1),
-  `ArchivedEventDiskSpace`=(SELECT SUM(`DiskSpace`) FROM `Events` WHERE `MonitorId`=`Event_Summaries`.`MonitorId` AND `Archived`=1 AND `DiskSpace` IS NOT NULL)
-  ';
+  # Resync Event_Summaries from ground truth in Events + bucket tables.
+  #
+  # Previous implementation used multi-table UPDATEs (UPDATE Event_Summaries
+  # INNER JOIN (... FROM Events_Hour ...)) and correlated subqueries against
+  # Events. Both patterns make MariaDB take S-locks on the joined/sub-queried
+  # rows for the duration of the UPDATE statement, regardless of isolation
+  # level — which deadlocks against event_update_trigger / event_delete_trigger
+  # holding X-locks on those same bucket rows.
+  #
+  # Snapshot all five aggregations with plain SELECTs (consistent reads, no
+  # row locks), merge them per MonitorId, then issue one single-row UPDATE
+  # per monitor against Event_Summaries. Each UPDATE only X-locks the one ES
+  # row it targets and reads no other table, so it can't form a cycle with
+  # the trigger writers.
+  {
+    my %agg;
 
-  ZoneMinder::Database::zmDbDo($eventcounts_sql);
-  aud_print('Finished updating TotalEvents, ArchivedEvents');
+    my $events_rows = $dbh->selectall_arrayref(q{
+      SELECT MonitorId,
+             COUNT(Id),
+             COALESCE(SUM(CASE WHEN DiskSpace IS NOT NULL THEN DiskSpace ELSE 0 END), 0),
+             COUNT(CASE WHEN Archived = 1 THEN 1 END),
+             COALESCE(SUM(CASE WHEN Archived = 1 AND DiskSpace IS NOT NULL THEN DiskSpace ELSE 0 END), 0)
+      FROM Events
+      GROUP BY MonitorId
+    });
+    if ($dbh->err()) {
+      Error("zmaudit Events aggregate failed: ".$dbh->errstr());
+    } else {
+      for my $r (@$events_rows) {
+        $agg{$r->[0]}{total_c}    = $r->[1];
+        $agg{$r->[0]}{total_s}    = $r->[2];
+        $agg{$r->[0]}{archived_c} = $r->[3];
+        $agg{$r->[0]}{archived_s} = $r->[4];
+      }
+    }
 
-  my $eventcounts_hour_sql = '
-  UPDATE `Event_Summaries` INNER JOIN (
-  SELECT  `MonitorId`, COUNT(*) AS `HourEvents`, SUM(COALESCE(`DiskSpace`,0)) AS `HourEventDiskSpace`
-  FROM `Events_Hour` GROUP BY `MonitorId`
-  ) AS `E` ON `E`.`MonitorId`=`Event_Summaries`.`MonitorId` SET
-  `Event_Summaries`.`HourEvents` = `E`.`HourEvents`,
-  `Event_Summaries`.`HourEventDiskSpace` = `E`.`HourEventDiskSpace`
-  ';
-  ZoneMinder::Database::zmDbDo($eventcounts_hour_sql);
-  aud_print("Finished updating HourEvents");
+    foreach my $bucket (
+      ['Events_Hour',  'h'],
+      ['Events_Day',   'd'],
+      ['Events_Week',  'w'],
+      ['Events_Month', 'm'],
+    ) {
+      my ($table, $key) = @$bucket;
+      my $rows = $dbh->selectall_arrayref(
+        "SELECT MonitorId, COUNT(*), COALESCE(SUM(DiskSpace), 0) FROM $table GROUP BY MonitorId"
+      );
+      if ($dbh->err()) {
+        Error("zmaudit $table aggregate failed: ".$dbh->errstr());
+        next;
+      }
+      for my $r (@$rows) {
+        $agg{$r->[0]}{$key.'_c'} = $r->[1];
+        $agg{$r->[0]}{$key.'_s'} = $r->[2];
+      }
+    }
 
+    # Include monitors that have an Event_Summaries row but no Events rows so
+    # we still zero them out instead of leaving stale counters.
+    my $existing = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
+    if ($dbh->err()) {
+      Error("zmaudit Event_Summaries enumerate failed: ".$dbh->errstr());
+    } else {
+      $agg{$_} ||= {} for @$existing;
+    }
 
-  my $eventcounts_day_sql = '
-  UPDATE `Event_Summaries` INNER JOIN (
-  SELECT  `MonitorId`, COUNT(*) AS `DayEvents`, SUM(COALESCE(`DiskSpace`,0)) AS `DayEventDiskSpace`
-  FROM `Events_Day` GROUP BY `MonitorId`
-  ) AS `E` ON `E`.`MonitorId`=`Event_Summaries`.`MonitorId` SET
-  `Event_Summaries`.`DayEvents` = `E`.`DayEvents`,
-  `Event_Summaries`.`DayEventDiskSpace` = `E`.`DayEventDiskSpace`
-  ';
-  ZoneMinder::Database::zmDbDo($eventcounts_day_sql);
-  aud_print("Finished updating DayEvents");
+    for my $mid (sort { $a <=> $b } keys %agg) {
+      my $a = $agg{$mid};
+      ZoneMinder::Database::zmDbDo(
+        'UPDATE Event_Summaries SET '.
+          'TotalEvents=?, TotalEventDiskSpace=?, '.
+          'ArchivedEvents=?, ArchivedEventDiskSpace=?, '.
+          'HourEvents=?, HourEventDiskSpace=?, '.
+          'DayEvents=?, DayEventDiskSpace=?, '.
+          'WeekEvents=?, WeekEventDiskSpace=?, '.
+          'MonthEvents=?, MonthEventDiskSpace=? '.
+        'WHERE MonitorId=?',
+        $a->{total_c}    // 0, $a->{total_s}    // 0,
+        $a->{archived_c} // 0, $a->{archived_s} // 0,
+        $a->{h_c}        // 0, $a->{h_s}        // 0,
+        $a->{d_c}        // 0, $a->{d_s}        // 0,
+        $a->{w_c}        // 0, $a->{w_s}        // 0,
+        $a->{m_c}        // 0, $a->{m_s}        // 0,
+        $mid
+      );
+    }
+    aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+  }
 
-  my $eventcounts_week_sql = '
-  UPDATE `Event_Summaries` INNER JOIN (
-  SELECT  `MonitorId`, COUNT(*) AS `WeekEvents`, SUM(COALESCE(`DiskSpace`,0)) AS `WeekEventDiskSpace`
-  FROM `Events_Week` GROUP BY `MonitorId`
-  ) AS `E` ON `E`.`MonitorId`=`Event_Summaries`.`MonitorId` SET
-  `Event_Summaries`.`WeekEvents` = `E`.`WeekEvents`,
-  `Event_Summaries`.`WeekEventDiskSpace` = `E`.`WeekEventDiskSpace`
-  ';
-  ZoneMinder::Database::zmDbDo($eventcounts_week_sql);
-  aud_print("Finished updating WeekEvents");
-
-  my $eventcounts_month_sql = '
-  UPDATE `Event_Summaries` INNER JOIN (
-  SELECT  `MonitorId`, COUNT(*) AS `MonthEvents`, SUM(COALESCE(`DiskSpace`,0)) AS `MonthEventDiskSpace`
-  FROM `Events_Month` GROUP BY `MonitorId`
-  ) AS `E` ON `E`.`MonitorId`=`Event_Summaries`.`MonitorId` SET
-  `Event_Summaries`.`MonthEvents` = `E`.`MonthEvents`,
-  `Event_Summaries`.`MonthEventDiskSpace` = `E`.`MonthEventDiskSpace`
-  ';
-  ZoneMinder::Database::zmDbDo($eventcounts_month_sql);
-  aud_print("Finished updating MonthEvents");
-
-  ZoneMinder::Database::zmDbDo('UPDATE Storage SET DiskSpace=(SELECT SUM(DiskSpace) FROM Events WHERE StorageId=Storage.Id)');
-  aud_print("Finished updating Storage DiskSpace");
+  # Storage DiskSpace resync: same trap. Snapshot per-Storage sums via plain
+  # SELECT, then UPDATE Storage one row at a time.
+  {
+    my $rows = $dbh->selectall_arrayref(
+      'SELECT StorageId, COALESCE(SUM(DiskSpace), 0) FROM Events GROUP BY StorageId'
+    );
+    if ($dbh->err()) {
+      Error('zmaudit Storage aggregate failed: '.$dbh->errstr());
+    } else {
+      my %disk = map { $_->[0] => $_->[1] } grep { defined $_->[0] } @$rows;
+      my $storage_ids = $dbh->selectcol_arrayref('SELECT Id FROM Storage');
+      if ($dbh->err()) {
+        Error('zmaudit Storage enumerate failed: '.$dbh->errstr());
+      } else {
+        for my $sid (@$storage_ids) {
+          ZoneMinder::Database::zmDbDo(
+            'UPDATE Storage SET DiskSpace=? WHERE Id=?',
+            $disk{$sid} // 0, $sid
+          );
+        }
+      }
+    }
+    aud_print('Finished updating Storage DiskSpace');
+  }
 
   sleep($Config{ZM_AUDIT_CHECK_INTERVAL}) if $continuous;
 };

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -942,6 +942,11 @@ FROM `Frames` WHERE `EventId`=?';
   # the trigger writers.
   {
     my %agg;
+    # All-or-nothing per column group: a transient SELECT failure must not
+    # cause the per-monitor UPDATE phase to write 0 over valid counters.
+    # Track which column groups are safe to write; skip the others entirely
+    # — zmaudit will resync them on its next pass.
+    my %ok = (events => 0, h => 0, d => 0, w => 0, m => 0);
 
     my $events_rows = $dbh->selectall_arrayref(q{
       SELECT MonitorId,
@@ -955,6 +960,7 @@ FROM `Frames` WHERE `EventId`=?';
     if ($dbh->err()) {
       Error("zmaudit Events aggregate failed: ".$dbh->errstr());
     } else {
+      $ok{events} = 1;
       for my $r (@$events_rows) {
         $agg{$r->[0]}{total_c}    = $r->[1];
         $agg{$r->[0]}{total_s}    = $r->[2];
@@ -977,14 +983,16 @@ FROM `Frames` WHERE `EventId`=?';
         Error("zmaudit $table aggregate failed: ".$dbh->errstr());
         next;
       }
+      $ok{$key} = 1;
       for my $r (@$rows) {
         $agg{$r->[0]}{$key.'_c'} = $r->[1];
         $agg{$r->[0]}{$key.'_s'} = $r->[2];
       }
     }
 
-    # Include monitors that have an Event_Summaries row but no Events rows so
-    # we still zero them out instead of leaving stale counters.
+    # Include monitors that have an Event_Summaries row but no rows in any
+    # successfully-aggregated source — those need to be zeroed for the
+    # column groups we did read.
     my $existing = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
     if ($dbh->err()) {
       Error("zmaudit Event_Summaries enumerate failed: ".$dbh->errstr());
@@ -992,27 +1000,34 @@ FROM `Frames` WHERE `EventId`=?';
       $agg{$_} ||= {} for @$existing;
     }
 
-    for my $mid (sort { $a <=> $b } keys %agg) {
-      my $a = $agg{$mid};
-      ZoneMinder::Database::zmDbDo(
-        'UPDATE Event_Summaries SET '.
-          'TotalEvents=?, TotalEventDiskSpace=?, '.
-          'ArchivedEvents=?, ArchivedEventDiskSpace=?, '.
-          'HourEvents=?, HourEventDiskSpace=?, '.
-          'DayEvents=?, DayEventDiskSpace=?, '.
-          'WeekEvents=?, WeekEventDiskSpace=?, '.
-          'MonthEvents=?, MonthEventDiskSpace=? '.
-        'WHERE MonitorId=?',
-        $a->{total_c}    // 0, $a->{total_s}    // 0,
-        $a->{archived_c} // 0, $a->{archived_s} // 0,
-        $a->{h_c}        // 0, $a->{h_s}        // 0,
-        $a->{d_c}        // 0, $a->{d_s}        // 0,
-        $a->{w_c}        // 0, $a->{w_s}        // 0,
-        $a->{m_c}        // 0, $a->{m_s}        // 0,
-        $mid
-      );
+    # Build the SET clause from only the column groups we successfully read.
+    my @set;
+    my @bind_template;
+    if ($ok{events}) {
+      push @set, 'TotalEvents=?, TotalEventDiskSpace=?, ArchivedEvents=?, ArchivedEventDiskSpace=?';
+      push @bind_template, qw(total_c total_s archived_c archived_s);
     }
-    aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+    for my $bucket (['h','Hour'], ['d','Day'], ['w','Week'], ['m','Month']) {
+      my ($key, $col) = @$bucket;
+      next unless $ok{$key};
+      push @set, "${col}Events=?, ${col}EventDiskSpace=?";
+      push @bind_template, $key.'_c', $key.'_s';
+    }
+
+    if (@set) {
+      my $sql = 'UPDATE Event_Summaries SET '.join(', ', @set).' WHERE MonitorId=?';
+      for my $mid (sort { $a <=> $b } keys %agg) {
+        my $a = $agg{$mid};
+        ZoneMinder::Database::zmDbDo(
+          $sql,
+          (map { $a->{$_} // 0 } @bind_template),
+          $mid
+        );
+      }
+      aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+    } else {
+      Error('zmaudit: every Event_Summaries aggregate SELECT failed; skipping resync');
+    }
   }
 
   # Storage DiskSpace resync: same trap. Snapshot per-Storage sums via plain

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -1025,15 +1025,28 @@ FROM `Frames` WHERE `EventId`=?';
 
     if (@set) {
       my $sql = 'UPDATE Event_Summaries SET '.join(', ', @set).' WHERE MonitorId=?';
+      my $update_attempted = 0;
+      my $update_failed    = 0;
       for my $mid (sort { $a <=> $b } keys %agg) {
         my $a = $agg{$mid};
-        ZoneMinder::Database::zmDbDo(
+        $update_attempted++;
+        my $rv = ZoneMinder::Database::zmDbDo(
           $sql,
           (map { $a->{$_} // 0 } @bind_template),
           $mid
         );
+        $update_failed++ if !defined $rv;
       }
-      aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+      my @skipped = grep { !$ok{$_} } qw(events h d w m);
+      if (!@skipped and !$update_failed) {
+        aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+      } else {
+        aud_print(sprintf(
+          'Partial Event_Summaries resync: skipped aggregates [%s], %d/%d per-monitor UPDATE(s) failed',
+          join(',', @skipped) || 'none',
+          $update_failed, $update_attempted
+        ));
+      }
     } else {
       Error('zmaudit: every Event_Summaries aggregate SELECT failed; skipping resync');
     }
@@ -1042,6 +1055,7 @@ FROM `Frames` WHERE `EventId`=?';
   # Storage DiskSpace resync: same trap. Snapshot per-Storage sums via plain
   # SELECT, then UPDATE Storage one row at a time.
   {
+    my $storage_done = 0;
     my $rows = $dbh->selectall_arrayref(
       'SELECT StorageId, COALESCE(SUM(DiskSpace), 0) FROM Events GROUP BY StorageId'
     );
@@ -1053,15 +1067,25 @@ FROM `Frames` WHERE `EventId`=?';
       if ($dbh->err()) {
         Error('zmaudit Storage enumerate failed: '.$dbh->errstr());
       } else {
+        my $attempted = 0;
+        my $failed    = 0;
         for my $sid (@$storage_ids) {
-          ZoneMinder::Database::zmDbDo(
+          $attempted++;
+          my $rv = ZoneMinder::Database::zmDbDo(
             'UPDATE Storage SET DiskSpace=? WHERE Id=?',
             $disk{$sid} // 0, $sid
           );
+          $failed++ if !defined $rv;
+        }
+        if (!$failed) {
+          aud_print('Finished updating Storage DiskSpace');
+          $storage_done = 1;
+        } else {
+          aud_print("Partial Storage DiskSpace update: $failed/$attempted row(s) failed");
         }
       }
     }
-    aud_print('Finished updating Storage DiskSpace');
+    Error('zmaudit Storage DiskSpace resync did not complete') if !$storage_done;
   }
 
   sleep($Config{ZM_AUDIT_CHECK_INTERVAL}) if $continuous;

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -940,6 +940,15 @@ FROM `Frames` WHERE `EventId`=?';
   # per monitor against Event_Summaries. Each UPDATE only X-locks the one ES
   # row it targets and reads no other table, so it can't form a cycle with
   # the trigger writers.
+  #
+  # Atomicity tradeoff (same as zmstats.pl): a concurrent trigger writer can
+  # adjust ES between our snapshot SELECTs and the per-monitor UPDATE; our
+  # UPDATE then overwrites that adjustment with the older snapshot. This is
+  # intentional. zmaudit is a periodic ground-truth resync — incremental
+  # trigger maintenance carries ES correctly between zmaudit passes, and any
+  # drift introduced by this race is bounded and corrected on the next pass.
+  # Locking ES before reading the aggregates would invert the canonical lock
+  # order and re-introduce the deadlock this rewrite eliminated.
   {
     my %agg;
     # All-or-nothing per column group: a transient SELECT failure must not

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -1001,11 +1001,14 @@ FROM `Frames` WHERE `EventId`=?';
 
     # Include monitors that have an Event_Summaries row but no rows in any
     # successfully-aggregated source — those need to be zeroed for the
-    # column groups we did read.
+    # column groups we did read. If we can't enumerate, we can't claim a
+    # full resync regardless of which aggregates succeeded.
+    my $enumerate_ok = 0;
     my $existing = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
     if ($dbh->err()) {
       Error("zmaudit Event_Summaries enumerate failed: ".$dbh->errstr());
     } else {
+      $enumerate_ok = 1;
       $agg{$_} ||= {} for @$existing;
     }
 
@@ -1038,12 +1041,13 @@ FROM `Frames` WHERE `EventId`=?';
         $update_failed++ if !defined $rv;
       }
       my @skipped = grep { !$ok{$_} } qw(events h d w m);
-      if (!@skipped and !$update_failed) {
+      if (!@skipped and !$update_failed and $enumerate_ok) {
         aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
       } else {
         aud_print(sprintf(
-          'Partial Event_Summaries resync: skipped aggregates [%s], %d/%d per-monitor UPDATE(s) failed',
+          'Partial Event_Summaries resync: skipped aggregates [%s], enumerate %s, %d/%d per-monitor UPDATE(s) failed',
           join(',', @skipped) || 'none',
+          $enumerate_ok ? 'ok' : 'failed',
           $update_failed, $update_attempted
         ));
       }

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -1072,9 +1072,14 @@ FROM `Frames` WHERE `EventId`=?';
         my @target = map { $a->{$_->[2]} // 0 } @set_pieces;
         my @cas    = map { $c->{$_->[2]} } @set_pieces;
         # Skip rows where the snapshot already matches every target column.
+        # Compare as strings, not numerics: Perl's != coerces to NV (double)
+        # and collapses BIGINTs above 2^53 to the same value, which would
+        # produce false "already correct" skips that persist across passes.
+        # DBI binds these scalars as strings anyway, so string compare is
+        # the same equality the database will see.
         my $needs_update = 0;
         for my $i (0 .. $#set_pieces) {
-          if (!defined $cas[$i] or $cas[$i] != $target[$i]) { $needs_update = 1; last; }
+          if (!defined $cas[$i] or "$cas[$i]" ne "$target[$i]") { $needs_update = 1; last; }
         }
         if (!$needs_update) { $update_skipped++; next; }
         $update_attempted++;
@@ -1138,8 +1143,10 @@ FROM `Frames` WHERE `EventId`=?';
         for my $r (@$storage_rows) {
           my ($sid, $current) = @$r;
           my $target = $disk{$sid} // 0;
-          # Skip if already correct (avoids redundant X-locks).
-          next if defined $current and $current == $target;
+          # Skip if already correct (avoids redundant X-locks). Compare as
+          # strings to avoid the BIGINT/NV precision-collapse trap — see
+          # the Event_Summaries loop comment for the same issue.
+          next if defined $current and "$current" eq "$target";
           $attempted++;
           # MariaDB null-safe equality (<=>) handles NULL DiskSpace.
           my $rv = ZoneMinder::Database::zmDbDo(

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -941,14 +941,14 @@ FROM `Frames` WHERE `EventId`=?';
   # row it targets and reads no other table, so it can't form a cycle with
   # the trigger writers.
   #
-  # Atomicity tradeoff (same as zmstats.pl): a concurrent trigger writer can
-  # adjust ES between our snapshot SELECTs and the per-monitor UPDATE; our
-  # UPDATE then overwrites that adjustment with the older snapshot. This is
-  # intentional. zmaudit is a periodic ground-truth resync — incremental
-  # trigger maintenance carries ES correctly between zmaudit passes, and any
-  # drift introduced by this race is bounded and corrected on the next pass.
-  # Locking ES before reading the aggregates would invert the canonical lock
-  # order and re-introduce the deadlock this rewrite eliminated.
+  # Atomicity: zmaudit guards each per-monitor UPDATE with a CAS predicate
+  # built from the ES values we read at snapshot time (see "Read current ES
+  # values" below). If a concurrent trigger writer adjusts ES between our
+  # snapshot and our UPDATE, the WHERE doesn't match and we leave their
+  # adjustment in place — necessary here because TotalEvents/ArchivedEvents
+  # have no zmstats correction path, so an overwrite would persist until
+  # the next zmaudit pass. zmstats can skip CAS because its TX holds the
+  # bucket X-locks that gate the trigger writers updating its column set.
   {
     my %agg;
     # All-or-nothing per column group: a transient SELECT failure must not
@@ -999,56 +999,108 @@ FROM `Frames` WHERE `EventId`=?';
       }
     }
 
-    # Include monitors that have an Event_Summaries row but no rows in any
-    # successfully-aggregated source — those need to be zeroed for the
-    # column groups we did read. If we can't enumerate, we can't claim a
-    # full resync regardless of which aggregates succeeded.
+    # Read current ES values alongside the enumerate so we can:
+    #   1. Skip rows that already match the aggregate snapshot (no-op).
+    #   2. CAS-guard the UPDATE so a concurrent trigger writer (zmc insert
+    #      path, event_delete_trigger updating TotalEvents/ArchivedEvents,
+    #      Events_*_update_trigger updating bucket disk-space) that adjusts
+    #      ES between our snapshot and our write doesn't get clobbered.
+    # TotalEvents/ArchivedEvents have no zmstats correction path, so without
+    # CAS a transient race could leave drift until the next zmaudit pass.
+    my %current;
     my $enumerate_ok = 0;
-    my $existing = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
+    my $existing = $dbh->selectall_arrayref(q{
+      SELECT MonitorId,
+             TotalEvents, TotalEventDiskSpace,
+             ArchivedEvents, ArchivedEventDiskSpace,
+             HourEvents, HourEventDiskSpace,
+             DayEvents, DayEventDiskSpace,
+             WeekEvents, WeekEventDiskSpace,
+             MonthEvents, MonthEventDiskSpace
+        FROM Event_Summaries
+    });
     if ($dbh->err()) {
       Error("zmaudit Event_Summaries enumerate failed: ".$dbh->errstr());
     } else {
       $enumerate_ok = 1;
-      $agg{$_} ||= {} for @$existing;
+      for my $r (@$existing) {
+        my $mid = $r->[0];
+        $agg{$mid} ||= {};
+        $current{$mid} = {
+          total_c    => $r->[1],  total_s    => $r->[2],
+          archived_c => $r->[3],  archived_s => $r->[4],
+          h_c        => $r->[5],  h_s        => $r->[6],
+          d_c        => $r->[7],  d_s        => $r->[8],
+          w_c        => $r->[9],  w_s        => $r->[10],
+          m_c        => $r->[11], m_s        => $r->[12],
+        };
+      }
     }
 
-    # Build the SET clause from only the column groups we successfully read.
-    my @set;
-    my @bind_template;
+    # Build SET and CAS-guard parallel lists for the column groups we
+    # successfully read. Each entry: [SET piece, CAS piece, %agg key].
+    my @set_pieces;
     if ($ok{events}) {
-      push @set, 'TotalEvents=?, TotalEventDiskSpace=?, ArchivedEvents=?, ArchivedEventDiskSpace=?';
-      push @bind_template, qw(total_c total_s archived_c archived_s);
+      push @set_pieces,
+        ['TotalEvents=?',            'TotalEvents<=>?',            'total_c'],
+        ['TotalEventDiskSpace=?',    'TotalEventDiskSpace<=>?',    'total_s'],
+        ['ArchivedEvents=?',         'ArchivedEvents<=>?',         'archived_c'],
+        ['ArchivedEventDiskSpace=?', 'ArchivedEventDiskSpace<=>?', 'archived_s'];
     }
     for my $bucket (['h','Hour'], ['d','Day'], ['w','Week'], ['m','Month']) {
       my ($key, $col) = @$bucket;
       next unless $ok{$key};
-      push @set, "${col}Events=?, ${col}EventDiskSpace=?";
-      push @bind_template, $key.'_c', $key.'_s';
+      push @set_pieces,
+        ["${col}Events=?",         "${col}Events<=>?",         $key.'_c'],
+        ["${col}EventDiskSpace=?", "${col}EventDiskSpace<=>?", $key.'_s'];
     }
 
-    if (@set) {
-      my $sql = 'UPDATE Event_Summaries SET '.join(', ', @set).' WHERE MonitorId=?';
+    if (@set_pieces) {
+      my $sql = 'UPDATE Event_Summaries SET '.
+        join(', ', map { $_->[0] } @set_pieces).
+        ' WHERE MonitorId=? AND '.
+        join(' AND ', map { $_->[1] } @set_pieces);
+
       my $update_attempted = 0;
       my $update_failed    = 0;
+      my $update_deferred  = 0;  # CAS lost — concurrent writer adjusted ES
+      my $update_skipped   = 0;  # already correct, no UPDATE needed
       for my $mid (sort { $a <=> $b } keys %agg) {
         my $a = $agg{$mid};
+        my $c = $current{$mid};
+        next if !$c;  # monitor exists in aggregates but not ES; original behavior was to skip
+        my @target = map { $a->{$_->[2]} // 0 } @set_pieces;
+        my @cas    = map { $c->{$_->[2]} } @set_pieces;
+        # Skip rows where the snapshot already matches every target column.
+        my $needs_update = 0;
+        for my $i (0 .. $#set_pieces) {
+          if (!defined $cas[$i] or $cas[$i] != $target[$i]) { $needs_update = 1; last; }
+        }
+        if (!$needs_update) { $update_skipped++; next; }
         $update_attempted++;
         my $rv = ZoneMinder::Database::zmDbDo(
           $sql,
-          (map { $a->{$_} // 0 } @bind_template),
-          $mid
+          @target, $mid, @cas
         );
-        $update_failed++ if !defined $rv;
+        if (!defined $rv) {
+          $update_failed++;
+        } elsif ($rv == 0) {
+          $update_deferred++;
+        }
       }
-      my @skipped = grep { !$ok{$_} } qw(events h d w m);
-      if (!@skipped and !$update_failed and $enumerate_ok) {
-        aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+      my @skipped_aggs = grep { !$ok{$_} } qw(events h d w m);
+      if (!@skipped_aggs and !$update_failed and $enumerate_ok) {
+        if ($update_deferred or $update_skipped) {
+          aud_print("Finished resyncing Event_Summaries ($update_attempted attempted, $update_deferred deferred to concurrent writers, $update_skipped no-op)");
+        } else {
+          aud_print('Finished resyncing Event_Summaries from Events + bucket tables');
+        }
       } else {
         aud_print(sprintf(
-          'Partial Event_Summaries resync: skipped aggregates [%s], enumerate %s, %d/%d per-monitor UPDATE(s) failed',
-          join(',', @skipped) || 'none',
+          'Partial Event_Summaries resync: skipped aggregates [%s], enumerate %s, %d/%d UPDATE(s) failed, %d deferred',
+          join(',', @skipped_aggs) || 'none',
           $enumerate_ok ? 'ok' : 'failed',
-          $update_failed, $update_attempted
+          $update_failed, $update_attempted, $update_deferred
         ));
       }
     } else {

--- a/scripts/zmaudit.pl.in
+++ b/scripts/zmaudit.pl.in
@@ -1056,33 +1056,57 @@ FROM `Frames` WHERE `EventId`=?';
     }
   }
 
-  # Storage DiskSpace resync: same trap. Snapshot per-Storage sums via plain
-  # SELECT, then UPDATE Storage one row at a time.
+  # Storage DiskSpace resync. Unlike Event_Summaries, Storage.DiskSpace is
+  # NOT maintained by DB triggers — Event::delete and the event-finalize
+  # paths do their own +/- adjustments in application code. So overwriting
+  # with a stale absolute snapshot would actively undo a concurrent
+  # adjustment instead of being self-corrected next pass.
+  #
+  # CAS pattern: read DiskSpace alongside the SUM snapshot, then UPDATE
+  # WHERE DiskSpace is still the value we observed. If a concurrent writer
+  # adjusted it between the SELECT and the UPDATE, the WHERE won't match
+  # and we leave their newer adjustment in place. Next zmaudit pass picks
+  # up any residual drift.
   {
     my $storage_done = 0;
-    my $rows = $dbh->selectall_arrayref(
+    my $events_rows = $dbh->selectall_arrayref(
       'SELECT StorageId, COALESCE(SUM(DiskSpace), 0) FROM Events GROUP BY StorageId'
     );
     if ($dbh->err()) {
       Error('zmaudit Storage aggregate failed: '.$dbh->errstr());
     } else {
-      my %disk = map { $_->[0] => $_->[1] } grep { defined $_->[0] } @$rows;
-      my $storage_ids = $dbh->selectcol_arrayref('SELECT Id FROM Storage');
+      my %disk = map { $_->[0] => $_->[1] } grep { defined $_->[0] } @$events_rows;
+      my $storage_rows = $dbh->selectall_arrayref('SELECT Id, DiskSpace FROM Storage');
       if ($dbh->err()) {
         Error('zmaudit Storage enumerate failed: '.$dbh->errstr());
       } else {
         my $attempted = 0;
         my $failed    = 0;
-        for my $sid (@$storage_ids) {
+        my $deferred  = 0;
+        for my $r (@$storage_rows) {
+          my ($sid, $current) = @$r;
+          my $target = $disk{$sid} // 0;
+          # Skip if already correct (avoids redundant X-locks).
+          next if defined $current and $current == $target;
           $attempted++;
+          # MariaDB null-safe equality (<=>) handles NULL DiskSpace.
           my $rv = ZoneMinder::Database::zmDbDo(
-            'UPDATE Storage SET DiskSpace=? WHERE Id=?',
-            $disk{$sid} // 0, $sid
+            'UPDATE Storage SET DiskSpace=? WHERE Id=? AND DiskSpace <=> ?',
+            $target, $sid, $current
           );
-          $failed++ if !defined $rv;
+          if (!defined $rv) {
+            $failed++;
+          } elsif ($rv == 0) {
+            # CAS lost: concurrent writer adjusted DiskSpace. Leave theirs.
+            $deferred++;
+          }
         }
         if (!$failed) {
-          aud_print('Finished updating Storage DiskSpace');
+          if ($deferred) {
+            aud_print("Updated Storage DiskSpace ($attempted attempted, $deferred deferred to concurrent writers)");
+          } else {
+            aud_print('Finished updating Storage DiskSpace');
+          }
           $storage_done = 1;
         } else {
           aud_print("Partial Storage DiskSpace update: $failed/$attempted row(s) failed");

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -87,17 +87,125 @@ while (!$zm_terminate) {
   my $monitor_ids = $dbh->selectcol_arrayref('SELECT MonitorId FROM Monitor_Status WHERE UpdatedOn < timestamp(DATE_SUB(NOW(), INTERVAL 1 MINUTE))');
   zmDbDo('DELETE FROM Monitor_Status WHERE MonitorId IN ('.join(',', map { '?' } @$monitor_ids).')', @$monitor_ids) if $monitor_ids and @$monitor_ids;
 
-  my $event_ids = $dbh->selectcol_arrayref('SELECT EventId FROM Events_Hour WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL 1 hour)');
-  zmDbDo('DELETE FROM Events_Hour WHERE EventId IN ('.join(',', map { '?' } @$event_ids).')', @$event_ids) if $event_ids and @$event_ids;
+  # Prune aged rows from Events_Hour/Day/Week/Month and resync Event_Summaries
+  # in one transaction.
+  #
+  # The resync MUST NOT use a multi-table UPDATE that joins Event_Summaries to
+  # the bucket tables: a multi-table UPDATE takes S-locks on the joined rows
+  # and holds them to TX commit *regardless of isolation level*, which
+  # deadlocks against event_update_trigger / event_delete_trigger holding
+  # X-locks on those same bucket rows. Snapshot the bucket aggregates first
+  # via plain SELECT (consistent read at RC -> no locks), then UPDATE
+  # Event_Summaries one row at a time using the snapshotted values.
+  #
+  # READ COMMITTED is still set for the bucket DELETE range scans, so they
+  # don't take next-key/gap locks against concurrent filter deletes / zma
+  # trigger updates on adjacent EventIds.
+  {
+    my $attempt = 0;
+    my $max_attempts = 5;
+    while (1) {
+      $attempt++;
+      # SET TRANSACTION ... applies only to the next transaction, so it must
+      # be issued before begin_work and re-issued on each retry.
+      zmDbDo('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+      $dbh->begin_work();
 
-  $event_ids = $dbh->selectcol_arrayref('SELECT EventId FROM Events_Day WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL 1 day)');
-  zmDbDo('DELETE FROM Events_Day WHERE EventId IN ('.join(',', map { '?' } @$event_ids).')', @$event_ids) if $event_ids and @$event_ids;
+      my $err = 0;
+      foreach my $bucket (
+        ['Events_Hour',  '1 hour'],
+        ['Events_Day',   '1 day'],
+        ['Events_Week',  '1 week'],
+        ['Events_Month', '1 month'],
+      ) {
+        my ($table, $interval) = @$bucket;
+        my $event_ids = $dbh->selectcol_arrayref(
+          "SELECT EventId FROM $table WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL $interval)"
+        );
+        if ($event_ids and @$event_ids) {
+          zmDbDo(
+            "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @$event_ids).')',
+            @$event_ids
+          );
+          $err = $dbh->err() // 0;
+          last if $err;
+        }
+      }
 
-  $event_ids = $dbh->selectcol_arrayref('SELECT EventId FROM Events_Week WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL 1 week)');
-  zmDbDo('DELETE FROM Events_Week WHERE EventId IN ('.join(',', map { '?' } @$event_ids).')', @$event_ids) if $event_ids and @$event_ids;
+      # Snapshot the per-monitor bucket aggregates. Plain SELECT under RC is
+      # a consistent read and takes no row locks, so this can't deadlock with
+      # the trigger writers.
+      my %agg;
+      if (!$err) {
+        foreach my $bucket (
+          ['Events_Hour',  'h'],
+          ['Events_Day',   'd'],
+          ['Events_Week',  'w'],
+          ['Events_Month', 'm'],
+        ) {
+          my ($table, $key) = @$bucket;
+          my $rows = $dbh->selectall_arrayref(
+            "SELECT MonitorId, COUNT(*), COALESCE(SUM(DiskSpace), 0) FROM $table GROUP BY MonitorId"
+          );
+          $err = $dbh->err() // 0;
+          last if $err;
+          for my $r (@$rows) {
+            $agg{$r->[0]}{$key.'_c'} = $r->[1];
+            $agg{$r->[0]}{$key.'_s'} = $r->[2];
+          }
+        }
+      }
 
-  $event_ids = $dbh->selectcol_arrayref('SELECT EventId FROM Events_Month WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL 1 month)');
-  zmDbDo('DELETE FROM Events_Month WHERE EventId IN ('.join(',', map { '?' } @$event_ids).')', @$event_ids) if $event_ids and @$event_ids;
+      # Pull the universe of MonitorIds from Event_Summaries so any monitor
+      # with zero rows in every bucket still gets zeroed out.
+      if (!$err) {
+        my $monitor_ids = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
+        $err = $dbh->err() // 0;
+        if (!$err) {
+          for my $mid (@$monitor_ids) {
+            $agg{$mid} ||= {};
+          }
+        }
+      }
+
+      # One UPDATE per monitor: each takes a single ES X-lock and reads
+      # nothing else, so it can't hold any bucket-row lock that would
+      # deadlock with the trigger path.
+      if (!$err) {
+        for my $mid (sort { $a <=> $b } keys %agg) {
+          my $a = $agg{$mid};
+          zmDbDo(
+            'UPDATE Event_Summaries SET '.
+              'HourEvents=?, HourEventDiskSpace=?, '.
+              'DayEvents=?, DayEventDiskSpace=?, '.
+              'WeekEvents=?, WeekEventDiskSpace=?, '.
+              'MonthEvents=?, MonthEventDiskSpace=? '.
+            'WHERE MonitorId=?',
+            $a->{h_c} // 0, $a->{h_s} // 0,
+            $a->{d_c} // 0, $a->{d_s} // 0,
+            $a->{w_c} // 0, $a->{w_s} // 0,
+            $a->{m_c} // 0, $a->{m_s} // 0,
+            $mid
+          );
+          $err = $dbh->err() // 0;
+          last if $err;
+        }
+      }
+
+      if (!$err) {
+        $dbh->commit();
+        last;
+      }
+
+      $dbh->rollback();
+      if ($err != 1213 or $attempt >= $max_attempts) {
+        Error("Event_Summaries prune+resync gave up after $attempt attempt(s): ".$dbh->errstr());
+        last;
+      }
+      Debug("Deadlock during Event_Summaries prune+resync, attempt $attempt/$max_attempts");
+      select(undef, undef, undef, 0.05 * (1 << $attempt) + rand(0.05));
+    }
+  }
 
   # Prune the Logs table if required (excluding AUDIT entries)
   if ( $Config{ZM_LOG_DATABASE_LIMIT} ) {

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -101,6 +101,15 @@ while (!$zm_terminate) {
   # READ COMMITTED is still set for the bucket DELETE range scans, so they
   # don't take next-key/gap locks against concurrent filter deletes / zma
   # trigger updates on adjacent EventIds.
+  #
+  # Atomicity tradeoff: between the per-bucket aggregate SELECT and the
+  # per-monitor UPDATE, a concurrent trigger writer (zma/zmc/Event::delete)
+  # can adjust Event_Summaries via the canonical lock chain. Our subsequent
+  # UPDATE will overwrite that adjustment with our older snapshot. This is
+  # intentional and safe: the bucket triggers keep ES drift bounded between
+  # zmstats passes, and any drift introduced by this race is corrected on
+  # the next pass. Locking ES before the snapshot would invert the canonical
+  # order and re-introduce the deadlock cycle this rewrite eliminated.
   {
     my $attempt = 0;
     my $max_attempts = 5;

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -116,8 +116,12 @@ while (!$zm_terminate) {
     while (1) {
       $attempt++;
       # SET TRANSACTION ... applies only to the next transaction, so it must
-      # be issued before begin_work and re-issued on each retry.
-      zmDbDo('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+      # be issued before begin_work and re-issued on each retry. Use
+      # $dbh->do directly, NOT zmDbDo: zmDbDo's success Debug would write to
+      # the Logs table on this same $dbh, and that INSERT would become the
+      # "next transaction" that consumes the isolation directive — silently
+      # dropping our prune+resync TX back to the default.
+      $dbh->do('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
       $dbh->begin_work();
 
       my $err = 0;

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -127,6 +127,13 @@ while (!$zm_terminate) {
       my $err = 0;
       my $errstr;  # captured before rollback() — rollback can clear errstr
       my %touched_monitors;  # MonitorIds whose buckets we just modified
+      # Chunk size for DELETE WHERE EventId IN (...) — keeps each DELETE
+      # well under max_allowed_packet / max_prepared_stmt_count on installs
+      # where Events_Month has accumulated tens of thousands of aged rows,
+      # while preserving PK-based per-row locking (DELETE by predicate would
+      # range-lock the bucket index and re-introduce the lock-ordering
+      # inversions this rewrite was meant to eliminate).
+      my $delete_chunk = 1000;
       foreach my $bucket (
         ['Events_Hour',  '1 hour'],
         ['Events_Day',   '1 day'],
@@ -142,11 +149,17 @@ while (!$zm_terminate) {
         next if !$rows or !@$rows;
         my @event_ids = map { $_->[0] } @$rows;
         $touched_monitors{$_->[1]} = 1 for @$rows;
-        zmDbDo(
-          "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @event_ids).')',
-          @event_ids
-        );
-        $err = $dbh->err() // 0;
+        for (my $i = 0; $i < @event_ids; $i += $delete_chunk) {
+          my $end = $i + $delete_chunk - 1;
+          $end = $#event_ids if $end > $#event_ids;
+          my @batch = @event_ids[$i .. $end];
+          zmDbDo(
+            "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @batch).')',
+            @batch
+          );
+          $err = $dbh->err() // 0;
+          last if $err;
+        }
         if ($err) { $errstr = $dbh->errstr() // ''; last; }
       }
 

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -122,6 +122,8 @@ while (!$zm_terminate) {
         my $event_ids = $dbh->selectcol_arrayref(
           "SELECT EventId FROM $table WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL $interval)"
         );
+        $err = $dbh->err() // 0;
+        last if $err;
         if ($event_ids and @$event_ids) {
           zmDbDo(
             "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @$event_ids).')',

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -121,6 +121,8 @@ while (!$zm_terminate) {
       $dbh->begin_work();
 
       my $err = 0;
+      my $errstr;  # captured before rollback() — rollback can clear errstr
+      my %touched_monitors;  # MonitorIds whose buckets we just modified
       foreach my $bucket (
         ['Events_Hour',  '1 hour'],
         ['Events_Day',   '1 day'],
@@ -128,26 +130,37 @@ while (!$zm_terminate) {
         ['Events_Month', '1 month'],
       ) {
         my ($table, $interval) = @$bucket;
-        my $event_ids = $dbh->selectcol_arrayref(
-          "SELECT EventId FROM $table WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL $interval)"
+        my $rows = $dbh->selectall_arrayref(
+          "SELECT EventId, MonitorId FROM $table WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL $interval)"
         );
         $err = $dbh->err() // 0;
-        last if $err;
-        if ($event_ids and @$event_ids) {
-          zmDbDo(
-            "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @$event_ids).')',
-            @$event_ids
-          );
-          $err = $dbh->err() // 0;
-          last if $err;
-        }
+        if ($err) { $errstr = $dbh->errstr() // ''; last; }
+        next if !$rows or !@$rows;
+        my @event_ids = map { $_->[0] } @$rows;
+        $touched_monitors{$_->[1]} = 1 for @$rows;
+        zmDbDo(
+          "DELETE FROM $table WHERE EventId IN (".join(',', map { '?' } @event_ids).')',
+          @event_ids
+        );
+        $err = $dbh->err() // 0;
+        if ($err) { $errstr = $dbh->errstr() // ''; last; }
       }
 
-      # Snapshot the per-monitor bucket aggregates. Plain SELECT under RC is
-      # a consistent read and takes no row locks, so this can't deadlock with
-      # the trigger writers.
-      my %agg;
-      if (!$err) {
+      # Only resync ES for monitors we actually touched in this cycle. If
+      # nothing was pruned, the bucket triggers maintain ES correctly between
+      # zmstats passes; zmaudit is the periodic deep-resync safety net.
+      # Restricting to touched monitors also avoids X-locking every ES row
+      # on every zmstats cycle (which would contend with the trigger writers
+      # this rewrite is meant to protect).
+      if (!$err and %touched_monitors) {
+        my @mids = sort { $a <=> $b } keys %touched_monitors;
+        my $placeholders = join(',', map { '?' } @mids);
+
+        # Snapshot the per-monitor bucket aggregates for the touched monitors
+        # only. Plain SELECT under RC is a consistent read and takes no row
+        # locks, so this can't deadlock with the trigger writers.
+        my %agg;
+        $agg{$_} ||= {} for @mids;  # seed so monitors with zero rows still get zeroed
         foreach my $bucket (
           ['Events_Hour',  'h'],
           ['Events_Day',   'd'],
@@ -156,55 +169,46 @@ while (!$zm_terminate) {
         ) {
           my ($table, $key) = @$bucket;
           my $rows = $dbh->selectall_arrayref(
-            "SELECT MonitorId, COUNT(*), COALESCE(SUM(DiskSpace), 0) FROM $table GROUP BY MonitorId"
+            "SELECT MonitorId, COUNT(*), COALESCE(SUM(DiskSpace), 0) FROM $table".
+            " WHERE MonitorId IN ($placeholders) GROUP BY MonitorId",
+            undef, @mids
           );
           $err = $dbh->err() // 0;
-          last if $err;
+          if ($err) { $errstr = $dbh->errstr() // ''; last; }
           for my $r (@$rows) {
             $agg{$r->[0]}{$key.'_c'} = $r->[1];
             $agg{$r->[0]}{$key.'_s'} = $r->[2];
           }
         }
-      }
 
-      # Pull the universe of MonitorIds from Event_Summaries so any monitor
-      # with zero rows in every bucket still gets zeroed out.
-      if (!$err) {
-        my $monitor_ids = $dbh->selectcol_arrayref('SELECT MonitorId FROM Event_Summaries');
-        $err = $dbh->err() // 0;
+        # One UPDATE per touched monitor. The transaction at this point is
+        # still holding the bucket-row X-locks acquired by the earlier
+        # DELETEs and any ES X-locks the bucket DELETE triggers acquired as
+        # a cascade. Those were all acquired in the canonical order
+        # (buckets -> ES) so they don't conflict with the trigger writers.
+        # The new statement itself only X-locks the one ES row it targets
+        # and reads no other table, so it doesn't add any cross-table
+        # dependency that could form a new cycle — its lock acquisition
+        # continues in the same direction.
         if (!$err) {
-          for my $mid (@$monitor_ids) {
-            $agg{$mid} ||= {};
+          for my $mid (@mids) {
+            my $a = $agg{$mid};
+            zmDbDo(
+              'UPDATE Event_Summaries SET '.
+                'HourEvents=?, HourEventDiskSpace=?, '.
+                'DayEvents=?, DayEventDiskSpace=?, '.
+                'WeekEvents=?, WeekEventDiskSpace=?, '.
+                'MonthEvents=?, MonthEventDiskSpace=? '.
+              'WHERE MonitorId=?',
+              $a->{h_c} // 0, $a->{h_s} // 0,
+              $a->{d_c} // 0, $a->{d_s} // 0,
+              $a->{w_c} // 0, $a->{w_s} // 0,
+              $a->{m_c} // 0, $a->{m_s} // 0,
+              $mid
+            );
+            $err = $dbh->err() // 0;
+            if ($err) { $errstr = $dbh->errstr() // ''; last; }
           }
-        }
-      }
-
-      # One UPDATE per monitor. The transaction at this point is still
-      # holding the bucket-row X-locks acquired by the earlier DELETEs and
-      # any ES X-locks the bucket DELETE triggers acquired as a cascade.
-      # Those were all acquired in the canonical order (buckets -> ES) so
-      # they don't conflict with the trigger writers. The new statement
-      # itself only X-locks the one ES row it targets and reads no other
-      # table, so it doesn't add any cross-table dependency that could form
-      # a new cycle — its lock acquisition continues in the same direction.
-      if (!$err) {
-        for my $mid (sort { $a <=> $b } keys %agg) {
-          my $a = $agg{$mid};
-          zmDbDo(
-            'UPDATE Event_Summaries SET '.
-              'HourEvents=?, HourEventDiskSpace=?, '.
-              'DayEvents=?, DayEventDiskSpace=?, '.
-              'WeekEvents=?, WeekEventDiskSpace=?, '.
-              'MonthEvents=?, MonthEventDiskSpace=? '.
-            'WHERE MonitorId=?',
-            $a->{h_c} // 0, $a->{h_s} // 0,
-            $a->{d_c} // 0, $a->{d_s} // 0,
-            $a->{w_c} // 0, $a->{w_s} // 0,
-            $a->{m_c} // 0, $a->{m_s} // 0,
-            $mid
-          );
-          $err = $dbh->err() // 0;
-          last if $err;
         }
       }
 
@@ -215,7 +219,7 @@ while (!$zm_terminate) {
 
       $dbh->rollback();
       if ($err != 1213 or $attempt >= $max_attempts) { # 1213 = ER_LOCK_DEADLOCK
-        Error("Event_Summaries prune+resync gave up after $attempt attempt(s): ".$dbh->errstr());
+        Error("Event_Summaries prune+resync gave up after $attempt attempt(s): ".($errstr // ''));
         last;
       }
       Debug("Deadlock during Event_Summaries prune+resync, attempt $attempt/$max_attempts");

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -200,7 +200,7 @@ while (!$zm_terminate) {
       }
 
       $dbh->rollback();
-      if ($err != 1213 or $attempt >= $max_attempts) {
+      if ($err != 1213 or $attempt >= $max_attempts) { # 1213 = ER_LOCK_DEADLOCK
         Error("Event_Summaries prune+resync gave up after $attempt attempt(s): ".$dbh->errstr());
         last;
       }

--- a/scripts/zmstats.pl.in
+++ b/scripts/zmstats.pl.in
@@ -179,9 +179,14 @@ while (!$zm_terminate) {
         }
       }
 
-      # One UPDATE per monitor: each takes a single ES X-lock and reads
-      # nothing else, so it can't hold any bucket-row lock that would
-      # deadlock with the trigger path.
+      # One UPDATE per monitor. The transaction at this point is still
+      # holding the bucket-row X-locks acquired by the earlier DELETEs and
+      # any ES X-locks the bucket DELETE triggers acquired as a cascade.
+      # Those were all acquired in the canonical order (buckets -> ES) so
+      # they don't conflict with the trigger writers. The new statement
+      # itself only X-locks the one ES row it targets and reads no other
+      # table, so it doesn't add any cross-table dependency that could form
+      # a new cycle — its lock acquisition continues in the same direction.
       if (!$err) {
         for my $mid (sort { $a <=> $b } keys %agg) {
           my $a = $agg{$mid};


### PR DESCRIPTION
## Summary

Eliminates the recurring InnoDB deadlock cycle observed under load between `zma`'s `event_update_trigger` path, `zmstats.pl`'s Event_Summaries maintenance, `zmaudit.pl`'s aggregations, and `zmfilter.pl` (`Event::delete`).

The root cause was a multi-table `UPDATE Event_Summaries es JOIN Events_Hour ...` pattern: MariaDB takes S-locks on the joined bucket rows and holds them to TX commit *regardless of isolation level*, which inverts the canonical lock order

```
Events[Id] -> buckets[EventId] -> Event_Summaries[MonitorId]
```

against the trigger writers that hold X-locks on those same bucket rows. The InnoDB deadlock log captured the exact `zma` vs `zmstats` cycle.

### What changes

* **`zmDbDo` auto-retries on errno 1213** (5 attempts, exponential backoff with jitter) when called outside an explicit transaction. Most call sites are autocommit-style and already idempotent on retry.
* **`Event::delete`** sets `READ COMMITTED` for the per-event delete TX, runs Stats/Event_Data/Frames/Events deletes, and retries the whole TX on 1213. Also fixes a latent `commit()` -> `rollback()` bug on the error path.
* **`zmstats.pl` Event_Summaries maintenance** is rewritten to:
  1. Prune aged rows from `Events_Hour/Day/Week/Month` (RC, no gap locks).
  2. Snapshot per-monitor counts/disk-space via plain `SELECT` (consistent read at RC, no locks).
  3. Apply one `UPDATE Event_Summaries` per `MonitorId` using the snapshotted values.
  
  This keeps the lock prefix (`buckets -> Event_Summaries`) consistent with the trigger path and never holds bucket S-locks while writing ES. Wrapped in 5-retry deadlock loop.
* **`zmaudit.pl`** receives the same snapshot-then-per-row treatment for its Event_Summaries and Storage `DiskSpace` recomputations, replacing five correlated/JOINed UPDATEs that had the same lock-ordering hazard.
* **`db/triggers.sql`** picks up a comment block above `event_update_trigger` documenting the canonical lock acquisition order so future writers don't reintroduce the cycle.

### Why isolation level alone wasn't enough

`SET TRANSACTION ISOLATION LEVEL READ COMMITTED` drops the next-key/gap locks on plain DELETE/UPDATE range scans, but a multi-table UPDATE *always* takes S-locks on the JOINed rows for as long as the transaction lives. The structural fix had to be removing the JOIN, not lowering isolation.

### Notes for reviewers

* No schema changes. Pure script + Perl module + retry-loop changes plus one comment block in `triggers.sql`.
* The `zmDbDo` retry is conditional on `AutoCommit` — it will not silently re-run statements that are part of an explicit caller transaction (those callers are responsible for their own retry, e.g. the `Event::delete` loop).
* `Event::delete`'s isolation set + retry path is bypassed when the caller is already inside a transaction (`$in_transaction` short-circuit), so callers that wrap multiple deletes in their own TX keep their semantics.

## Test plan

- [ ] Build clean (`cmake --build build`) — Perl scripts go through cmake `configure_file`.
- [ ] `perl -c` on the touched modules with a real install (placeholders substituted).
- [ ] Run `zmstats.pl`, `zmaudit.pl` against a busy install and confirm no `Deadlock found` errors in `/var/log/zm/`.
- [ ] Force contention by deleting a hot event via filter while `zma` is updating the same monitor; confirm `Event::delete` retries succeed and the row is removed.
- [ ] Verify Event_Summaries totals match recomputed `SUM(DiskSpace)/COUNT(*)` from the bucket tables after a full `zmstats` cycle.
- [ ] Confirm `zmaudit.pl --interactive` Storage DiskSpace UPDATE still produces correct totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)