### PR TITLE
If we're trying to view a remote event, we shouldn't pollute the logs

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1359,6 +1359,10 @@ function onStatsResize(vidWidth) {
 }
 
 function initPage() {
+  if (eventNotFound) {
+    console.log("Event was not found.");
+    return;
+  }
   getAvailableTags();
   getSelectedTags();
 

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -17,6 +17,7 @@
 // PHP variables to JS
 //
 var connKey = '<?php echo $connkey ?>';
+const eventNotFound = <?php echo ((!$Event->Id() || ($Event->Id() and !file_exists($Event->Path()))) ? "true" : "false") ?>;
 
 var eventData = {
 <?php if ( $Event->Id() ) { ?>

--- a/web/views/view_video.php
+++ b/web/views/view_video.php
@@ -83,7 +83,7 @@ if ( $errorText ) {
 } 
 
 if ( ! ($fh = @fopen($path, 'rb') ) ) {
-  ZM\Error('Can\'t open video at '.$path);
+  ZM\Debug('Can\'t open video at '.$path);
   header('HTTP/1.0 404 Not Found');
   die();
 }


### PR DESCRIPTION
For example, we were viewing an event, but the page in the browser wasn't closed, and in the meantime, the recorded event was deleted. In this case, there will be a persistent error in the logs.
The code on the Event page probably also needs to be changed.

- Added the "eventNotFound" JS constant for the Event page.
- If a recorded event isn't found (eventNotFound == true), then print a message to the browser console and stop further script processing, as this is pointless, but it will help avoid unnecessary warnings and errors.