### PR TITLE
docs: resolve conflicting license statements in Perl modules (fixes #817)

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder.pm
@@ -130,9 +130,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2005 by Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in
@@ -314,9 +314,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -4284,9 +4284,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control.pm
@@ -642,9 +642,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/3S.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/3S.pm
@@ -567,9 +567,8 @@ Juan Manuel Castro, E<lt>juanmanuel.castro@gmail.comE<gt>
 
 Copyright (C) 2014 Juan Manuel Castro
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/AxisV2.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/AxisV2.pm
@@ -587,9 +587,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/DCS3415.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/DCS3415.pm
@@ -183,7 +183,6 @@ If you have a web site set up for your module, mention it here.
 Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 =head1 COPYRIGHT AND LICENSE
 Copyright (C) 2001-2008  Philip Coombes
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8608W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8608W_Y2k.pm
@@ -669,9 +669,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8620_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8620_Y2k.pm
@@ -745,9 +745,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8918W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI8918W.pm
@@ -322,9 +322,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9821W_Y2k.pm
@@ -750,9 +750,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9831W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FI9831W.pm
@@ -754,9 +754,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/FOSCAMR2C.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/FOSCAMR2C.pm
@@ -372,9 +372,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Floureon.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Floureon.pm
@@ -350,9 +350,8 @@ Ognyan Bankov, E<lt>ogibankov@gmail.comE<gt>
 
 Copyright (C) 2017  Ognyan Bankov
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Grandstream.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Grandstream.pm
@@ -264,8 +264,7 @@ Isaac Connor E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2021 by ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/IPCC7210W.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/IPCC7210W.pm
@@ -345,8 +345,7 @@ ZoneMinder::Control::Wanscam
 
 Copyright (C) 2001-2008  
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/M8640.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/M8640.pm
@@ -447,9 +447,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/MaginonIPC.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/MaginonIPC.pm
@@ -294,9 +294,8 @@ Martin Gutenbrunner, E<lt>martin.gutenbrunner@gmx.atE<gt>
 
 Copyright (C) 2017 by Martin Gutenbrunner
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Ncs370.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Ncs370.pm
@@ -200,9 +200,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/PanasonicIP.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/PanasonicIP.pm
@@ -281,9 +281,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoD.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoD.pm
@@ -699,9 +699,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoP.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/PelcoP.pm
@@ -707,9 +707,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/SPP1802SWPTZ.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/SPP1802SWPTZ.pm
@@ -320,9 +320,8 @@ git checkout -b SunEyes_sp-p1802swptz
 
 Copyright (C) 2015-  Bobby Billingsley
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Serial_HEX_PelcoD.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Serial_HEX_PelcoD.pm
@@ -499,9 +499,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 Copyright (C) 2001-2008  Philip Coombes
 Copyright (C) 2025  V.Nikolaev
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/SkyIPCam7xx.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/SkyIPCam7xx.pm
@@ -258,8 +258,7 @@ Brian Rudy, E<lt>brudyNO@SPAMpraecogito.comE<gt>
 
 Copyright (C) 2008 by Brian Rudy
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Sony.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Sony.pm
@@ -333,8 +333,7 @@ Updated by Isaac Connor E<lt>isaac@zoneminder.com<gt>
 
 Copyright (C) 2013-2014  Iman Darabi
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Toshiba_IK_WB11A.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Toshiba_IK_WB11A.pm
@@ -218,9 +218,8 @@ Tim Craig, E<lt>timcraigNO@SPAMsonic.netE<gt>
 
 Copyright (C) 2013 by Tim Craig
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Visca.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Visca.pm
@@ -633,9 +633,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Vivotek_ePTZ.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Vivotek_ePTZ.pm
@@ -316,8 +316,7 @@ Robin Daermann E<lt>r.daermann@ids-services.deE<gt>
 
 Copyright (C) 2015 by Robin Daermann
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Wanscam.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Wanscam.pm
@@ -462,9 +462,8 @@ Philip Coombes, <philip.coombes@zoneminder.com>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/WanscamHW0025.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/WanscamHW0025.pm
@@ -360,9 +360,8 @@ Philip Coombes, <philip.coombes@zoneminder.com>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/mjpgStreamer.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/mjpgStreamer.pm
@@ -215,9 +215,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2005 by Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event.pm
@@ -1129,9 +1129,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event_Summary.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event_Summary.pm
@@ -91,9 +91,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Event_Tag.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Event_Tag.pm
@@ -77,9 +77,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2022  ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Filter.pm
@@ -682,9 +682,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Frame.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Frame.pm
@@ -70,9 +70,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Group.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Group.pm
@@ -95,9 +95,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2022 ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Logger.pm
@@ -919,9 +919,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Manufacturer.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Manufacturer.pm
@@ -62,9 +62,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2023  ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in
@@ -918,9 +918,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Model.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Model.pm
@@ -79,9 +79,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2023  ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Monitor.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Monitor.pm
@@ -637,9 +637,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Monitor_Status.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Monitor_Status.pm
@@ -75,9 +75,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/ONVIF.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ONVIF.pm.in
@@ -415,9 +415,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Object.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Object.pm
@@ -990,9 +990,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/State.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/State.pm
@@ -69,9 +69,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2022  ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Storage.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Storage.pm
@@ -237,9 +237,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2022 ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Tag.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Tag.pm
@@ -72,9 +72,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2022  ZoneMinder Inc
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel.pm
@@ -158,9 +158,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/File.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/File.pm
@@ -116,9 +116,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Handle.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Handle.pm
@@ -152,9 +152,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Inet.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Inet.pm
@@ -144,9 +144,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Serial.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Serial.pm
@@ -164,9 +164,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Spawning.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Spawning.pm
@@ -104,9 +104,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Unix.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Channel/Unix.pm
@@ -141,9 +141,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Connection.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Connection.pm
@@ -237,9 +237,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Connection/Example.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Trigger/Connection/Example.pm
@@ -126,9 +126,8 @@ Philip Coombes, E<lt>philip.coombes@zoneminder.comE<gt>
 
 Copyright (C) 2001-2008  Philip Coombes
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/User.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/User.pm
@@ -72,9 +72,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut

--- a/scripts/ZoneMinder/lib/ZoneMinder/Zone.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Zone.pm
@@ -105,9 +105,8 @@ Isaac Connor, E<lt>isaac@zoneminder.comE<gt>
 
 Copyright (C) 2001-2017  ZoneMinder LLC
 
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself, either Perl version 5.8.3 or,
-at your option, any later version of Perl 5 you may have available.
+Licensed under the GNU General Public License v2 or later; see the COPYING
+file distributed with ZoneMinder for the full text.
 
 
 =cut


### PR DESCRIPTION
## Summary

Fixes #817 (open since 2015). The ZoneMinder Perl modules carry a **GPL-2-or-later** notice in their file header, but end with an `h2xs`-scaffolding POD footer claiming the code may be used *"under the same terms as Perl itself"* (Artistic-1.0-or-GPL-1+). The two statements contradict each other.

## Why this is a clarification, not a relicense

- The project is GPL-2+ (`COPYING` is GPLv2; every affected file's header is GPL-2+).
- In **every** file the *same copyright holder* wrote both the GPL-2+ header and the Perl-terms footer — including the third-party-contributed `Control/*.pm` modules. Each was contributed to a GPL-2+ project under a GPL-2+ header; the Perl-terms line is inherited boilerplate copied from an existing module template, never an intentional license election.
- GPL-2+ is therefore already the governing license. This change removes a contradictory line; it does not change the license anyone relied on.

## Change

Replace the contradictory POD paragraph:

```
This library is free software; you can redistribute it and/or modify
it under the same terms as Perl itself, either Perl version 5.8.3 or,
at your option, any later version of Perl 5 you may have available.
```

with a single-line pointer to the canonical license (the full notice already lives in each file's header, so it is not duplicated):

```
Licensed under the GNU General Public License v2 or later; see the COPYING
file distributed with ZoneMinder for the full text.
```

Copyright and author attribution lines are left untouched. The edit is entirely within POD (`=head1 … =cut`), so there is no code or runtime impact.

## Scope

60 `.pm` / `.pm.in` files under `scripts/ZoneMinder/lib/ZoneMinder` (all and only the files that contained the boilerplate; a whole-repo scan found no others). All 60 contained the byte-identical block, so the replacement is uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)