### PR TITLE
Fix: Correct end timestamp of events when exporting MP4 for multiple events

### DIFF
--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -169,7 +169,7 @@ function downloadEvents(
 
   if (count($exportFileList) === 0) {
    ZM\Warning('No events were found for export.');
-   return "";
+   return false;
   }
 
   generateFileList($exportFormat, $exportStructure, $archive_path, $exportCompressed, $export_dir, $export_root, $exportFileList);

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -116,7 +116,7 @@ function downloadEvents(
         $maxTime = $event->EndDateTime();
       }
       $fileName = basename(findVideoEventFile($event));
-      if (strpos($fileName, 'incomplete') !== -1) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
+      if (strpos($fileName, 'incomplete') !== false) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
       $eventFileList .= 'file \''.$event->Path().'/'.$fileName.'\''.PHP_EOL;
     }
 

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -105,6 +105,11 @@ function downloadEvents(
     $maxTimeSecs = -1;
     $maxTime = '';
     foreach ($events_by_monitor_id[$mid] as $event) {
+      $filePath = findVideoEventFile($event);
+      if ($filePath ==='') {
+        ZM\Warning('The file path for event '.$event->Id().' was not found.');
+        continue;
+      }
       if ($minTimeSecs == -1 or $minTimeSecs > $event->StartDateTimeSecs()) {
         $minTimeSecs = $event->StartDateTimeSecs();
         $minTime = $event->StartDateTime();
@@ -115,9 +120,14 @@ function downloadEvents(
         $maxTimeSecs = $endSecs;
         $maxTime = $event->EndDateTime();
       }
-      $fileName = basename(findVideoEventFile($event));
+
+      $fileName = basename($filePath);
       if (strpos($fileName, 'incomplete') !== false) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
       $eventFileList .= 'file \''.$event->Path().'/'.$fileName.'\''.PHP_EOL;
+
+    if ($eventFileList === '') {
+      ZM\Warning('No event files were found for exporting monitor events with ID='.$event->MonitorId());
+      continue;
     }
 
     $mergedFileName = $monitor->Name().' '.$minTime.' to '.$maxTime.'.mp4';
@@ -155,6 +165,11 @@ function downloadEvents(
       if (executeShelCommand($command, $deleteFile = $mergedFileName) === false) return false;
     }
   } # end foreach monitor
+
+  if (count($exportFileList) === 0) {
+   ZM\Warning('No events were found for export.');
+   return "";
+  }
 
   generateFileList($exportFormat, $exportStructure, $archive_path, $exportCompressed, $export_dir, $export_root, $exportFileList);
 

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -105,7 +105,7 @@ function downloadEvents(
     $maxTimeSecs = -1;
     $maxTime = '';
     foreach ($events_by_monitor_id[$mid] as $event) {
-      $filePath = findVideoEventFile($event);
+      $filePath = findVideoEventFile($event, "mp4");
       if ($filePath ==='') {
         ZM\Warning('The file path for event '.$event->Id().' was not found.');
         continue;

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -115,10 +115,11 @@ function downloadEvents(
         $maxTimeSecs = $endSecs;
         $maxTime = $event->EndDateTime();
       }
-      $eventFileList .= 'file \''.$event->Path().'/'.basename(findVideoEventFile($event)).'\''.PHP_EOL;
+      $fileName = basename(findVideoEventFile($event));
+      if (strpos($fileName, 'incomplete') !== -1) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
+      $eventFileList .= 'file \''.$event->Path().'/'.$fileName.'\''.PHP_EOL;
     }
 
-    $maxTime = ($maxTime !== '') ?: date('Y-m-d H:i:s'); # Probably incomplete event.
     $mergedFileName = $monitor->Name().' '.$minTime.' to '.$maxTime.'.mp4';
     if (($fp = fopen('event_files.txt', 'w'))) {
       fwrite($fp, $eventFileList);

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -96,7 +96,7 @@ function downloadEvents(
     }
 
     usort($events_by_monitor_id[$mid], function($a, $b) {
-        return strtotime($a->StartDateTime) <=> strtotime($b->StartDateTime);
+      return strtotime($a->StartDateTime) <=> strtotime($b->StartDateTime);
     });
 
     $eventFileList = '';
@@ -109,13 +109,16 @@ function downloadEvents(
         $minTimeSecs = $event->StartDateTimeSecs();
         $minTime = $event->StartDateTime();
       }
-      if ($maxTimeSecs == -1 or $maxTimeSecs < $event->StartDateTimeSecs()) {
-        $maxTimeSecs = $event->EndDateTimeSecs();
+
+      $endSecs = $event->EndDateTimeSecs();
+      if ($endSecs and ($maxTimeSecs == -1 or $maxTimeSecs < $endSecs)) {
+        $maxTimeSecs = $endSecs;
         $maxTime = $event->EndDateTime();
       }
-      $eventFileList .= 'file \''.$event->Path().'/'.$event->DefaultVideo().'\''.PHP_EOL;
+      $eventFileList .= 'file \''.$event->Path().'/'.basename(findVideoEventFile($event)).'\''.PHP_EOL;
     }
 
+    $maxTime = ($maxTime !== '') ?: date('Y-m-d H:i:s'); # Probably incomplete event.
     $mergedFileName = $monitor->Name().' '.$minTime.' to '.$maxTime.'.mp4';
     if (($fp = fopen('event_files.txt', 'w'))) {
       fwrite($fp, $eventFileList);

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -122,7 +122,7 @@ function downloadEvents(
       }
 
       $fileName = basename($filePath);
-      if (strpos($fileName, 'incomplete') !== false) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
+      if (strpos($fileName, 'incomplete') !== false && !$endSecs) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
       $eventFileList .= 'file \''.$event->Path().'/'.$fileName.'\''.PHP_EOL;
     }
 
@@ -131,6 +131,7 @@ function downloadEvents(
       continue;
     }
 
+    if (!$maxTime) $maxTime = date('Y-m-d H:i:s'); # For example, we download a single non-incomlete event, but it's missing EndDateTimeSecs() due to a crash
     $mergedFileName = $monitor->Name().' '.$minTime.' to '.$maxTime.'.mp4';
     if (($fp = fopen('event_files.txt', 'w'))) {
       fwrite($fp, $eventFileList);

--- a/web/includes/download_functions.php
+++ b/web/includes/download_functions.php
@@ -124,9 +124,10 @@ function downloadEvents(
       $fileName = basename($filePath);
       if (strpos($fileName, 'incomplete') !== false) $maxTime = date('Y-m-d H:i:s'); # Probably incomplete event.
       $eventFileList .= 'file \''.$event->Path().'/'.$fileName.'\''.PHP_EOL;
+    }
 
     if ($eventFileList === '') {
-      ZM\Warning('No event files were found for exporting monitor events with ID='.$event->MonitorId());
+      ZM\Warning('No event files were found for exporting monitor events with ID='.$mid);
       continue;
     }
 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2488,6 +2488,7 @@ function findVideoEventFile ($Event) {
   $dir = $Event->Path();
   $eventDefaultVideo = to_string($Event->DefaultVideo());
   $path = ($eventDefaultVideo !== '' && !str_ends_with($eventDefaultVideo, '.m3u8')) ? $dir.'/'.$eventDefaultVideo : '';
+  if (!is_file($path)) $path = ''; # So we don't return a reference to a non-existent file.
 
   if ($path === '') {
     // Look for the final renamed mp4 first, then incomplete

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2486,8 +2486,8 @@ function to_string($thing) {
 
 function findVideoEventFile ($Event) {
   $dir = $Event->Path();
-  $eventDefaultVideo = $Event->DefaultVideo();
-  $path = (!str_ends_with($eventDefaultVideo, '.m3u8')) ? $dir.'/'.$eventDefaultVideo : '';
+  $eventDefaultVideo = to_string($Event->DefaultVideo());
+  $path = ($eventDefaultVideo !== '' && !str_ends_with($eventDefaultVideo, '.m3u8')) ? $dir.'/'.$eventDefaultVideo : '';
 
   if ($path === '') {
     // Look for the final renamed mp4 first, then incomplete

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2484,16 +2484,44 @@ function to_string($thing) {
   return strval($thing);
 }
 
-function findVideoEventFile ($Event) {
+if (!function_exists('mb_ucfirst')) { // Available in PHP >= 8.4
+  function mb_ucfirst($str, $encoding='UTF-8') {
+    if (extension_loaded('mbstring')) {
+      $result = mb_strtoupper(mb_substr($str, 0, 1, $encoding), $encoding) . mb_substr($str, 1, null, $encoding);
+    } else {
+      $result = (ucfirst($str));
+    }
+    return $result;
+  }
+}
+
+if (!function_exists('mb_lcfirst')) { // Available in PHP >= 8.4
+  function mb_lcfirst($str, $encoding='UTF-8') {
+    if (extension_loaded('mbstring')) {
+      $result = mb_strtolower(mb_substr($str, 0, 1, $encoding), $encoding) . mb_substr($str, 1, null, $encoding);
+    } else {
+      $result = (lcfirst($str));
+    }
+    return $result;
+  }
+}
+
+function findVideoEventFile ($Event, $ext="*") {
   $dir = $Event->Path();
   $eventDefaultVideo = to_string($Event->DefaultVideo());
-  $path = ($eventDefaultVideo !== '' && !str_ends_with($eventDefaultVideo, '.m3u8')) ? $dir.'/'.$eventDefaultVideo : '';
+  $path = '';
+  if ($eventDefaultVideo !== '' &&
+    !str_ends_with($eventDefaultVideo, '.m3u8') &&
+    ($ext === "*" || str_ends_with(strtolower($eventDefaultVideo), '.' . $ext))) {
+      $path = $dir.'/'.$eventDefaultVideo;
+  }
   if (!is_file($path)) $path = ''; # So we don't return a reference to a non-existent file.
 
   if ($path === '') {
-    // Look for the final renamed mp4 or mkv or webm first, then incomplete
-    $candidates = glob($dir.'/'.$Event->Id().'-video.*.*');
-    if (!$candidates) $candidates = glob($dir.'/incomplete.*.*');
+    # By default, we search for files with any extension, such as mp4, mkv, or webm.
+    # Look for the final renamed first, then incomplete
+    $candidates = glob($dir.'/'.$Event->Id().'-video.*.'.$ext);
+    if (!$candidates) $candidates = glob($dir.'/incomplete.*.'.$ext);
     if ($candidates) {
       $path = $candidates[0];
     }

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2519,8 +2519,10 @@ function findVideoEventFile ($Event, $ext="*") {
 
   if ($path === '') {
     # By default, we search for files with any extension, such as mp4, mkv, or webm.
-    # Look for the final renamed first, then incomplete
+    # Look for the final renamed first, then incomplete.
+    # Incomplete files may exist as either incomplete.<container> or incomplete.<codec>.<container>.
     $candidates = glob($dir.'/'.$Event->Id().'-video.*.'.$ext);
+    if (!$candidates) $candidates = glob($dir.'/incomplete.'.$ext);
     if (!$candidates) $candidates = glob($dir.'/incomplete.*.'.$ext);
     if ($candidates) {
       $path = $candidates[0];

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2491,9 +2491,9 @@ function findVideoEventFile ($Event) {
   if (!is_file($path)) $path = ''; # So we don't return a reference to a non-existent file.
 
   if ($path === '') {
-    // Look for the final renamed mp4 first, then incomplete
-    $candidates = glob($dir.'/'.$Event->Id().'-video.*.mp4');
-    if (!$candidates) $candidates = glob($dir.'/incomplete.*.mp4');
+    // Look for the final renamed mp4 or mkv or webm first, then incomplete
+    $candidates = glob($dir.'/'.$Event->Id().'-video.*.*');
+    if (!$candidates) $candidates = glob($dir.'/incomplete.*.*');
     if ($candidates) {
       $path = $candidates[0];
     }

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2483,4 +2483,20 @@ function to_string($thing) {
   if (is_array($thing)) return implode(', ', $thing);
   return strval($thing);
 }
+
+function findVideoEventFile ($Event) {
+  $dir = $Event->Path();
+  $eventDefaultVideo = $Event->DefaultVideo();
+  $path = (!str_ends_with($eventDefaultVideo, '.m3u8')) ? $dir.'/'.$eventDefaultVideo : '';
+
+  if ($path === '') {
+    // Look for the final renamed mp4 first, then incomplete
+    $candidates = glob($dir.'/'.$Event->Id().'-video.*.mp4');
+    if (!$candidates) $candidates = glob($dir.'/incomplete.*.mp4');
+    if ($candidates) {
+      $path = $candidates[0];
+    }
+  }
+  return $path;
+}
 ?>


### PR DESCRIPTION
Closed: #4767
Also, an error when downloading an incomplete event has been fixed. This error occurred when` $Event->DefaultVideo() `started storing the value` 'index.m3u8' `instead of the incomplete event filename.

If this PR is approved, I will replace the code in the `if ($shouldUseMp4Fallback) {` condition from #4798 with the new findVideoEventFile() function to ensure consistency.

It will also be necessary to get rid of the `find_video($path)` function in `views\image.php` in favor of the new function findVideoEventFile()