### PR TITLE
Fix: Save the selected filter level in the session on Log page

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -157,10 +157,11 @@ function queryRequest() {
     $where = '(' .implode(' OR ', $likes). ')';
   }
 
-  if (!empty($_REQUEST['Component'])) {
+  $requestComponent = (isset($_REQUEST['Component']) && !empty($_REQUEST['Component']) && is_scalar($_REQUEST['Component'])) ? (string) $_REQUEST['Component'] : '';
+  if (!empty($requestComponent)) {
     if ($where) $where .= ' AND ';
     $where .= 'Component = ?';
-    $query['values'][] = $_REQUEST['Component'];
+    $query['values'][] = $requestComponent;
   }
 
   if (!empty($_REQUEST['ServerId'])) {
@@ -205,7 +206,7 @@ function queryRequest() {
   }
 
   zm_session_start();
-  $_SESSION['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
+  $_SESSION['zmLogComponent'] = $requestComponent;
   $_SESSION['zmLogFilterLevel'] = isset($level_codes[$L]) ? $L : '';
   session_write_close();
 

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -185,6 +185,10 @@ function queryRequest() {
     $where .= ' Level = ?';
     $query['values'][] = $level_codes[$L];
   }
+  zm_session_start();
+  $_SESSION['zmLogFilterLevel'] = $L;
+  session_write_close();
+
   if (!empty($_REQUEST['StartDateTime'])) {
     $start_time = strtotime($_REQUEST['StartDateTime']);
     if ($start_time) {

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -1,5 +1,5 @@
 <?php
-$data = array(); 
+$data = array();
 $message = '';
 
 //

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -1,5 +1,5 @@
 <?php
-$data = array();
+$data = array(); 
 $message = '';
 
 //

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -175,7 +175,7 @@ function queryRequest() {
     $query['values'][] = $_REQUEST['level'];
   }
 */
-  $L = (!empty($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
+  $L = (isset($_REQUEST['level']) && !empty($_REQUEST['level']) && is_scalar($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
   $level_codes = array_flip(ZM\Logger::$codes);
   if (!empty($L) && isset($level_codes[$L])) {
     if ($where) $where .= ' AND ';

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -69,6 +69,7 @@ function createRequest() {
 
 function queryRequest() {
   // Offset specifies the starting row to return, used for pagination
+  $newSessionValue = [];
   $offset = 0;
   if (isset($_REQUEST['offset'])) {
     if ((!is_int($_REQUEST['offset']) and !ctype_digit($_REQUEST['offset']))) {
@@ -162,9 +163,7 @@ function queryRequest() {
     $where .= 'Component = ?';
     $query['values'][] = $_REQUEST['Component'];
   }
-  zm_session_start();
-  $_SESSION['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
-  session_write_close();
+  $newSessionValue['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
 
   if (!empty($_REQUEST['ServerId'])) {
     if ($where) $where .= ' AND ';
@@ -185,9 +184,7 @@ function queryRequest() {
     $where .= ' Level = ?';
     $query['values'][] = $level_codes[$L];
   }
-  zm_session_start();
-  $_SESSION['zmLogFilterLevel'] = $L;
-  session_write_close();
+  $newSessionValue['zmLogFilterLevel'] = isset($level_codes[$L]) ? $L : '';
 
   if (!empty($_REQUEST['StartDateTime'])) {
     $start_time = strtotime($_REQUEST['StartDateTime']);
@@ -209,6 +206,13 @@ function queryRequest() {
       ZM\Warning("Unable to parse EndDateTime ".$_REQUEST['EndDateTime']. " into a timestamp");
     }
   }
+
+  zm_session_start();
+  foreach ($newSessionValue as $name => $value) {
+    $_SESSION[$name] = $value;
+  }
+  session_write_close();
+
   if ($where) $where = ' WHERE '.$where;
 
   $data['totalNotFiltered'] = dbFetchOne('SELECT count(*) AS Total FROM `' .$table.'`', 'Total');

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -69,7 +69,6 @@ function createRequest() {
 
 function queryRequest() {
   // Offset specifies the starting row to return, used for pagination
-  $newSessionValue = [];
   $offset = 0;
   if (isset($_REQUEST['offset'])) {
     if ((!is_int($_REQUEST['offset']) and !ctype_digit($_REQUEST['offset']))) {
@@ -163,7 +162,6 @@ function queryRequest() {
     $where .= 'Component = ?';
     $query['values'][] = $_REQUEST['Component'];
   }
-  $newSessionValue['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
 
   if (!empty($_REQUEST['ServerId'])) {
     if ($where) $where .= ' AND ';
@@ -177,14 +175,13 @@ function queryRequest() {
     $query['values'][] = $_REQUEST['level'];
   }
 */
-  $L = $_REQUEST['level'] ?? '';
+  $L = (!empty($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
   $level_codes = array_flip(ZM\Logger::$codes);
   if (!empty($L) && isset($level_codes[$L])) {
     if ($where) $where .= ' AND ';
     $where .= ' Level = ?';
     $query['values'][] = $level_codes[$L];
   }
-  $newSessionValue['zmLogFilterLevel'] = isset($level_codes[$L]) ? $L : '';
 
   if (!empty($_REQUEST['StartDateTime'])) {
     $start_time = strtotime($_REQUEST['StartDateTime']);
@@ -208,9 +205,8 @@ function queryRequest() {
   }
 
   zm_session_start();
-  foreach ($newSessionValue as $name => $value) {
-    $_SESSION[$name] = $value;
-  }
+  $_SESSION['zmLogComponent'] = !empty($_REQUEST['Component']) ? $_REQUEST['Component'] : '';
+  $_SESSION['zmLogFilterLevel'] = isset($level_codes[$L]) ? $L : '';
   session_write_close();
 
   if ($where) $where = ' WHERE '.$where;

--- a/web/skins/classic/views/log.php
+++ b/web/skins/classic/views/log.php
@@ -99,9 +99,10 @@ $levels = array(''=>translate('All'));
 foreach (array_values(ZM\Logger::$codes) as $level) {
   $levels[$level] = $level;
 }
+$selectedLevel = (isset($_SESSION['zmLogFilterLevel']) && !empty($_SESSION['zmLogFilterLevel']) && is_scalar($_SESSION['zmLogFilterLevel'])) ? (string) $_SESSION['zmLogFilterLevel'] : '';
+$selectedLevel = isset($levels[$selectedLevel]) ? $selectedLevel : '';
 echo '<span class="term-value-wrapper">';
-echo htmlSelect('filterLevel', $levels,
-    (isset($_SESSION['zmLogFilterLevel']) ? $_SESSION['zmLogFilterLevel'] : ''),
+echo htmlSelect('filterLevel', $levels, $selectedLevel,
     array('data-on-change'=>'filterLog', 'id'=>'filterLevel', 'class'=>'chosen'));
     #array('class'=>'form-control chosen', 'data-on-change'=>'filterLog'));
 echo '</span>';

--- a/web/skins/classic/views/log.php
+++ b/web/skins/classic/views/log.php
@@ -101,7 +101,7 @@ foreach (array_values(ZM\Logger::$codes) as $level) {
 }
 echo '<span class="term-value-wrapper">';
 echo htmlSelect('filterLevel', $levels,
-    (isset($_SESSION['ZM_LOG_FILTER_LEVEL']) ? $_SESSION['ZM_LOG_FILTER_LEVEL'] : ''),
+    (isset($_SESSION['zmLogFilterLevel']) ? $_SESSION['zmLogFilterLevel'] : ''),
     array('data-on-change'=>'filterLog', 'id'=>'filterLevel', 'class'=>'chosen'));
     #array('class'=>'form-control chosen', 'data-on-change'=>'filterLog'));
 echo '</span>';


### PR DESCRIPTION
- In `\skins\classic\views\log.php`, we tried to read the `ZM_LOG_FILTER_LEVEL' session, but it was always empty because we didn't save anything to it.
- Let's rename `ZM_LOG_FILTER_LEVEL' to `zmLogFilterLevel' for code consistency.