### PR TITLE
fix: store event StartDateTime with second precision to match disk path (refs #4870)

### DIFF
--- a/src/zm_time.cpp
+++ b/src/zm_time.cpp
@@ -37,17 +37,20 @@ std::string SystemTimePointToString(SystemTimePoint tp) {
 }
 
 std::string SystemTimePointToMysqlString(SystemTimePoint tp) {
+  // Format to whole-second precision only. The MySQL datetime columns this feeds
+  // (e.g. Events.StartDateTime) have no fractional precision, and MySQL 8 ROUNDS
+  // a fractional string when storing it, so ".999999" before midnight would be
+  // promoted to 00:00:00 of the next day. Event::SetPath() derives the on-disk
+  // day folder from to_time_t() (which truncates), so emitting a roundable
+  // fractional made the DB row and the disk folder diverge by a day for events
+  // starting just before local midnight. Truncate here to match to_time_t and
+  // keep both representations on the same second. refs #4870
   time_t tp_sec = std::chrono::system_clock::to_time_t(tp);
-  Microseconds now_frac = std::chrono::duration_cast<Microseconds>(
-                            tp.time_since_epoch() - std::chrono::duration_cast<Seconds>(tp.time_since_epoch()));
 
-  std::string timeString;
-  timeString.reserve(64);
-  char *timePtr = &*(timeString.begin());
+  char buffer[32];
   tm tp_tm = {};
-  timePtr += strftime(timePtr, timeString.capacity(), "%Y-%m-%d %H:%M:%S", localtime_r(&tp_sec, &tp_tm));
-  snprintf(timePtr, timeString.capacity() - (timePtr - timeString.data()), ".%06" PRIi64, static_cast<int64_t>(now_frac.count()));
-  return timeString;
+  strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", localtime_r(&tp_sec, &tp_tm));
+  return std::string(buffer);
 }
 
 std::string TimePointToString(TimePoint tp) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCES
   zm_font.cpp
   zm_onvif_renewal.cpp
   zm_poly.cpp
+  zm_time.cpp
   zm_utils.cpp
   zm_vector2.cpp
   zm_zone.cpp)

--- a/tests/zm_time.cpp
+++ b/tests/zm_time.cpp
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_time.h"
+
+#include <chrono>
+#include <ctime>
+#include <string>
+
+// Build the local-time "%Y-%m-%d %H:%M:%S" string for a whole-second time_t the
+// same way SetPath() derives the on-disk event directory, so the test stays
+// timezone-independent (it compares against the same localtime conversion the
+// production code uses rather than a hard-coded TZ-specific string).
+static std::string LocalSecondString(time_t sec) {
+  tm tm_local = {};
+  localtime_r(&sec, &tm_local);
+  char buffer[32];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm_local);
+  return std::string(buffer);
+}
+
+TEST_CASE("SystemTimePointToMysqlString: whole second has no fractional part") {
+  // 1764623999 == 2025-12-01 19:59:59 UTC; exact-second timepoints must format
+  // without a fractional component because the Events.StartDateTime column is
+  // datetime (second precision).
+  SystemTimePoint tp = std::chrono::system_clock::from_time_t(1764623999);
+  REQUIRE(SystemTimePointToMysqlString(tp) == LocalSecondString(1764623999));
+}
+
+TEST_CASE("SystemTimePointToMysqlString: sub-second part is floored, never rounded up") {
+  // refs #4870: a continuous event whose backdated start keyframe lands in the
+  // last fraction of a second before local midnight must not be promoted to the
+  // next second. MySQL 8 rounds fractional seconds when storing into a
+  // datetime(0) column, while Event::SetPath() truncates via to_time_t(); if the
+  // string we hand MySQL carries a roundable fractional, the DB row and the
+  // on-disk day folder diverge by a day. The string must already be floored to
+  // the whole second that SetPath() (to_time_t) uses.
+  const time_t base_sec = 1764623999;  // floored second SetPath would use
+
+  // Worst case: 999999us before the next second boundary - MySQL 8 would round
+  // this up to base_sec + 1 if we emitted ".999999".
+  SystemTimePoint tp_high =
+    std::chrono::system_clock::from_time_t(base_sec) + Microseconds(999999);
+  REQUIRE(SystemTimePointToMysqlString(tp_high) == LocalSecondString(base_sec));
+
+  // Half-second: the classic round-vs-truncate divergence point.
+  SystemTimePoint tp_half =
+    std::chrono::system_clock::from_time_t(base_sec) + Microseconds(500000);
+  REQUIRE(SystemTimePointToMysqlString(tp_half) == LocalSecondString(base_sec));
+
+  // Small fraction: trivially floors with either policy, included for coverage.
+  SystemTimePoint tp_low =
+    std::chrono::system_clock::from_time_t(base_sec) + Microseconds(1);
+  REQUIRE(SystemTimePointToMysqlString(tp_low) == LocalSecondString(base_sec));
+}
+
+TEST_CASE("SystemTimePointToMysqlString: matches the second used to build the event path") {
+  // The DB StartDateTime and Event::SetPath() must resolve to the same calendar
+  // day. SetPath() derives the directory from to_time_t(start_time); the Mysql
+  // string must use that identical floored second so the day folder and the
+  // StartDateTime row never disagree (refs #4870).
+  const time_t base_sec = 1764623999;
+  SystemTimePoint tp =
+    std::chrono::system_clock::from_time_t(base_sec) + Microseconds(999999);
+
+  time_t path_sec = std::chrono::system_clock::to_time_t(tp);
+  REQUIRE(SystemTimePointToMysqlString(tp) == LocalSecondString(path_sec));
+}

--- a/tests/zm_time.cpp
+++ b/tests/zm_time.cpp
@@ -36,7 +36,7 @@ static std::string LocalSecondString(time_t sec) {
 }
 
 TEST_CASE("SystemTimePointToMysqlString: whole second has no fractional part") {
-  // 1764623999 == 2025-12-01 19:59:59 UTC; exact-second timepoints must format
+  // 1764623999 == 2025-12-01 21:19:59 UTC; exact-second timepoints must format
   // without a fractional component because the Events.StartDateTime column is
   // datetime (second precision).
   SystemTimePoint tp = std::chrono::system_clock::from_time_t(1764623999);


### PR DESCRIPTION
## Problem

Fixes #4870. A continuous-recording event whose start lands just before local midnight is written to disk under the **previous** day's folder while `Events.StartDateTime` records the **next** day, producing a permanent `zmaudit` path mismatch and orphaned files when the event ages out (the purge path is built from `StartDateTime`).

## Root cause

For continuous recording the event start is backdated to the preceding keyframe. When a section is force-closed at local midnight, that keyframe falls a fraction of a second *before* midnight (e.g. `23:59:59.999999`). Two paths derive dates from the same `start_time` but disagree:

- **DB** — `SystemTimePointToMysqlString()` appended `.%06d` microseconds to the string for `Events.StartDateTime` (a `datetime`, no fractional precision). **MySQL 8 rounds** the fractional part when storing into a second-precision column → promoted to `00:00:00` of the next day.
- **Disk** — `Event::SetPath()` uses `to_time_t()`, which **truncates** → previous day's folder.

This is engine-dependent: MySQL 8 (Ubuntu's default) rounds and exhibits the bug; MariaDB truncates and does not. Verified the round-vs-truncate split against a live DB.

## Fix

Format `SystemTimePointToMysqlString()` to whole seconds only. The target column can't hold sub-second precision anyway, and dropping the fractional makes the stored value match the floored `to_time_t()` second that `SetPath()` uses — so the DB row and the disk folder stay on the same second regardless of whether the engine rounds or truncates.

Frame deltas still use the full-precision in-memory `start_time`, so no recorded-timing precision is lost.

## Tests

New `tests/zm_time.cpp` (registered in `tests/CMakeLists.txt`) covering:
- whole-second timepoints format without a fractional part,
- sub-second parts are floored (not rounded up) at the `.5` and `.999999` boundaries,
- the formatted second matches the `to_time_t`-derived path second.

Tests are timezone-independent (compared against the same `localtime_r` conversion the production code uses).

**Results:** new tests pass (5 assertions / 3 cases); full suite passes (678 assertions / 66 cases).

## Note

This fixes the cause going forward. Pre-existing orphaned files / mismatched rows would need a one-time `zmaudit` reconcile — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)