### PR TITLE
[1.38] Fix: PanZoom. When scale > 1, prevent the player from responding to image clicks (panzoom.js)

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -252,12 +252,16 @@ var zmPanZoom = {
       }
     }
 
+    const videoJs = document.querySelector('.video-js .vjs-tech');
+
     if (this.panZoom[id].getScale().toFixed(1) > 1) {
       this.panZoom[id].setOptions({handleStartEvent: (event) => {
         event.preventDefault();
       }});
+      if (videoJs) videoJs.style.pointerEvents = 'none';
     } else {
       this.panZoom[id].setOptions({handleStartEvent: (event) => {}});
+      if (videoJs) videoJs.style.pointerEvents = '';
     }
   },
 


### PR DESCRIPTION
Similar to the Master branch: #4651
Closed #4872