### PR TITLE
Fix: Save the selected "All" value in the "zmLogComponent" session on Log page

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -149,14 +149,11 @@ function queryRequest() {
     if ($where) $where .= ' AND ';
     $where .= 'Component = ?';
     $query['values'][] = $_REQUEST['Component'];
-    zm_session_start();
-    $_SESSION['zmLogComponent'] = $_REQUEST['Component'];
-    session_write_close();
-  } else {
-    zm_session_start();
-    $_SESSION['zmLogComponent'] = '';
-    session_write_close();
   }
+  zm_session_start();
+  $_SESSION['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
+  session_write_close();
+
   if (!empty($_REQUEST['ServerId'])) {
     if ($where) $where .= ' AND ';
     $where .= 'ServerId = ?';

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -152,6 +152,10 @@ function queryRequest() {
     zm_session_start();
     $_SESSION['zmLogComponent'] = $_REQUEST['Component'];
     session_write_close();
+  } else {
+    zm_session_start();
+    $_SESSION['zmLogComponent'] = '';
+    session_write_close();
   }
   if (!empty($_REQUEST['ServerId'])) {
     if ($where) $where .= ' AND ';

--- a/web/skins/classic/views/log.php
+++ b/web/skins/classic/views/log.php
@@ -70,7 +70,7 @@ $options = [''=>translate('All')] + array_combine($components, $components);
 ZM\Debug(print_r($options, true));
 $selected_component = '';
 if (isset($_SESSION['zmLogComponent'])) {
-  if (array_search($_SESSION['zmLogComponent'], $components)) {
+  if (array_search($_SESSION['zmLogComponent'], $components) !== -1) {
     $selected_component = $_SESSION['zmLogComponent'];
   } else {
     unset($_SESSION['zmLogComponent']);


### PR DESCRIPTION
Previously, there was an issue where selecting "All" didn't change the session value because "All"=""