### PR TITLE
Allow overflow for "#contentForm" on Monitor page

### DIFF
--- a/web/skins/classic/css/base/views/monitor.css
+++ b/web/skins/classic/css/base/views/monitor.css
@@ -78,6 +78,11 @@ tr td input[type="radio"] {
   padding-top: 0.5rem;
 }
 
+#contentForm {
+  height: 100%;
+  overflow: visible;
+}
+
 body.sticky #content {
   overflow-y: auto;
   height: 100%;


### PR DESCRIPTION
There's no need to restrict overflow specifically for the form, as we're controlling the sizes of the parent blocks. Allowing overflow visibility will allow drop-down lists to display more correctly.

**Before**
<img width="1460" height="792" alt="Before1" src="https://github.com/user-attachments/assets/0e7a1577-669d-4cc2-955b-f229c3154b22" />

**After**
<img width="1458" height="796" alt="After1" src="https://github.com/user-attachments/assets/a88b33cf-46e1-4826-b5df-4917b1407a68" />