### PR TITLE
fix: correct stale SharedData and TriggerData offsets in PHP shm map

### DIFF
--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -49,11 +49,12 @@ class Monitor extends ZM_Object {
     'last_write_time'  => [ 'type'=>'time_t64', 'offset'=>128, 'size'=>8 ],
     'last_read_time'   => [ 'type'=>'time_t64', 'offset'=>136, 'size'=>8 ],
     'last_viewed_time' => [ 'type'=>'time_t64', 'offset'=>144, 'size'=>8 ],
-    'control_state'    => [ 'type'=>'uint8[256]', 'offset'=>152, 'size'=>256 ],
-    'alarm_cause'      => [ 'type'=>'int8[256]', 'offset'=>408, 'size'=>256 ],
-    'video_fifo'       => [ 'type'=>'int8[64]', 'offset'=>664, 'size'=>64 ],
-    'audio_fifo'       => [ 'type'=>'int8[64]', 'offset'=>728, 'size'=>64 ],
-    'janus_pin'        => [ 'type'=>'int8[64]', 'offset'=>792, 'size'=>64 ],
+    'last_analysis_viewed_time' => [ 'type'=>'time_t64', 'offset'=>152, 'size'=>8 ],
+    'control_state'    => [ 'type'=>'uint8[256]', 'offset'=>160, 'size'=>256 ],
+    'alarm_cause'      => [ 'type'=>'int8[256]', 'offset'=>416, 'size'=>256 ],
+    'video_fifo'       => [ 'type'=>'int8[64]', 'offset'=>672, 'size'=>64 ],
+    'audio_fifo'       => [ 'type'=>'int8[64]', 'offset'=>736, 'size'=>64 ],
+    'janus_pin'        => [ 'type'=>'int8[64]', 'offset'=>800, 'size'=>64 ],
   ], 
   'TriggerData' => [
     'size'     => [ 'type'=>'uint32', 'offset'=>864, 'size'=>4 ],
@@ -62,7 +63,7 @@ class Monitor extends ZM_Object {
     'padding'  => [ 'type'=>'uint32', 'offset'=>876, 'size'=>4 ],
     'cause'    => [ 'type'=>'int8[32]', 'offset'=>880, 'size'=>32 ],
     'text'     => [ 'type'=>'int8[256]', 'offset'=>912, 'size'=>256 ],
-    'showtext' => [ 'type'=>'int8[256]', 'offset'=>1268, 'size'=>256 ],
+    'showtext' => [ 'type'=>'int8[256]', 'offset'=>1168, 'size'=>256 ],
     // 1424
   ]
   ];


### PR DESCRIPTION
## What

The PHP shared-memory map in `web/includes/Monitor.php` was not updated when `last_analysis_viewed_time` was added to `SharedData` (`src/zm_monitor.h`, offset +152), so every field after it is read 8 bytes early by the web UI:

| Field | C++ struct | PHP map (before) |
|---|---|---|
| `last_analysis_viewed_time` | +152 | missing |
| `control_state[256]` | +160 | 152 |
| `alarm_cause[256]` | +416 | 408 |
| `video_fifo_path[64]` | +672 | 664 |
| `audio_fifo_path[64]` | +736 | 728 |
| `janus_pin[64]` | +800 | 792 |

The `TriggerData` base offset (864) *was* updated at the time, so only the SharedData tail is skewed. The skew goes undetected because `connect()` only checks the `valid` byte at +88 (in the unaffected region) and never compares the `size` field.

Also fixes a second, independent typo in the TriggerData map: `text` is 256 bytes at offset 912, so `showtext` starts at 1168, not 1268.

## Impact

Anything the web UI reads from the SharedData tail is affected — most visibly `alarm_cause` (returns the last 8 bytes of `control_state` followed by the truncated cause) and `janus_pin` (read 8 bytes into the previous string).

## Notes

- The Perl map (`scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in`) computes offsets from the field sequence and already includes `last_analysis_viewed_time`, so it is unaffected — only the hardcoded PHP table drifted.
- Offsets verified field-by-field against `SharedData`/`TriggerData` in `src/zm_monitor.h` on current master; `php -l` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)