### PR TITLE
Fix: Fixed overlapping ".eventStats" and dropdown tags on Event page

### DIFF
--- a/web/skins/classic/css/base/views/event.css
+++ b/web/skins/classic/css/base/views/event.css
@@ -120,6 +120,7 @@ height: 100%;
 }
 .eventStats {
   padding-left: 0;
+  z-index: 1;
   /* margin-right: 5px; */
 }
 


### PR DESCRIPTION
Closed issue: https://github.com/ZoneMinder/zoneminder/issues/4831#issuecomment-4460535978