### PR TITLE
Remove "Loading, please wait" if nothing is found on add_monitors page

### DIFF
--- a/web/skins/classic/views/js/add_monitors.js
+++ b/web/skins/classic/views/js/add_monitors.js
@@ -53,6 +53,8 @@ function probe(params) {
         const rows = data.Streams;
         // rearrange the result into what bootstrap-table expects
         params.success({total: rows.length, totalNotFiltered: rows.length, rows: rows});
+      } else {
+        params.success({total: 0, totalNotFiltered: 0, rows: []});
       }
     },
     error: function(jqXHR) {


### PR DESCRIPTION
Without this change, the message "Loading, please wait" will always be displayed on the page if nothing is found when searching for monitors.
Now Bootstrap table will display "No matching records found"