### PR TITLE
Fix: Filter block on Events page

### DIFF
--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -1089,7 +1089,7 @@ class Filter extends ZM_Object {
   // This displays filters from the events page.
   //
   public function simple_widget() {
-    $html = '<div id="fieldsTable" class="filterTable">';
+    $html = '<div id="fieldsTable" class="filterTable controlHeader">';
     $terms = $this->terms();
     $attrTypes = $this->attrTypes();
     $opTypes = $this->opTypes();

--- a/web/skins/classic/css/base/sidebar.css
+++ b/web/skins/classic/css/base/sidebar.css
@@ -271,7 +271,7 @@ body #sidebarMain .sub-menu-list {
 .extruder-wrapper span.term,
 .extruder-wrapper span.term .term-value-wrapper input,
 .extruder-wrapper span.term > span { /* Aligning input fields */
-  width: 100%;
+  width: 100% !important;
 }
 
 .extruder-wrapper span.term > span:first-child{


### PR DESCRIPTION
- Selected elements in the multi-select overlapped the "Remove all" buttons
- "Value placeholder" was cut off