### PR TITLE
fix: strip control characters from client-supplied web_js log fields

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -49,28 +49,36 @@ ajaxResponse($data);
 //
 
 function createRequest() {
-  if (!empty($_POST['level']) && !empty($_POST['message'])) {
-    ZM\logInit(array('id'=>'web_js'));
+  // Every field here is attacker-controlled. Coerce each to a scalar and strip
+  // control characters (newlines, carriage returns, tabs, etc.) so nothing can
+  // forge additional lines in the text log file, and so non-scalar input (e.g.
+  // message[]=x) cannot trip a TypeError in logPrint(). A log message is a
+  // single line; the Log view stores it as one Message column regardless.
+  $sanitize = function($value) {
+    return is_scalar($value) ? preg_replace('/[\x00-\x1F\x7F]+/', ' ', (string)$value) : '';
+  };
 
-    $file = !empty($_POST['file']) ? preg_replace('/\w+:\/\/[\w.:]+\//', '', $_POST['file']) : '';
-    // Strip control characters (newlines, carriage returns, tabs, etc.) from the
-    // client-supplied fields so they cannot forge additional lines in the text
-    // log file. A log message is a single line; the Log view stores it as one
-    // Message column regardless.
-    $file = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $file);
-    $message = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $_POST['message']);
-    $line = empty($_POST['line']) ? NULL : validInt($_POST['line']);
+  $level = $sanitize($_POST['level'] ?? '');
+  $message = $sanitize($_POST['message'] ?? '');
+  // Strip the URL scheme/host from file, then the control characters.
+  $file = (isset($_POST['file']) && is_scalar($_POST['file']))
+    ? $sanitize(preg_replace('/\w+:\/\/[\w.:]+\//', '', (string)$_POST['file']))
+    : '';
 
-    $levels = array_flip(ZM\Logger::$codes);
-    if (!isset($levels[$_POST['level']])) {
-      ZM\Error('Unexpected logger level '.$_POST['level']);
-      $_POST['level'] = 'ERR';
-    }
-    $level = $levels[$_POST['level']];
-    ZM\Logger::fetch()->logPrint($level, $message, $file, $line);
-  } else {
-    ZM\Error('Invalid log create: '.print_r($_POST, true));
+  if ($level === '' || $message === '') {
+    ZM\Error('Invalid log create: level and message are required');
+    return;
   }
+
+  ZM\logInit(array('id'=>'web_js'));
+  $line = empty($_POST['line']) ? NULL : validInt($_POST['line']);
+
+  $levels = array_flip(ZM\Logger::$codes);
+  if (!isset($levels[$level])) {
+    ZM\Error('Unexpected logger level '.$level); // already sanitized above
+    $level = 'ERR';
+  }
+  ZM\Logger::fetch()->logPrint($levels[$level], $message, $file, $line);
 }
 
 function queryRequest() {

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -53,6 +53,12 @@ function createRequest() {
     ZM\logInit(array('id'=>'web_js'));
 
     $file = !empty($_POST['file']) ? preg_replace('/\w+:\/\/[\w.:]+\//', '', $_POST['file']) : '';
+    // Strip control characters (newlines, carriage returns, tabs, etc.) from the
+    // client-supplied fields so they cannot forge additional lines in the text
+    // log file. A log message is a single line; the Log view stores it as one
+    // Message column regardless.
+    $file = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $file);
+    $message = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $_POST['message']);
     $line = empty($_POST['line']) ? NULL : validInt($_POST['line']);
 
     $levels = array_flip(ZM\Logger::$codes);
@@ -61,7 +67,7 @@ function createRequest() {
       $_POST['level'] = 'ERR';
     }
     $level = $levels[$_POST['level']];
-    ZM\Logger::fetch()->logPrint($level, $_POST['message'], $file, $line);
+    ZM\Logger::fetch()->logPrint($level, $message, $file, $line);
   } else {
     ZM\Error('Invalid log create: '.print_r($_POST, true));
   }


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the `request=log&task=create` endpoint (`web/ajax/log.php`), relating to the long-standing log injection report #2466.

`createRequest()` passed the client-supplied `message` and `file` straight to `logPrint()`. `logPrint()` only strips *trailing* newlines (`/[\r\n]+$/`), so embedded newlines survived into the flat text log file and could forge what looked like additional log lines. (Notably, `logPrint()` even carries the comment *"Didn't we already replace all newlines with spaces above?"* — the intent was to strip them, but the regex only handles the trailing case.)

This strips control characters (newlines, CR, tabs, etc.) from `message` and `file` before logging:

```php
$file = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $file);
$message = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $_POST['message']);
```

## Context — this is hardening, not a fix for an exploitable hole

The endpoint is already well-guarded, which is why #2466 is being closed as not a current vulnerability:
- Requires an authenticated **System:Edit** user; `ZM_LOG_INJECT` (which would relax that) defaults to **off**.
- Component is hardcoded to `web_js` — daemon entries cannot be spoofed.
- Level is validated, line is `validInt`, file strips the URL scheme/host.
- The Log view (`skins/classic/views/js/log.js` → `processRows()`) escapes `<`/`>`, so the earlier stored-XSS variant (exploit-db 51071, < 1.37.24) no longer applies.

A log message is a single line and the Log view stores it as one `Message` column, so this change has no effect on legitimate use.

## Testing

`php -l web/ajax/log.php` clean. No build required (PHP). Behaviour unchanged for normal single-line messages; embedded control characters are collapsed to spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)