### PR TITLE
Fix: Managing the availability of the clear logs button on Log page

### DIFF
--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -115,8 +115,11 @@ function manageClearLogsModalBtns() {
     document.getElementById('clearLogsConfirmBtn').disabled = true;
     deleteLogs(getIdSelections());
   });
-  document.getElementById('clearLogsCancelBtn').addEventListener('click', function onClearLogsCancelClick(evt) {
+  $j('#clearLogsConfirm').on('hidden.bs.modal', function onClearLogsConfirmHidden() {
     manageClearButtonAvailability();
+  });
+  document.getElementById('clearLogsCancelBtn').addEventListener('click', function onClearLogsCancelClick(evt) {
+    evt.preventDefault();
     $j('#clearLogsConfirm').modal('hide');
   });
 }

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -116,6 +116,7 @@ function manageClearLogsModalBtns() {
     deleteLogs(getIdSelections());
   });
   document.getElementById('clearLogsCancelBtn').addEventListener('click', function onClearLogsCancelClick(evt) {
+    manageClearButtonAvailability();
     $j('#clearLogsConfirm').modal('hide');
   });
 }
@@ -204,6 +205,7 @@ function initPage() {
   const clearLogsBtn = document.getElementById('clearLogsBtn');
   if (clearLogsBtn) {
     clearLogsBtn.addEventListener('click', function onClearLogsClick(evt) {
+      manageClearButtonAvailability(false);
       evt.preventDefault();
       if (evt.ctrlKey) {
         // Bypass confirmation, but ensure the modal (and its ticker) exists
@@ -216,6 +218,7 @@ function initPage() {
                 deleteLogs(getIdSelections());
               })
               .fail(function(jqXHR) {
+                manageClearButtonAvailability();
                 console.log('error getting clearlogsconfirm', jqXHR);
                 logAjaxFail(jqXHR);
               });
@@ -231,6 +234,7 @@ function initPage() {
                 $j('#clearLogsConfirm').modal('show');
               })
               .fail(function(jqXHR) {
+                manageClearButtonAvailability();
                 console.log('error getting clearlogsconfirm', jqXHR);
                 logAjaxFail(jqXHR);
               });
@@ -243,12 +247,10 @@ function initPage() {
   }
 
   // Enable or disable clear button based on selection
-  table.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', function() {
-    const selections = table.bootstrapTable('getSelections');
-    const clearLogsBtn = document.getElementById('clearLogsBtn');
-    if (clearLogsBtn) {
-      clearLogsBtn.disabled = !selections.length;
-    }
+  table.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', manageClearButtonAvailability);
+
+  table.on('load-success.bs.table', function() {
+    manageClearButtonAvailability();
   });
 
   $j('#filterStartDateTime, #filterEndDateTime')
@@ -257,6 +259,17 @@ function initPage() {
       .on('change', filterLog);
   $j('#filterComponent')
       .on('change', filterLog);
+}
+
+function manageClearButtonAvailability(enable = null) {
+  const selections = table.bootstrapTable('getSelections');
+  const clearLogsBtn = document.getElementById('clearLogsBtn');
+  if (clearLogsBtn) {
+    if (enable === false || !selections.length)
+      clearLogsBtn.disabled = true;
+    else if (enable === true || selections.length)
+      clearLogsBtn.disabled = false;
+  }
 }
 
 $j(document).ready(function() {

--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -112,11 +112,15 @@ function updateHeaderStats(data) {
 function manageClearLogsModalBtns() {
   document.getElementById('clearLogsConfirmBtn').addEventListener('click', function onClearLogsConfirmClick(evt) {
     evt.preventDefault();
+    $j('#clearLogsConfirm').modal('hide');
     document.getElementById('clearLogsConfirmBtn').disabled = true;
     deleteLogs(getIdSelections());
   });
-  $j('#clearLogsConfirm').on('hidden.bs.modal', function onClearLogsConfirmHidden() {
-    manageClearButtonAvailability();
+  $j('#clearLogsConfirm').on('hide.bs.modal', function onClearLogsConfirmHidden(evt) {
+    const idRelatedTarget = $j(document.activeElement).attr('id');
+    // When executing deleteLogs(), we always call a table update
+    // after which manageClearButtonAvailability() is always executed, so there is no need to execute manageClearButtonAvailability() here
+    if (idRelatedTarget != "clearLogsConfirmBtn") manageClearButtonAvailability();
   });
   document.getElementById('clearLogsCancelBtn').addEventListener('click', function onClearLogsCancelClick(evt) {
     evt.preventDefault();
@@ -142,7 +146,6 @@ function deleteLogs(log_ids) {
     data: {'ids[]': chunk},
     success: function(data) {
       if (!log_ids.length) {
-        $j('#clearLogsConfirm').modal('hide');
         table.bootstrapTable('refresh');
       } else {
         if (ticker.innerHTML.length < 1 || ticker.innerHTML.length > 10) {
@@ -155,7 +158,6 @@ function deleteLogs(log_ids) {
     },
     error: function(jqxhr) {
       logAjaxFail(jqxhr);
-      $j('#clearLogsConfirm').modal('hide');
       table.bootstrapTable('refresh');
     }
   });
@@ -268,10 +270,11 @@ function manageClearButtonAvailability(enable = null) {
   const selections = table.bootstrapTable('getSelections');
   const clearLogsBtn = document.getElementById('clearLogsBtn');
   if (clearLogsBtn) {
-    if (enable === false || !selections.length)
+    if (enable === false || !selections.length) {
       clearLogsBtn.disabled = true;
-    else if (enable === true || selections.length)
+    } else if (enable === true || selections.length) {
       clearLogsBtn.disabled = false;
+    }
   }
 }
 


### PR DESCRIPTION
The delete logs button now remains active even after deleting logs (both successful and unsuccessful).
This PR allows for more accurate management of the button's availability.
- After clicking the delete logs button, the button becomes unavailable to avoid repeated clicks, as the bootstrap table can take a long time to update, allowing time for another click of the delete logs button.
- After each table update is complete, a check is made to determine whether rows are selected, and the availability of the clear logs button is determined based on this.
- After clicking the "Cancel" button in the modal confirmation window, the selected rows in the table are checked, and the availability of the clear logs button is determined based on this.
- If an error occurs executing the AJAX request to delete logs, the selected table rows are also analyzed, and the availability of the clear logs button is determined based on this.