### PR TITLE
Fix: Don't send AJAX table update requests if the page is hidden Log, Frames, Watch, Reports, Console, Events, Snapshots pages

### DIFF
--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -74,7 +74,10 @@ function updateFooter(footer) {
 
 // Called by bootstrap-table to retrieve monitor data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if (ajax) ajax.abort();
 
   // Get filter selections from the form and add to params.data

--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -74,7 +74,7 @@ function updateFooter(footer) {
 
 // Called by bootstrap-table to retrieve monitor data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if (ajax) ajax.abort();
 
   // Get filter selections from the form and add to params.data

--- a/web/skins/classic/views/js/console.js
+++ b/web/skins/classic/views/js/console.js
@@ -74,6 +74,7 @@ function updateFooter(footer) {
 
 // Called by bootstrap-table to retrieve monitor data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   if (ajax) ajax.abort();
 
   // Get filter selections from the form and add to params.data

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -38,7 +38,10 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -38,6 +38,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/events.js
+++ b/web/skins/classic/views/js/events.js
@@ -38,7 +38,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/frames.js
+++ b/web/skins/classic/views/js/frames.js
@@ -3,6 +3,7 @@ var table = $j('#framesTable');
 
 // Called by bootstrap-table to retrieve zm frame data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   if ( params.data && params.data.filter ) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/frames.js
+++ b/web/skins/classic/views/js/frames.js
@@ -3,7 +3,10 @@ var table = $j('#framesTable');
 
 // Called by bootstrap-table to retrieve zm frame data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if ( params.data && params.data.filter ) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/frames.js
+++ b/web/skins/classic/views/js/frames.js
@@ -3,7 +3,7 @@ var table = $j('#framesTable');
 
 // Called by bootstrap-table to retrieve zm frame data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if ( params.data && params.data.filter ) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -28,7 +28,8 @@ var params =
 
 // Called by bootstrap-table to retrieve zm log data
 function ajaxRequest(params) {
-  if ($j('#filterServerId').val()) {
+  if(document.visibilityState == 'hidden') return;
+	if ($j('#filterServerId').val()) {
     params.data.ServerId = $j('#filterServerId').val();
   }
   if ($j('#filterLevel').val()) {

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -28,7 +28,10 @@ var params =
 
 // Called by bootstrap-table to retrieve zm log data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if ($j('#filterServerId').val()) {
     params.data.ServerId = $j('#filterServerId').val();
   }

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -29,7 +29,7 @@ var params =
 // Called by bootstrap-table to retrieve zm log data
 function ajaxRequest(params) {
   if(document.visibilityState == 'hidden') return;
-	if ($j('#filterServerId').val()) {
+  if ($j('#filterServerId').val()) {
     params.data.ServerId = $j('#filterServerId').val();
   }
   if ($j('#filterLevel').val()) {

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -28,7 +28,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm log data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if ($j('#filterServerId').val()) {
     params.data.ServerId = $j('#filterServerId').val();
   }

--- a/web/skins/classic/views/js/reports.js
+++ b/web/skins/classic/views/js/reports.js
@@ -31,6 +31,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/reports.js
+++ b/web/skins/classic/views/js/reports.js
@@ -31,7 +31,10 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/reports.js
+++ b/web/skins/classic/views/js/reports.js
@@ -31,7 +31,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if (params.data && params.data.filter) {
     params.data.advsearch = params.data.filter;
     delete params.data.filter;

--- a/web/skins/classic/views/js/snapshots.js
+++ b/web/skins/classic/views/js/snapshots.js
@@ -31,7 +31,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   if (ajax) ajax.abort();
 
   if ( params.data && params.data.filter ) {

--- a/web/skins/classic/views/js/snapshots.js
+++ b/web/skins/classic/views/js/snapshots.js
@@ -31,6 +31,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   if (ajax) ajax.abort();
 
   if ( params.data && params.data.filter ) {

--- a/web/skins/classic/views/js/snapshots.js
+++ b/web/skins/classic/views/js/snapshots.js
@@ -31,7 +31,10 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    table.bootstrapTable('hideLoading');
+    return;
+  }
   if (ajax) ajax.abort();
 
   if ( params.data && params.data.filter ) {

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -58,7 +58,10 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if (document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') {
+    eventListTable.bootstrapTable('hideLoading');
+    return;
+  }
   // Maintain legacy behavior by statically setting these parameters
   const data = params.data;
   data.order = 'desc';

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -58,7 +58,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
-  if(document.visibilityState == 'hidden') return;
+  if (document.visibilityState == 'hidden') return;
   // Maintain legacy behavior by statically setting these parameters
   const data = params.data;
   data.order = 'desc';

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -58,6 +58,7 @@ var params =
 
 // Called by bootstrap-table to retrieve zm event data
 function ajaxRequest(params) {
+  if(document.visibilityState == 'hidden') return;
   // Maintain legacy behavior by statically setting these parameters
   const data = params.data;
   data.order = 'desc';


### PR DESCRIPTION
This will significantly reduce the server load.
Because right now, if you open multiple Log pages and collapse them, the server is constantly receiving requests!