### PR TITLE
fix: apply filter result limit when an empty Tags term is present

### DIFF
--- a/web/ajax/events.php
+++ b/web/ajax/events.php
@@ -272,7 +272,7 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
   } # end foreach row
 
   # Filter limits come before pagination limits.
-  if ($filter->limit() and ($filter->limit() > count($unfiltered_rows))) {
+  if ($filter->limit() and ($filter->limit() < count($unfiltered_rows))) {
     ZM\Debug("Filtering rows due to filter->limit " . count($unfiltered_rows)." limit: ".$filter->limit());
     $unfiltered_rows = array_slice($unfiltered_rows, 0, $filter->limit());
   }

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -116,7 +116,8 @@ class Filter extends ZM_Object {
     if ( ! isset($this->_pre_sql_conditions) ) {
       $this->_pre_sql_conditions = array();
       foreach ( $this->FilterTerms() as $term ) {
-        if ( $term->is_pre_sql() )
+        // Invalid terms add no SQL, so must not count as a condition.
+        if ( $term->is_pre_sql() and $term->valid() )
           $this->_pre_sql_conditions[] = $term;
       } # end foreach term
     }
@@ -128,7 +129,8 @@ class Filter extends ZM_Object {
     if ( ! isset($this->_post_sql_conditions) ) {
       $this->_post_sql_conditions = array();
       foreach ( $this->FilterTerms() as $term ) {
-        if ( $term->is_post_sql() )
+        // Invalid terms add no SQL, so must not count as a condition.
+        if ( $term->is_post_sql() and $term->valid() )
           $this->_post_sql_conditions[] = $term;
       } # end foreach term
     }

--- a/web/includes/FilterTerm.php
+++ b/web/includes/FilterTerm.php
@@ -501,7 +501,8 @@ class FilterTerm {
   }
 
   public function is_post_sql() {
-    if ( $this->attr == 'ExistsInFileSystem' || $this->attr == 'Tags') {
+    // Tags is filtered in SQL (see sql_attr/sql), so it is not post-sql.
+    if ( $this->attr == 'ExistsInFileSystem' ) {
         return true;
     }
     return false;


### PR DESCRIPTION
@connortechnology below is Claude's version, not sure if simpler had a reason to apply tags as post sql. I don't really have PHP frontend to test with anymore....

The event filter "Limit to first N" stopped being honored in 1.38. Using "List Matches" on a filter that should return N events returned all matching events instead. This was a regression from 1.36, triggered by the Tags feature.

Root cause chain:

1. The events view adds a default, empty `Tags` term to unsaved filters. That term is invalid (empty value) so Filter::sql() correctly omits it from the WHERE clause, but pre_sql_conditions()/post_sql_conditions() counted it regardless of validity.

2. Tags was classified as a post-sql condition, even though it is filtered in SQL (sql_attr() returns T.Id, with EXISTS/NOT EXISTS for any/no tag) and its post-sql test() was a no-op stub. So the empty Tags term made has_post_sql_conditions true.

3. has_post_sql_conditions being true disabled the SQL LIMIT fast-path in ajax/events.php, leaving the PHP-side trim as the only limit enforcement -- and that trim used an inverted comparison (limit > row count), so it never trimmed when there were more rows than the limit.

Fixes:

- Filter::pre_sql_conditions()/post_sql_conditions() now require term->valid(), so empty default terms no longer count as conditions and the SQL LIMIT fast-path stays enabled.
- FilterTerm::is_post_sql() no longer returns true for Tags, since Tags is handled in SQL.
- ajax/events.php filter-limit trim comparison corrected to '<' so the limit is applied when there are more matches than the limit (matches the pagination trim below it). This covers genuine post-sql filters such as ExistsInFileSystem.