### PR TITLE
Fix: Correct calculation of the total number of pages for pagination with filters on Log page

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -185,12 +185,7 @@ function queryRequest() {
   }
   if ($where) $where = ' WHERE '.$where;
 
-  $data['totalNotFiltered'] = dbFetchOne('SELECT count(*) AS Total FROM ' .$table, 'Total');
-  if ( $search != '' || count($advsearch) ) {
-    $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM ' .$table.$where , 'Total', $query['values']);
-  } else {
-    $data['total'] = $data['totalNotFiltered'];
-  }
+  $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'` '.$where , 'Total', $query['values']);
 
   $query['sql'] = 'SELECT ' .$col_str. ' FROM `' .$table. '` ' .$where. ' ORDER BY ' .$sort. ' ' .$order. ' LIMIT ?, ?';
   array_push($query['values'], $offset, $limit);

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -186,8 +186,12 @@ function queryRequest() {
   }
   if ($where) $where = ' WHERE '.$where;
 
-  $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'` '.$where, 'Total', $query['values']);
   $data['totalNotFiltered'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'`', 'Total');
+  if ($where) {
+    $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'` '.$where, 'Total', $query['values']);
+  } else {
+    $data['total'] = $data['totalNotFiltered'];
+  }
 
   $query['sql'] = 'SELECT ' .$col_str. ' FROM `' .$table. '` ' .$where. ' ORDER BY ' .$sort. ' ' .$order. ' LIMIT ?, ?';
   array_push($query['values'], $offset, $limit);

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -185,7 +185,8 @@ function queryRequest() {
   }
   if ($where) $where = ' WHERE '.$where;
 
-  $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'` '.$where , 'Total', $query['values']);
+  $data['total'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'` '.$where, 'Total', $query['values']);
+  $data['totalNotFiltered'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'`', 'Total');
 
   $query['sql'] = 'SELECT ' .$col_str. ' FROM `' .$table. '` ' .$where. ' ORDER BY ' .$sort. ' ' .$order. ' LIMIT ?, ?';
   array_push($query['values'], $offset, $limit);


### PR DESCRIPTION
We don't need an additional check to include the WHERE clause in the query string, since $where will only be populated if filters are specified.

Previously, there was an issue with counting the total number of pages when using a filter by components or levels.