### PR TITLE
Make HLS event playback actually work end-to-end (fixes #4757)

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -202,9 +202,12 @@ Event::~Event() {
   /* Close the video file */
   // We close the videowriter first, because if we finish the event, we might try to view the file, but we aren't done writing it yet.
   if (videoStore != nullptr) {
-    // Finalize last fragment before closing the video store
+    // Flush the trailer + record the final fragment before writing the m3u8.
+    // finalize() must run before writeM3U8 so the manifest contains every
+    // fragment (including the one no later keyframe was around to close).
+    videoStore->finalize();
+
     std::string m3u8_path = path + "/index.m3u8";
-    // Write temporary m3u8 with incomplete filename (writeM3U8 finalizes last fragment)
     std::string video_url_tmp = "index.php?view=view_video&eid=" + std::to_string(id)
       + "&file=" + video_incomplete_file;
     videoStore->writeM3U8(m3u8_path, video_url_tmp, true);

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -258,26 +258,17 @@ Event::~Event() {
   if (frame_data.size()) WriteDbFrames();
 
   uint64_t video_size = 0;
-  bool has_m3u8 = false;
   DIR *video_dir;
   if ((video_dir = opendir(path.c_str())) != NULL) {
     struct dirent *dir_entry;
     while ((dir_entry = readdir(video_dir)) != NULL) {
       struct stat vf_stat;
       if (stat((path + "/" + dir_entry->d_name).c_str(), &vf_stat) == 0 &&
-          S_ISREG(vf_stat.st_mode)) {
+          S_ISREG(vf_stat.st_mode))
         video_size += vf_stat.st_size;
-        if (!strcmp(dir_entry->d_name, "index.m3u8")) has_m3u8 = true;
-      }
     }
     closedir(video_dir);
   }
-
-  // Prefer index.m3u8 as DefaultVideo when an HLS manifest was written, so
-  // event.php picks the HLS player on closed events too — otherwise the player
-  // selection logic falls back to direct mp4 playback for everything except a
-  // manual MP4HLS codec choice.
-  std::string default_video = has_m3u8 ? "index.m3u8" : video_file;
 
   // Use async dbQueue instead of synchronous zmDbDoUpdate to avoid blocking
   // the close_event_thread (which blocks the analysis thread on the next closeEvent).
@@ -295,7 +286,7 @@ Event::~Event() {
       frames, alarm_frames,
       tot_score, static_cast<uint32>(alarm_frames ? (tot_score / alarm_frames) : 0),
       max_score, max_score_frame_id,
-      default_video.c_str(),
+      video_file.c_str(), // defaults to ""
       video_size,
       id);
   dbQueue.push(std::move(sql));

--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -258,17 +258,26 @@ Event::~Event() {
   if (frame_data.size()) WriteDbFrames();
 
   uint64_t video_size = 0;
+  bool has_m3u8 = false;
   DIR *video_dir;
   if ((video_dir = opendir(path.c_str())) != NULL) {
     struct dirent *dir_entry;
     while ((dir_entry = readdir(video_dir)) != NULL) {
       struct stat vf_stat;
       if (stat((path + "/" + dir_entry->d_name).c_str(), &vf_stat) == 0 &&
-          S_ISREG(vf_stat.st_mode))
+          S_ISREG(vf_stat.st_mode)) {
         video_size += vf_stat.st_size;
+        if (!strcmp(dir_entry->d_name, "index.m3u8")) has_m3u8 = true;
+      }
     }
     closedir(video_dir);
   }
+
+  // Prefer index.m3u8 as DefaultVideo when an HLS manifest was written, so
+  // event.php picks the HLS player on closed events too — otherwise the player
+  // selection logic falls back to direct mp4 playback for everything except a
+  // manual MP4HLS codec choice.
+  std::string default_video = has_m3u8 ? "index.m3u8" : video_file;
 
   // Use async dbQueue instead of synchronous zmDbDoUpdate to avoid blocking
   // the close_event_thread (which blocks the analysis thread on the next closeEvent).
@@ -286,7 +295,7 @@ Event::~Event() {
       frames, alarm_frames,
       tot_score, static_cast<uint32>(alarm_frames ? (tot_score / alarm_frames) : 0),
       max_score, max_score_frame_id,
-      video_file.c_str(), // defaults to ""
+      default_video.c_str(),
       video_size,
       id);
   dbQueue.push(std::move(sql));

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -76,7 +76,8 @@ VideoStore::VideoStore(
   reorder_queue_size(0),
   last_fragment_offset_(0),
   last_fragment_start_dts_(AV_NOPTS_VALUE),
-  init_segment_end_(0) {
+  init_segment_end_(0),
+  finalized_(false) {
   FFMPEGInit();
   swscale.init();
   opkt = av_packet_ptr{av_packet_alloc()};
@@ -706,7 +707,7 @@ VideoStore::~VideoStore() {
     }
   }
 
-  if (oc->pb) {
+  if (!finalized_ && oc->pb) {
     flush_codecs();
 
     // Flush Queues
@@ -1551,26 +1552,31 @@ int VideoStore::write_packet(AVPacket *pkt, AVStream *stream) {
   Debug(3, "next_dts for stream %d has become %" PRId64 " last_dts %" PRId64,
         stream->index, next_dts[stream->index], last_dts[stream->index]);
 
-  // HLS fragment tracking: with frag_keyframe movflag, FFmpeg creates a new
-  // moof+mdat at each video keyframe. We record the byte range of each fragment
-  // by checking the file position before and after the write call.
-  //
-  // Strategy: before writing a video keyframe, snapshot the file position.
-  // This marks the end of the previous fragment. We record that fragment and
-  // start tracking the new one.
   bool is_video_keyframe = (stream == video_out_stream) && (pkt->flags & AV_PKT_FLAG_KEY);
+  // Snapshot the keyframe's dts before the write call may modify the packet.
+  int64_t this_keyframe_dts = is_video_keyframe ? pkt->dts : AV_NOPTS_VALUE;
 
+  int ret = av_interleaved_write_frame(oc, pkt);
+  if (ret != 0) {
+    Error("Error writing packet: %s", av_make_error_string(ret).c_str());
+  } else {
+    Debug(4, "Success writing packet");
+  }
+
+  // HLS fragment tracking: with movflags=frag_keyframe, the muxer flushes the
+  // previous fragment to disk inside av_interleaved_write_frame() when a new
+  // keyframe arrives. So the position *after* this call equals the end of the
+  // just-flushed fragment, and last_fragment_offset_/_dts_ describe that
+  // fragment. Record it, then move tracking to the new fragment.
   if (is_video_keyframe && oc && oc->pb) {
-    // Force flush any buffered data so the file position reflects all previous writes
     avio_flush(oc->pb);
-    int64_t pos_now = avio_tell(oc->pb);
+    int64_t pos_after = avio_tell(oc->pb);
 
-    if (last_fragment_start_dts_ != AV_NOPTS_VALUE && pos_now > last_fragment_offset_) {
-      // Record the completed fragment
-      int64_t frag_size = pos_now - last_fragment_offset_;
+    if (last_fragment_start_dts_ != AV_NOPTS_VALUE && pos_after > last_fragment_offset_) {
+      int64_t frag_size = pos_after - last_fragment_offset_;
       double duration = 0;
       if (video_out_stream->time_base.den > 0) {
-        duration = static_cast<double>(pkt->dts - last_fragment_start_dts_)
+        duration = static_cast<double>(this_keyframe_dts - last_fragment_start_dts_)
                    * video_out_stream->time_base.num
                    / video_out_stream->time_base.den;
       }
@@ -1580,49 +1586,101 @@ int VideoStore::write_packet(AVPacket *pkt, AVStream *stream) {
               fragments_.size() - 1, last_fragment_offset_, frag_size, duration);
       }
     }
-    // New fragment starts here
-    last_fragment_offset_ = pos_now;
-    last_fragment_start_dts_ = pkt->dts;
-  }
-
-  // Initialize tracking after init segment is written
-  if (last_fragment_start_dts_ == AV_NOPTS_VALUE && is_video_keyframe) {
-    if (oc && oc->pb) {
-      last_fragment_offset_ = avio_tell(oc->pb);
-    }
-    last_fragment_start_dts_ = pkt->dts;
-  }
-
-  int ret = av_interleaved_write_frame(oc, pkt);
-  if (ret != 0) {
-    Error("Error writing packet: %s", av_make_error_string(ret).c_str());
-  } else {
-    Debug(4, "Success writing packet");
+    last_fragment_offset_ = pos_after;
+    last_fragment_start_dts_ = this_keyframe_dts;
   }
 
   return ret;
 }  // end int VideoStore::write_packet(AVPacket *pkt, AVStream *stream)
 
-void VideoStore::writeM3U8(const std::string &m3u8_path, const std::string &video_url, bool is_complete) {
-  // Finalize last fragment if there's data after the last recorded fragment
-  if (oc && oc->pb) {
-    int64_t file_end = avio_tell(oc->pb);
-    if (file_end > last_fragment_offset_ && last_fragment_start_dts_ != AV_NOPTS_VALUE) {
-      int64_t frag_size = file_end - last_fragment_offset_;
-      // Estimate duration from last known DTS
-      double duration = 0;
-      if (video_out_stream && video_out_stream->time_base.den > 0 &&
-          last_dts.count(video_out_stream->index) && last_dts[video_out_stream->index] != AV_NOPTS_VALUE) {
-        duration = static_cast<double>(last_dts[video_out_stream->index] + last_duration[video_out_stream->index] - last_fragment_start_dts_)
-                   * video_out_stream->time_base.num
-                   / video_out_stream->time_base.den;
+void VideoStore::finalize() {
+  if (finalized_) return;
+  finalized_ = true;
+
+  if (!oc || !oc->pb) return;
+
+  flush_codecs();
+
+  Debug(4, "Flushing interleaved queues");
+  av_interleaved_write_frame(oc, nullptr);
+
+  Debug(1, "Writing trailer");
+  int rc = av_write_trailer(oc);
+  if (rc < 0) {
+    Error("Error writing trailer %s", av_err2str(rc));
+  } else {
+    Debug(3, "Success Writing trailer");
+  }
+
+  // After av_write_trailer, the file contains init+fragments_1..N + mfra trailer.
+  // Capture the on-disk length so we can size the final fragment.
+  avio_flush(oc->pb);
+  int64_t file_size = avio_tell(oc->pb);
+
+  // Close the output file before reading it back to inspect the mfra box.
+  if (!(out_format->flags & AVFMT_NOFILE)) {
+    Debug(4, "Closing");
+    if ((rc = avio_close(oc->pb)) < 0) {
+      Error("Error closing avio %s", av_err2str(rc));
+    }
+  }
+  oc->pb = nullptr;
+
+  // The MOV muxer writes an mfra (Movie Fragment Random Access) box at the end
+  // of the file when fragmentation is on. Its trailing mfro box is exactly 16
+  // bytes and contains the mfra size, so we can subtract that to find where
+  // the final fragment's mdat actually ends.
+  int64_t fragment_n_end = file_size;
+  if (filename && file_size >= 16) {
+    FILE *fp = fopen(filename, "rb");
+    if (fp) {
+      if (fseeko(fp, file_size - 16, SEEK_SET) == 0) {
+        uint8_t mfro[16];
+        if (fread(mfro, 1, 16, fp) == 16) {
+          uint32_t box_size = (static_cast<uint32_t>(mfro[0]) << 24)
+                            | (static_cast<uint32_t>(mfro[1]) << 16)
+                            | (static_cast<uint32_t>(mfro[2]) << 8)
+                            | static_cast<uint32_t>(mfro[3]);
+          if (box_size == 16
+              && mfro[4] == 'm' && mfro[5] == 'f' && mfro[6] == 'r' && mfro[7] == 'o') {
+            uint32_t mfra_size = (static_cast<uint32_t>(mfro[12]) << 24)
+                               | (static_cast<uint32_t>(mfro[13]) << 16)
+                               | (static_cast<uint32_t>(mfro[14]) << 8)
+                               | static_cast<uint32_t>(mfro[15]);
+            if (mfra_size > 0 && static_cast<int64_t>(mfra_size) <= file_size) {
+              fragment_n_end = file_size - mfra_size;
+              Debug(1, "mfra trailer is %u bytes; final fragment ends at %" PRId64,
+                    mfra_size, fragment_n_end);
+            }
+          }
+        }
       }
-      if (duration > 0 && frag_size > 0) {
-        fragments_.push_back({last_fragment_offset_, frag_size, duration});
-      }
+      fclose(fp);
     }
   }
 
+  // Record the final fragment that no subsequent keyframe was around to record.
+  if (last_fragment_start_dts_ != AV_NOPTS_VALUE
+      && fragment_n_end > last_fragment_offset_
+      && video_out_stream && video_out_stream->time_base.den > 0
+      && last_dts.count(video_out_stream->index)
+      && last_dts[video_out_stream->index] != AV_NOPTS_VALUE) {
+    int64_t frag_size = fragment_n_end - last_fragment_offset_;
+    double duration = static_cast<double>(
+        last_dts[video_out_stream->index]
+        + last_duration[video_out_stream->index]
+        - last_fragment_start_dts_)
+        * video_out_stream->time_base.num
+        / video_out_stream->time_base.den;
+    if (duration > 0 && frag_size > 0) {
+      fragments_.push_back({last_fragment_offset_, frag_size, duration});
+      Debug(1, "HLS final fragment: offset=%" PRId64 " size=%" PRId64 " duration=%.3f",
+            last_fragment_offset_, frag_size, duration);
+    }
+  }
+}
+
+void VideoStore::writeM3U8(const std::string &m3u8_path, const std::string &video_url, bool is_complete) {
   if (fragments_.empty()) return;
 
   // Calculate max duration for EXT-X-TARGETDURATION (must be integer, rounded up)

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -692,54 +692,11 @@ Debug(1, "Done flushing");
 
 VideoStore::~VideoStore() {
 
-  // When finalize() has run it already drained these queues; doing it again
-  // would push packets into a closed AVFormatContext. Also skip when oc was
-  // never allocated (open() failed before assigning oc) — the write helpers
-  // dereference oc.
-  if (!finalized_ && oc) {
-    for (auto &n : reorder_queues) {
-      auto &queue = n.second;
-      Debug(1, "Queue for %d length is %zu", n.first, queue.size());
-      while (!queue.empty()) {
-        auto pkt = queue.front();
-        queue.pop_front();
-        if (pkt->codec_type == AVMEDIA_TYPE_VIDEO) {
-          writeVideoFramePacket(pkt);
-        } else if (pkt->codec_type == AVMEDIA_TYPE_AUDIO) {
-          writeAudioFramePacket(pkt);
-        }
-      }
-    }
-  }
-
-  if (!finalized_ && oc && oc->pb) {
-    flush_codecs();
-
-    // Flush Queues
-    Debug(4, "Flushing interleaved queues");
-    av_interleaved_write_frame(oc, nullptr);
-
-    Debug(1, "Writing trailer");
-    /* Write the trailer before close */
-    int rc;
-    if ((rc = av_write_trailer(oc)) < 0) {
-      Error("Error writing trailer %s", av_err2str(rc));
-    } else {
-      Debug(3, "Success Writing trailer");
-    }
-
-    // When will we not be using a file ?
-    if (!(out_format->flags & AVFMT_NOFILE)) {
-      /* Close the out file. */
-      Debug(4, "Closing");
-      if ((rc = avio_close(oc->pb)) < 0) {
-        Error("Error closing avio %s", av_err2str(rc));
-      }
-    } else {
-      Debug(3, "Not closing avio because we are not writing to a file.");
-    }
-    oc->pb = nullptr;
-  }  // end if oc->pb
+  // Run the shutdown path through finalize() so the queue-drain / trailer /
+  // close logic lives in one place. finalize() is idempotent and bails early
+  // if oc was never allocated, so the legacy "caller didn't call finalize"
+  // path and the open()-failed-before-allocating-oc path both work.
+  finalize();
 
   // I wonder if we should be closing the file first.
   // I also wonder if we really need to be doing all the ctx

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -62,7 +62,7 @@ VideoStore::VideoStore(
   resample_ctx(nullptr),
   fifo(nullptr),
   converted_in_samples(nullptr),
-  filename(filename_in),
+  filename(filename_in ? filename_in : ""),
   format(format_in),
   video_first_pts(AV_NOPTS_VALUE),
   video_first_dts(AV_NOPTS_VALUE),
@@ -85,24 +85,24 @@ VideoStore::VideoStore(
 
 /* Failure to open audio will not be a total failure. */
 bool VideoStore::open() {
-  Debug(1, "Opening video storage stream %s format: %s", filename, format);
+  Debug(1, "Opening video storage stream %s format: %s", filename.c_str(), format);
 
-  int ret = avformat_alloc_output_context2(&oc, nullptr, nullptr, filename);
+  int ret = avformat_alloc_output_context2(&oc, nullptr, nullptr, filename.c_str());
   if (ret < 0) {
     Warning(
       "Could not create video storage stream %s as no out ctx"
       " could be assigned based on filename: %s",
-      filename, av_make_error_string(ret).c_str());
+      filename.c_str(), av_make_error_string(ret).c_str());
   }
 
   // Couldn't deduce format from filename, trying from format name
   if (!oc) {
-    avformat_alloc_output_context2(&oc, nullptr, format, filename);
+    avformat_alloc_output_context2(&oc, nullptr, format, filename.c_str());
     if (!oc) {
       Error(
         "Could not create video storage stream %s as no out ctx"
         " could not be assigned based on filename or format %s",
-        filename, format);
+        filename.c_str(), format);
       return false;
     }
   } // end if ! oc
@@ -522,9 +522,9 @@ bool VideoStore::open() {
 
   /* open the out file, if needed */
   if (!(out_format->flags & AVFMT_NOFILE)) {
-    ret = avio_open2(&oc->pb, filename, AVIO_FLAG_WRITE, nullptr, nullptr);
+    ret = avio_open2(&oc->pb, filename.c_str(), AVIO_FLAG_WRITE, nullptr, nullptr);
     if (ret < 0) {
-      Error("Could not open out file '%s': %s", filename, av_make_error_string(ret).c_str());
+      Error("Could not open out file '%s': %s", filename.c_str(), av_make_error_string(ret).c_str());
       return false;
     }
   }
@@ -563,7 +563,7 @@ bool VideoStore::open() {
   av_dict_free(&opts);
   if (ret < 0) {
     Error("Error occurred when writing out file header to %s: %s",
-          filename, av_make_error_string(ret).c_str());
+          filename.c_str(), av_make_error_string(ret).c_str());
     avio_closep(&oc->pb);
     return false;
   }
@@ -693,8 +693,10 @@ Debug(1, "Done flushing");
 VideoStore::~VideoStore() {
 
   // When finalize() has run it already drained these queues; doing it again
-  // would push packets into a closed AVFormatContext.
-  if (!finalized_) {
+  // would push packets into a closed AVFormatContext. Also skip when oc was
+  // never allocated (open() failed before assigning oc) — the write helpers
+  // dereference oc.
+  if (!finalized_ && oc) {
     for (auto &n : reorder_queues) {
       auto &queue = n.second;
       Debug(1, "Queue for %d length is %zu", n.first, queue.size());
@@ -710,7 +712,7 @@ VideoStore::~VideoStore() {
     }
   }
 
-  if (!finalized_ && oc->pb) {
+  if (!finalized_ && oc && oc->pb) {
     flush_codecs();
 
     // Flush Queues
@@ -1651,8 +1653,8 @@ void VideoStore::finalize() {
   // bytes and contains the mfra size, so we can subtract that to find where
   // the final fragment's mdat actually ends.
   int64_t fragment_n_end = file_size;
-  if (filename && file_size >= 16) {
-    FILE *fp = fopen(filename, "rb");
+  if (!filename.empty() && file_size >= 16) {
+    FILE *fp = fopen(filename.c_str(), "rb");
     if (fp) {
       if (fseeko(fp, file_size - 16, SEEK_SET) == 0) {
         uint8_t mfro[16];

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -692,18 +692,21 @@ Debug(1, "Done flushing");
 
 VideoStore::~VideoStore() {
 
-  for (auto &n : reorder_queues) {
-    auto &queue = n.second;
-    Debug(1, "Queue for %d length is %zu", n.first, queue.size());
-    while (!queue.empty()) {
-      auto pkt = queue.front();
-      queue.pop_front();
-      if (pkt->codec_type == AVMEDIA_TYPE_VIDEO) {
-        writeVideoFramePacket(pkt);
-      } else if (pkt->codec_type == AVMEDIA_TYPE_AUDIO) {
-        writeAudioFramePacket(pkt);
+  // When finalize() has run it already drained these queues; doing it again
+  // would push packets into a closed AVFormatContext.
+  if (!finalized_) {
+    for (auto &n : reorder_queues) {
+      auto &queue = n.second;
+      Debug(1, "Queue for %d length is %zu", n.first, queue.size());
+      while (!queue.empty()) {
+        auto pkt = queue.front();
+        queue.pop_front();
+        if (pkt->codec_type == AVMEDIA_TYPE_VIDEO) {
+          writeVideoFramePacket(pkt);
+        } else if (pkt->codec_type == AVMEDIA_TYPE_AUDIO) {
+          writeAudioFramePacket(pkt);
+        }
       }
-      //delete pkt;
     }
   }
 
@@ -1598,6 +1601,23 @@ void VideoStore::finalize() {
   finalized_ = true;
 
   if (!oc || !oc->pb) return;
+
+  // Drain reorder queues before writing the trailer — the destructor would
+  // otherwise try to run these packets through av_interleaved_write_frame()
+  // after we've already closed oc->pb here.
+  for (auto &n : reorder_queues) {
+    auto &queue = n.second;
+    Debug(1, "Queue for %d length is %zu", n.first, queue.size());
+    while (!queue.empty()) {
+      auto pkt = queue.front();
+      queue.pop_front();
+      if (pkt->codec_type == AVMEDIA_TYPE_VIDEO) {
+        writeVideoFramePacket(pkt);
+      } else if (pkt->codec_type == AVMEDIA_TYPE_AUDIO) {
+        writeAudioFramePacket(pkt);
+      }
+    }
+  }
 
   flush_codecs();
 

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -93,11 +93,17 @@ class VideoStore {
   size_t reorder_queue_size;
   std::map<int, std::list<std::shared_ptr<ZMPacket>>> reorder_queues;
 
-  // HLS fragment tracking
+  // HLS fragment tracking. With movflags=frag_keyframe, FFmpeg's mov muxer
+  // doesn't write a fragment to disk until the *next* keyframe arrives (or
+  // until av_write_trailer is called). So when keyframe N arrives, fragment
+  // N-1 is what just got flushed. We snapshot avio_tell *after*
+  // av_interleaved_write_frame() to capture the position past that flush, and
+  // record fragment N-1 then.
   std::vector<Fragment> fragments_;
-  int64_t last_fragment_offset_;    // byte offset where current fragment started
-  int64_t last_fragment_start_dts_; // DTS of first video keyframe in current fragment
+  int64_t last_fragment_offset_;    // byte offset where the current (in-progress) fragment starts
+  int64_t last_fragment_start_dts_; // DTS of the keyframe that started the current fragment
   int64_t init_segment_end_;        // byte offset where init segment (ftyp+moov) ends
+  bool    finalized_;               // true once finalize() has run trailer + last-fragment recording
 
   bool setup_resampler();
   int write_packet(AVPacket *pkt, AVStream *stream);
@@ -124,6 +130,11 @@ class VideoStore {
   const std::vector<Fragment> &fragments() const { return fragments_; }
   int64_t init_segment_end() const { return init_segment_end_; }
   void writeM3U8(const std::string &path, const std::string &video_url, bool is_complete);
+  // Flush queues, write trailer, close output, and record the final fragment.
+  // Call this before writeM3U8(true) so the manifest contains every fragment.
+  // Safe to call once; subsequent calls are no-ops. The destructor will skip
+  // the trailer write if finalize() has already run.
+  void finalize();
 
   const char *get_codec() {
     if (chosen_codec_data)

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -71,7 +71,10 @@ class VideoStore {
   AVAudioFifo *fifo;
   uint8_t *converted_in_samples;
 
-  const char *filename;
+  // filename is owned (std::string) so it stays valid for the lifetime of
+  // VideoStore even if the caller later renames/reassigns the source path
+  // it was constructed from. A bare const char* would dangle in that case.
+  std::string filename;
   const char *format;
 
   // These are for in

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -354,9 +354,13 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
                     <div id="zoompan" class="zoompan">
 <?php
 if ($video_tag) {
-  // Use HLS byte-range playback if m3u8 manifest exists on disk
-  $has_hls = (($codec == 'MP4HLS') || str_ends_with($Event->DefaultVideo(), '.m3u8'))
-    && file_exists($Event->Path() . '/index.m3u8');
+  // Prefer HLS byte-range playback whenever the manifest exists on disk and the
+  // user hasn't explicitly opted into a non-HLS playback mode. Closed events
+  // have DefaultVideo rewritten to the renamed mp4, so checking the file system
+  // is what catches them.
+  $has_hls = file_exists($Event->Path() . '/index.m3u8')
+    && (($codec == 'MP4HLS') || ($codec == 'MP4') || ($codec == 'auto')
+        || str_ends_with($Event->DefaultVideo(), '.m3u8'));
   if ($has_hls) {
     $Server = $Event->Server();
     $hlsSrc = $Server->PathToIndex() . '?view=view_hls&amp;eid=' . $Event->Id();

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -354,12 +354,13 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
                     <div id="zoompan" class="zoompan">
 <?php
 if ($video_tag) {
-  // Prefer HLS byte-range playback whenever the manifest exists on disk and the
-  // user hasn't explicitly opted into a non-HLS playback mode. Closed events
-  // have DefaultVideo rewritten to the renamed mp4, so checking the file system
-  // is what catches them.
+  // Prefer HLS byte-range playback when the manifest exists on disk and the
+  // user picked MP4HLS / auto. Explicit MP4 means "play the mp4 file directly"
+  // and must stay non-HLS even when a manifest is available. Closed events
+  // recorded before DefaultVideo was preserved as 'index.m3u8' still need to
+  // fall through here on auto.
   $has_hls = file_exists($Event->Path() . '/index.m3u8')
-    && (($codec == 'MP4HLS') || ($codec == 'MP4') || ($codec == 'auto')
+    && (($codec == 'MP4HLS') || ($codec == 'auto')
         || str_ends_with($Event->DefaultVideo(), '.m3u8'));
   if ($has_hls) {
     $Server = $Event->Server();

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -406,7 +406,11 @@ if ($video_tag) {
                         autoplay: true,
                         preload: 'auto',
                         playbackRates: rates,
-                        liveui: <?php echo $has_hls && !$Event->EndDateTime() ? 'true' : 'false' ?>,
+                        // liveui replaces the seekbar with a live-edge-only control,
+                        // which makes it impossible to scrub back through the already-
+                        // recorded portion of an in-progress event. Always false so the
+                        // standard seekbar is rendered.
+                        liveui: false,
                         liveTracker: {
                           trackingThreshold: 0
                         }

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -355,13 +355,13 @@ if (file_exists($Event->Path().'/objdetect.jpg')) {
 <?php
 if ($video_tag) {
   // Prefer HLS byte-range playback when the manifest exists on disk and the
-  // user picked MP4HLS / auto. Explicit MP4 means "play the mp4 file directly"
-  // and must stay non-HLS even when a manifest is available. Closed events
-  // recorded before DefaultVideo was preserved as 'index.m3u8' still need to
-  // fall through here on auto.
+  // user picked MP4HLS / auto. Explicit MP4 must stay native ("play the mp4
+  // file directly"); explicit MJPEG never reaches here because $video_tag is
+  // false for it. DefaultVideo's extension is deliberately not consulted —
+  // in-progress events have DefaultVideo='index.m3u8' from the constructor,
+  // and using that as a signal would override the explicit MP4 choice.
   $has_hls = file_exists($Event->Path() . '/index.m3u8')
-    && (($codec == 'MP4HLS') || ($codec == 'auto')
-        || str_ends_with($Event->DefaultVideo(), '.m3u8'));
+    && (($codec == 'MP4HLS') || ($codec == 'auto'));
   if ($has_hls) {
     $Server = $Event->Server();
     $hlsSrc = $Server->PathToIndex() . '?view=view_hls&amp;eid=' . $Event->Id();

--- a/web/views/view_hls.php
+++ b/web/views/view_hls.php
@@ -57,16 +57,19 @@ $content = file_get_contents($m3u8_path);
 $Server = $Event->Server();
 $base_url = $Server->PathToIndex();
 
-// Replace bare URLs with full paths including auth
+// Replace bare relative segment URLs with full paths including auth.
+// The m3u8 has lines like "index.php?view=view_video&eid=N&file=F" — capture
+// only the query string (after "index.php?") so the replacement doesn't emit
+// "/zm/index.php?index.php?view=…".
 $content = preg_replace(
-  '/^(index\.php\?.+)$/m',
+  '/^index\.php\?(.+)$/m',
   $base_url . '?$1' . $auth_query,
   $content
 );
 
-// Also fix the EXT-X-MAP URI
+// Also fix the EXT-X-MAP URI (initialization segment) the same way.
 $content = preg_replace(
-  '/URI="(index\.php\?[^"]+)"/m',
+  '/URI="index\.php\?([^"]+)"/m',
   'URI="' . $base_url . '?$1' . $auth_query . '"',
   $content
 );

--- a/web/views/view_video.php
+++ b/web/views/view_video.php
@@ -87,7 +87,10 @@ if ( ! ($fh = @fopen($path, 'rb') ) ) {
   header('HTTP/1.0 404 Not Found');
   die();
 }
-$filename = ($mode == 'mp4') ? basename($path) : (($Event) ? $Event->DefaultVideo() : '');
+// Always derive the filename from the resolved $path: after the m3u8 fallback
+// above, $path can point at an mp4 even when DefaultVideo is 'index.m3u8', so
+// reporting DefaultVideo would advertise a manifest while serving mp4 bytes.
+$filename = basename($path);
 
 $size = filesize($path);
 $begin = 0;


### PR DESCRIPTION
Eleven commits that fix everything between recording an event and a browser scrubbing it back via HLS. Supersedes #4803 and #4806; closes #4757.

## Bugs fixed

### C++ — m3u8 generation produced duplicate / mis-pointed fragments
`zm_videostore.cpp` snapshotted `avio_tell()` *before* `av_interleaved_write_frame()`, but with `movflags=frag_keyframe` the mov muxer flushes fragment N *inside* that call when keyframe N+1 arrives. So `last_fragment_offset_` described the next fragment while the bytes at that offset hadn't been written yet. `writeM3U8` then push_back'd a tentative entry per live update, and the next keyframe push duplicated it with the correct duration. Result: every fragment past the first appeared twice in the manifest (once with bogus `0.040s`, once correctly), and the final fragment was either missing or pointed at the previous fragment's bytes. Players seek-jerked backwards. Fixed in `0e532cd77` by snapshotting after the write; a new `VideoStore::finalize()` runs the trailer logic and parses the trailing `mfro` box so the last fragment's actual byte range can be recorded.

### PHP — `view_hls.php` produced double-prefixed URLs
The regex captured `index.php?…` in `$1` and prepended `$base_url . '?'`, emitting `/zm/index.php?index.php?view=…` which drops the `view=` route param. Players fetched the manifest as if it were the mp4 fragment. Fixed in `275b675ac` by capturing only the query string.

### PHP — `view_video.php` advertised m3u8 filename when serving mp4 bytes
The fallback resolves `$path` to the actual mp4, but `Content-Disposition` still used `DefaultVideo`, so the download button saved a manifest. Fixed in `20da5e5f1` by deriving the filename from `$path`.

### PHP — closed-event detection bypassed HLS
The original `$has_hls` check required `DefaultVideo` to end in `.m3u8`, but closed events get their `DefaultVideo` rewritten to the renamed mp4. Fixed in `10a4f9af1` / `375e82fd8` / `5c0532fe3` by keying HLS selection off on-disk `index.m3u8` plus a (MP4HLS / auto) codec choice. Explicit MP4 stays native; MJPEG short-circuits earlier via `$video_tag`.

### PHP — `liveui:true` blocked scrubbing
video.js's liveui replaces the seekbar with a live-edge-only control for in-progress events, making it impossible to seek back through the already-recorded portion. Fixed in `e378da3d1` by keeping the standard seekbar.

### C++ — VideoStore lifecycle bugs surfaced by `finalize()`
- `4182a829d` drains `reorder_queues` inside `finalize()` ahead of the trailer write (the destructor's drain would otherwise push packets into a closed AVFormatContext).
- `4aa62a4d8` makes `VideoStore::filename` a `std::string` (the caller renames + reassigns the source `video_incomplete_path`, dangling any `const char*` finalize() held into it for `fopen()`); also adds `oc` null guards in the destructor.
- `2c…` (latest) refactors the destructor to just call `finalize()` so the queue-drain / trailer / close logic lives in one place.

## Supersedes

- #4803 — view_hls.php regex fix
- #4806 — same plus view_video.php and liveui

## Test plan

- [ ] Record a fresh event, open it before it closes — m3u8 loads, scrubbing works
- [ ] Let the event close, reopen — HLS player still picked, m3u8 still loads, byte-range mp4 segments fetch with correct `Content-Type` / `Content-Disposition`
- [ ] Download button saves the mp4 file (not the manifest)
- [ ] Inspect a generated `index.m3u8` — each fragment listed exactly once, byte ranges are contiguous, durations match keyframe intervals (not `0.04s`)
- [ ] Open an older closed event (DefaultVideo is the mp4, not index.m3u8) — PHP fallback picks HLS when manifest exists
- [ ] Pick MP4 explicitly from the codec dropdown on an event whose monitor records H.264 — native mp4 playback, no HLS fetch
- [ ] Pick MJPEG explicitly — MJPEG stream, no HLS fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)