### PR TITLE
Fix: Correct operation on the Monitor page with "Source Type = Web site"

### DIFF
--- a/web/skins/classic/views/js/monitor.js
+++ b/web/skins/classic/views/js/monitor.js
@@ -313,37 +313,40 @@ function initPage() {
 
   var sourceFormMonitor = $j('#contentForm').serialize();
   // Manage the ZONES Button
-  document.getElementById("zones-tab").addEventListener("click", function onZonesClick(evt) {
-    if ($j('#contentForm').serialize() !== sourceFormMonitor) {
-      evt.preventDefault();
-      const data = {
-        request: "modal",
-        modal: "saveconfirm",
-        key: messageSavingDataWhenLeavingPage
-      };
+  const zonesTab = document.getElementById("zones-tab");
+  if (zonesTab) {
+    zonesTab.addEventListener("click", function onZonesClick(evt) {
+      if ($j('#contentForm').serialize() !== sourceFormMonitor) {
+        evt.preventDefault();
+        const data = {
+          request: "modal",
+          modal: "saveconfirm",
+          key: messageSavingDataWhenLeavingPage
+        };
 
-      if (!document.getElementById('saveConfirm')) {
-        // Load the save confirmation modal into the DOM
-        $j.getJSON(thisUrl, data)
-            .done(function(data) {
-              insertModalHtml('saveConfirm', data.html);
-              manageSaveConfirmModalBtns();
-              $j('#saveConfirm').modal('show');
-            })
-            .fail(function(jqXHR) {
-              console.log('error getting saveconfirm', jqXHR);
-              logAjaxFail(jqXHR);
-            });
-        return;
+        if (!document.getElementById('saveConfirm')) {
+          // Load the save confirmation modal into the DOM
+          $j.getJSON(thisUrl, data)
+              .done(function(data) {
+                insertModalHtml('saveConfirm', data.html);
+                manageSaveConfirmModalBtns();
+                $j('#saveConfirm').modal('show');
+              })
+              .fail(function(jqXHR) {
+                console.log('error getting saveconfirm', jqXHR);
+                logAjaxFail(jqXHR);
+              });
+          return;
+        } else {
+          document.getElementById('saveConfirmBtn').disabled = false; // re-enable the button
+          $j('#saveConfirm').modal('show');
+        }
       } else {
-        document.getElementById('saveConfirmBtn').disabled = false; // re-enable the button
-        $j('#saveConfirm').modal('show');
+        const href = '?view=zones&mid='+mid;
+        window.location.assign(href);
       }
-    } else {
-      const href = '?view=zones&mid='+mid;
-      window.location.assign(href);
-    }
-  });
+    });
+  }
 
   // Manage the SAVE CONFIRMATION modal button
   function manageSaveConfirmModalBtns() {

--- a/web/skins/classic/views/js/monitor.js.php
+++ b/web/skins/classic/views/js/monitor.js.php
@@ -175,7 +175,7 @@ function validateForm(form) {
       errors[errors.length] = "<?php echo translate('BadWebColour') ?>";
   }
 
-  if ( form.elements['newMonitor[RTSPStreamName]'].value
+  if ( form.elements['newMonitor[RTSPStreamName]'] && form.elements['newMonitor[RTSPStreamName]'].value
       &&
       rtspStreamNames[form.elements['newMonitor[RTSPStreamName]'].value]
     )
@@ -186,7 +186,7 @@ function validateForm(form) {
     return false;
   }
 
-  if ( (form.elements['newMonitor[Recording]'].value != 'None') ) {
+  if ( (form.elements['newMonitor[Recording]'] && form.elements['newMonitor[Recording]'].value != 'None') ) {
     if ( (form.elements['newMonitor[SaveJPEGs]'].value == '0') && (form.elements['newMonitor[VideoWriter]'].value == '0') ) {
       warnings[warnings.length] = "<?php echo translate('BadNoSaveJPEGsOrVideoWriter'); ?>";
     }


### PR DESCRIPTION
- The absence of "#zones-tab" should not result in errors on the Monitor page. (monitor.js)
- When getting the value for "form.elements['newMonitor[RTSPStreamName]']" and "form.elements['newMonitor[Recording]']", check for the presence of the elements themselves. (monitor.js.php)