### PR TITLE
fix: pass monitor Id through validCardinal in Janus_Pin shell command

### DIFF
--- a/web/includes/Monitor.php
+++ b/web/includes/Monitor.php
@@ -396,7 +396,7 @@ class Monitor extends ZM_Object {
     if (!$this->{'JanusEnabled'}) return '';
 
     if ((!defined('ZM_SERVER_ID')) or ( property_exists($this, 'ServerId') and (ZM_SERVER_ID==$this->{'ServerId'}) )) {
-      $cmd = getZmuCommand(' --janus-pin -m '.$this->{'Id'});
+      $cmd = getZmuCommand(' --janus-pin -m '.validCardinal($this->{'Id'}));
       $output = shell_exec($cmd);
       Debug("Running $cmd output: $output");
       return $output ? trim($output) : $output;


### PR DESCRIPTION
## Summary

`Monitor::Janus_Pin()` interpolated `$this->Id()` directly into the `zmu` command string passed to `shell_exec()`, whereas the sibling `AlarmCommand()` path already routes the same value through `validCardinal()` before building its command. This brings the two into line so every `Id` reaching a shell sink is validated as a cardinal number.

```diff
-      $cmd = getZmuCommand(' --janus-pin -m '.$this->{'Id'});
+      $cmd = getZmuCommand(' --janus-pin -m '.validCardinal($this->{'Id'}));
```

## Exploitability

Not exploitable. `Id` is the monitor's integer primary key sourced from the database, not user-controlled. This is a consistency / defense-in-depth change, not a fix for a reachable vulnerability — filed openly per `SECURITY.md` ("if it's not such a big deal, by all means, create an issue here").

## Testing

PHP is interpreted; no build required. Janus pin retrieval continues to work — `validCardinal()` returns the integer Id unchanged for valid monitors. `validCardinal()` is already used in this file (e.g. `AlarmCommand()`), so it is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)