### PR TITLE
Slightly sped up DOM rendering when switching monitors on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -944,6 +944,7 @@ function streamReStart(oldId, newId) {
   el.removeEventListener('mouseleave', handleMouseLeave);
 
   //Change main monitor block
+  monitor_div.textContent = '';
   monitor_div.innerHTML = currentMonitor.streamHTML;
 
   const volumeControls = document.getElementById('volumeControls'+oldId);


### PR DESCRIPTION
Clearing via `textContent` is performed without page parsing, which speeds up cleanup. 
When executing `innerHTML`, clearing will first occur by parsing the page, and then assigning new elements. 
This will slightly speed up DOM rendering by quickly clearing.