### PR TITLE
Chore: Optimizing the menu style on the Monitor page

### DIFF
--- a/web/skins/classic/css/base/views/monitor.css
+++ b/web/skins/classic/css/base/views/monitor.css
@@ -78,6 +78,7 @@ body.sticky #content {
   overflow-y: auto;
   height: 100%;
 }
+
 nav ul.nav {
   height: 100%;
   flex-direction: column;
@@ -89,11 +90,22 @@ ul.form > li {
   padding-left: 300px;
   margin: 10px 0;
 }
+
 ul.form > li > label:first-child {
   width: 290px;
   margin-left: -300px;
   text-align: right;
 }
+
+nav a.nav-link {
+  margin-top: -0.5em;
+  margin-bottom: -0.5em;
+}
+
+nav .nav-item.form-control-sm {
+  height: auto;
+}
+
 .EncoderParameters label {
   vertical-align: top;
 }

--- a/web/skins/classic/css/base/views/monitor.css
+++ b/web/skins/classic/css/base/views/monitor.css
@@ -97,12 +97,12 @@ ul.form > li > label:first-child {
   text-align: right;
 }
 
-nav a.nav-link {
+nav #pills-tab a.nav-link {
   margin-top: -0.5em;
   margin-bottom: -0.5em;
 }
 
-nav .nav-item.form-control-sm {
+nav #pills-tab .nav-item.form-control-sm {
   height: auto;
 }
 


### PR DESCRIPTION
If a menu item doesn't fit on one line, the menu looks terrible because the height of the `<li> `block is hard-coded.

**Before:**
<img width="948" height="835" alt="d11" src="https://github.com/user-attachments/assets/4d777666-d871-426b-9fdd-ca8efc381e73" />

**After:**
<img width="964" height="822" alt="d1" src="https://github.com/user-attachments/assets/c3d13e9b-05e6-4ab6-82ab-628402d7ae63" />
