### PR TITLE
Feat: When updating the status panel, also update the status logs

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -24,6 +24,7 @@ if ($_REQUEST['entity'] == 'navBar') {
   $data['getStorageHTML'] = getStorageHTML();
   //$data['getShmHTML'] = getShmHTML();
   $data['getRamHTML'] = getRamHTML();
+  $data['getLogStatusHTML'] = logState();
 
   ajaxResponse($data);
   return;

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -507,6 +507,20 @@ if ( currentView != 'none' && currentView != 'login' ) {
     // iterate through all the keys then update each element id with the same name
     for (const key of Object.keys(data)) {
       if ( $j('#'+key).hasClass("show") ) continue; // don't update if the user has the dropdown open
+      if (key == 'getLogStatusHTML') {
+        let getLogHTML = [];
+        logState = data[key];
+        const _class = (logState == 'ok') ? 'text-success' : (logState == 'alert' ? 'text-warning' : ((logState == 'alarm' ? 'text-danger' : '')));
+        getLogHTML.push(document.querySelector('#getLogHTML a'));
+        getLogHTML.push(document.querySelector('#getLogIconHTML a span')); // Navbar Type = Collapsed
+        getLogHTML.push(document.querySelector('#logState')); // Log page
+        for (let i = 0; i < getLogHTML.length; i++) {
+          if (getLogHTML[i] === null) continue;
+            getLogHTML[i].classList.remove('text-success', 'text-warning', 'text-danger');
+            getLogHTML[i].classList.add(_class);
+        }
+        continue;
+      }
       if ( $j('#'+key).length ) $j('#'+key).replaceWith(data[key]);
       if ( key == 'getBandwidthHTML' ) bwClickFunction();
     }

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -508,16 +508,16 @@ if ( currentView != 'none' && currentView != 'login' ) {
     for (const key of Object.keys(data)) {
       if ( $j('#'+key).hasClass("show") ) continue; // don't update if the user has the dropdown open
       if (key == 'getLogStatusHTML') {
-        let getLogHTML = [];
-        logState = data[key];
+        const getLogHTML = [];
+        const logState = data[key];
         const _class = (logState == 'ok') ? 'text-success' : (logState == 'alert' ? 'text-warning' : ((logState == 'alarm' ? 'text-danger' : '')));
         getLogHTML.push(document.querySelector('#getLogHTML a'));
         getLogHTML.push(document.querySelector('#getLogIconHTML a span')); // Navbar Type = Collapsed
         getLogHTML.push(document.querySelector('#logState')); // Log page
         for (let i = 0; i < getLogHTML.length; i++) {
           if (getLogHTML[i] === null) continue;
-            getLogHTML[i].classList.remove('text-success', 'text-warning', 'text-danger');
-            getLogHTML[i].classList.add(_class);
+          getLogHTML[i].classList.remove('text-success', 'text-warning', 'text-danger');
+          getLogHTML[i].classList.add(_class);
         }
         continue;
       }


### PR DESCRIPTION
Currently, the text and icon colors for logs don't change when updating the status bar.

I don't think this is right, as the log status is useful information.
We won't completely redraw the DOM element, as is implemented in` getSysLoadHTML(), getRamHTML()`, and the like. We'll change the element's class.