### PR TITLE
Prevent pointless setInterval(this.statusCmdQuery) calls for "frozen"objects. (MonitorStream.js)

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1564,12 +1564,12 @@ function MonitorStream(monitorData) {
         .fail(logAjaxFail);
 
     if (this.Go2RTCEnabled && ((!this.player) || (-1 !== this.player.indexOf('go2rtc')))) {
-      if (!this.element.currentMode) {
-        // TODO: For some reason, when switching monitors very quickly on the Watch page while using go2rtc, "this.statusCmdTimer" sometimes doesn't clear.
-        // This is likely due to the generation of the <video> tag in video-rtc.js.
-        clearInterval(this.statusCmdTimer);
+      if (!this.element || !this.element.isConnected) {
+        // Stream element has been detached; stop polling to avoid intervals running on stale objects.
+        this.statusCmdTimer = clearInterval(this.statusCmdTimer);
         return;
       }
+      if (!this.element.currentMode) return;
       if (-1 !== this.element.currentMode.toLowerCase().indexOf('mse')) {
         $j('#delay'+this.id).removeClass('hidden');
         this.manageMSESocket(this.element.video, this.element.ws, this.element.ms);

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1564,6 +1564,12 @@ function MonitorStream(monitorData) {
         .fail(logAjaxFail);
 
     if (this.Go2RTCEnabled && ((!this.player) || (-1 !== this.player.indexOf('go2rtc')))) {
+      if (!this.element.currentMode) {
+        // TODO: For some reason, when switching monitors very quickly on the Watch page while using go2rtc, "this.statusCmdTimer" sometimes doesn't clear.
+        // This is likely due to the generation of the <video> tag in video-rtc.js.
+        clearInterval(this.statusCmdTimer);
+        return;
+      }
       if (-1 !== this.element.currentMode.toLowerCase().indexOf('mse')) {
         $j('#delay'+this.id).removeClass('hidden');
         this.manageMSESocket(this.element.video, this.element.ws, this.element.ms);


### PR DESCRIPTION
This PR doesn't fix the root cause of the issue, but addresses the consequences. I spent time investigating the problem, but I couldn't figure out the root cause because it's difficult to debug. Perhaps I'll revisit this issue later.
For now, let's leave it at that.