### PR TITLE
When closing SIDEBAR_MAIN_EXTRUDER, reset its z-Index (skin.js)

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2141,6 +2141,7 @@ function insertControlModuleMenu() {
     if (!SIDEBAR_MAIN_EXTRUDER.classList.contains('isOpened')) {
       $j(SIDEBAR_MAIN_EXTRUDER).openMbExtruder();
     } else {
+      SIDEBAR_MAIN_EXTRUDER.style.zIndex = 'unset';
       $j(SIDEBAR_MAIN_EXTRUDER).closeMbExtruder();
     }
   });

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -44,6 +44,7 @@ var shifted = false;
 var ctrled = false;
 var alted = false;
 var mainContent = document.getElementById('content');
+var timeOutExtruderChange;
 
 const showExtruderPanelOnMouseHover = false;
 const NAVBAR_RELOAD = document.getElementById('reload'); // Top panel with statistics
@@ -2139,10 +2140,10 @@ function insertControlModuleMenu() {
   // Assign to Show/hide button
   menuControlModule.on("click", function() {
     if (!SIDEBAR_MAIN_EXTRUDER.classList.contains('isOpened')) {
+      clearTimeout(timeOutExtruderChange);
       $j(SIDEBAR_MAIN_EXTRUDER).openMbExtruder();
     } else {
-      SIDEBAR_MAIN_EXTRUDER.style.zIndex = 'unset';
-      $j(SIDEBAR_MAIN_EXTRUDER).closeMbExtruder();
+      closeMbExtruder(true);
     }
   });
 
@@ -2448,6 +2449,10 @@ function closeMbExtruder(updateCookie = false) {
     setCookie('zmVisibleMbExtruder', !!SIDEBAR_MAIN_EXTRUDER.classList.contains('isOpened'));
   }
   $j(SIDEBAR_MAIN_EXTRUDER).closeMbExtruder();
+  timeOutExtruderChange = setTimeout(function() {
+    // Prevent premature reset of z-index, as Extruder does not disappear immediately
+    SIDEBAR_MAIN_EXTRUDER.style.zIndex = 'unset';
+  }, 300);
 }
 
 /*


### PR DESCRIPTION
When closing SIDEBAR_MAIN_EXTRUDER, reset its z-Index, as the z-Index is calculated automatically in openMbExtruder(). If you don't reset the index, it will constantly increase every time you open or close SIDEBAR_MAIN_EXTRUDER.