### PR TITLE
If the requested Object isn't found in the database, generate a Warning instead of an Error. (Object.php)

### DIFF
--- a/web/includes/Object.php
+++ b/web/includes/Object.php
@@ -24,7 +24,7 @@ class ZM_Object {
         $table = $class::$table;
         $row = dbFetchOne("SELECT * FROM `$table` WHERE `Id`=?", NULL, array($IdOrRow));
         if (!$row) {
-          Error("Unable to load $class record for Id=$IdOrRow");
+          Warning("Unable to load $class record for Id=$IdOrRow");
           return;
         }
       } else {


### PR DESCRIPTION
It seems to me that if the requested Object wasn't found in the database, it's not a fatal error, but simply a warning. Perhaps it should even be logged as a Debug level.
Isaac, I could be wrong, of course. If I'm wrong, just close this PR.