### PR TITLE
More readable text color for the DBG level for the dark theme on Log page

### DIFF
--- a/web/skins/classic/css/dark/views/log.css
+++ b/web/skins/classic/css/dark/views/log.css
@@ -39,7 +39,7 @@ tr.log-war td {
 }
 
 tr.log-dbg td {
-    color: #666666;
+    color: #aaaaaa;
     font-style: italic;
 }
 


### PR DESCRIPTION
**Before:**
<img width="1298" height="626" alt="112" src="https://github.com/user-attachments/assets/42319d4d-2124-4089-8a52-3d6f4b1956e4" />

**After:**
<img width="1304" height="628" alt="122" src="https://github.com/user-attachments/assets/26fe23d3-861f-42bd-923d-7f411ec158dd" />
