### PR TITLE
docs: update security policy supported versions and reporting channels

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,32 @@
 
 ## Supported Versions
 
-Time and computers move on. We do not have the resources to support every ancient version of everything (unless you'd like to pay us to do so). We ONLY support the latest stable release and development releases. ZoneMinder uses Semantic Versioning with even minor versions being stable and odd being development. 
+We do not have the resources to support every old version. ZoneMinder uses
+Semantic Versioning: even minor versions are stable, odd are development. We
+support the current stable release series and the current development series;
+the previous stable series receives security fixes on a best-effort basis.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.36.x   | :white_check_mark: |
-| 1.37.x   | :white_check_mark: |
-| < 1.36.x   | :x:                |
+| 1.39.x (dev)    | :white_check_mark: |
+| 1.38.x (stable) | :white_check_mark: |
+| 1.36.x (legacy) | :warning: best-effort security fixes |
+| < 1.36.x        | :x:                |
 
 ## Reporting a Vulnerability
 
-Since sometimes security vulnerabilities can be sensitive, you can just email me at isaac@zoneminder.com. If it's not such a big deal, by all means, create an issue here on GitHub.
+Please report security vulnerabilities **privately** so we can fix them before
+they are disclosed publicly. Two options:
+
+1. **GitHub Private Vulnerability Reporting (preferred)** — go to the
+   [Security tab](https://github.com/ZoneMinder/zoneminder/security/advisories)
+   and click **Report a vulnerability**. This opens a private advisory where we
+   can collaborate on a fix and issue a CVE.
+2. **Email** — isaac@zoneminder.com.
+
+Please do **not** open a public GitHub issue for a suspected vulnerability.
+Non-sensitive hardening suggestions (defense-in-depth with no exploit path) are
+fine as normal issues or pull requests.
+
+We aim to acknowledge reports within a few days and to coordinate disclosure
+once a fix is available.


### PR DESCRIPTION
## Summary

Refreshes `SECURITY.md`, which had drifted from reality.

**Supported versions** — the table listed 1.36.x and 1.37.x. 1.37 was the development line that became 1.38 stable and no longer exists. Updated to the current series:

| Version | Supported |
| ------- | --------- |
| 1.39.x (dev) | ✅ |
| 1.38.x (stable) | ✅ |
| 1.36.x (legacy) | ⚠️ best-effort security fixes |
| < 1.36.x | ❌ |

The 1.36.x "best-effort" row reflects actual practice — the `release-1.36` branch is still receiving security backports (most recently the per-event ACL fix for GHSA-vj5r-pc2v-gfwv on 2026-06-03), but no feature work.

**Reporting a vulnerability** — rewritten to direct reports to **GitHub Private Vulnerability Reporting** (already enabled on this repo) as the preferred channel, with email as a fallback. It now explicitly asks people **not** to open public issues for suspected vulnerabilities, while still welcoming non-sensitive hardening suggestions as issues or PRs.

No functional/code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)