### PR TITLE
fix: keep temp/scratch files in ZoneMinder's own temp dir, not system /tmp (refs #2915)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,8 @@ set(ZM_RUNDIR "/var/run/zm" CACHE PATH
   "Location of transient process files, default: /var/run/zm")
 set(ZM_SOCKDIR "/var/run/zm" CACHE PATH
   "Location of Unix domain socket files, default /var/run/zm")
-set(ZM_TMPDIR "/var/tmp/zm" CACHE PATH
-  "Location of temporary files, default: /tmp/zm")
+set(ZM_TMPDIR "/var/cache/zoneminder/temp" CACHE PATH
+  "Location of regenerable temporary files, default: /var/cache/zoneminder/temp")
 set(ZM_LOGDIR "/var/log/zm" CACHE PATH
   "Location of generated log files, default: /var/log/zm")
 set(ZM_WEBDIR "${CMAKE_INSTALL_FULL_DATADIR}/zoneminder/www" CACHE PATH

--- a/distros/beowulf/rules
+++ b/distros/beowulf/rules
@@ -23,7 +23,7 @@ override_dh_auto_configure:
             -DZM_CONFIG_SUBDIR="/etc/zm/conf.d"        \
             -DZM_RUNDIR="/run/zm"                  \
             -DZM_SOCKDIR="/run/zm"                 \
-            -DZM_TMPDIR="/tmp/zm"                      \
+            -DZM_TMPDIR="/var/cache/zoneminder/temp"                      \
             -DZM_CGIDIR="/usr/lib/zoneminder/cgi-bin"  \
             -DZM_CACHEDIR="/var/cache/zoneminder/cache"  \
             -DZM_DIR_EVENTS="/var/cache/zoneminder/events"    \

--- a/distros/beowulf/zoneminder.links
+++ b/distros/beowulf/zoneminder.links
@@ -1,1 +1,1 @@
-/var/tmp  /usr/share/zoneminder/www/api/app/tmp
+/var/cache/zoneminder/temp  /usr/share/zoneminder/www/api/app/tmp

--- a/distros/ubuntu2004/rules
+++ b/distros/ubuntu2004/rules
@@ -24,7 +24,7 @@ override_dh_auto_configure:
             -DZM_CONFIG_SUBDIR="/etc/zm/conf.d"        \
             -DZM_RUNDIR="/run/zm"                  \
             -DZM_SOCKDIR="/run/zm"                 \
-            -DZM_TMPDIR="/var/tmp/zm"                      \
+            -DZM_TMPDIR="/var/cache/zoneminder/temp"                      \
             -DZM_CGIDIR="/usr/lib/zoneminder/cgi-bin"  \
             -DZM_CACHEDIR="/var/cache/zoneminder/cache"  \
             -DZM_DIR_EVENTS="/var/cache/zoneminder/events"    \

--- a/distros/ubuntu2004/zoneminder.links
+++ b/distros/ubuntu2004/zoneminder.links
@@ -1,1 +1,1 @@
-/var/tmp  /usr/share/zoneminder/www/api/app/tmp
+/var/cache/zoneminder/temp  /usr/share/zoneminder/www/api/app/tmp

--- a/scripts/zmvideo.pl.in
+++ b/scripts/zmvideo.pl.in
@@ -75,6 +75,7 @@ use autouse 'Data::Dumper'=>qw(Dumper);
 use POSIX qw(strftime);
 use Getopt::Long qw(:config no_ignore_case );
 use Cwd;
+use File::Temp qw(tempfile);
 use autouse 'Pod::Usage'=>qw(pod2usage);
 
 $| = 1;
@@ -235,11 +236,15 @@ if ( $concat_name ) {
   ($cwd) = $cwd =~ /(.*)/; # detaint
   chdir( $cwd );
   ($concat_name ) = $concat_name =~ /([\-A-Za-z0-9_\.]*)/;
-  my $concat_list_file = "/tmp/$concat_name.concat.lst";
 
   my $video_file = $concat_name . '.'. $detaint_format;
 
-  open( my $fd, '>', $concat_list_file ) or die "Can't open $concat_list_file: $!";
+  # Create the ffmpeg concat list with a randomized name (atomic O_EXCL) inside
+  # ZoneMinder's own temp dir, rather than a predictable /tmp/<name>.concat.lst
+  # in world-writable /tmp, which was open to a symlink/race and leaked
+  # monitor/event names. The list entries are absolute paths, so its location
+  # does not affect ffmpeg's resolution.
+  my ($fd, $concat_list_file) = tempfile('zmconcat-XXXXXX', SUFFIX => '.concat.lst', DIR => '@ZM_TMPDIR@');
   foreach ( @video_files ) {
     print $fd "file '$_'\n";
   }

--- a/web/ajax/training.php
+++ b/web/ajax/training.php
@@ -785,7 +785,9 @@ switch ($action) {
     // Copy to temp file so the script can read it.
     // tempnam() creates the base file; rename it to add .jpg extension
     // so the detection script receives a proper image filename.
-    $tmpBase = tempnam(sys_get_temp_dir(), 'zm_detect_');
+    // Use ZoneMinder's configured temp dir (ZM_DIR_TEMP) rather than the PHP
+    // system temp, so the file stays inside ZM's controlled/cleaned tree.
+    $tmpBase = tempnam(ZM_DIR_TEMP, 'zm_detect_');
     $tmpFile = $tmpBase.'.jpg';
     rename($tmpBase, $tmpFile);
     if (!copy($srcImage, $tmpFile)) {


### PR DESCRIPTION
Addresses the temp-file half of #2915: ZoneMinder scratch files were written into world-writable system temp, and on the Debian/Ubuntu family the temp dir *itself* lived in `/tmp` / `/var/tmp`.

Two commits.

## 1. Scratch files use randomized names in ZM's temp dir, not hardcoded `/tmp`
- `scripts/zmvideo.pl.in`: the ffmpeg concat list was built at a predictable `/tmp/<concat_name>.concat.lst` — open to a symlink/race and leaking monitor/event names. Now created with `File::Temp` (randomized, atomic `O_EXCL`) under `@ZM_TMPDIR@`. The list entries are absolute paths, so its location doesn't affect ffmpeg resolution.
- `web/ajax/training.php`: detection scratch image used `tempnam(sys_get_temp_dir(), ...)`, escaping ZM's tree. Now `tempnam(ZM_DIR_TEMP, ...)`.

## 2. Move `ZM_TMPDIR` out of system temp → `/var/cache/zoneminder/temp`
Only the RedHat build used a ZM-owned temp dir; everyone else used shared system temp:

| Build | before | after |
|-------|--------|-------|
| CMake default | `/var/tmp/zm` | `/var/cache/zoneminder/temp` |
| `distros/ubuntu2004` | `/var/tmp/zm` | `/var/cache/zoneminder/temp` |
| `distros/beowulf` | `/tmp/zm` | `/var/cache/zoneminder/temp` |

Also repoints the CakePHP `api/app/tmp` symlink (cache/sessions/logs) from shared `/var/tmp` to the same dir, matching what RedHat already does. `/var/cache` is correct here because everything written to this dir is regenerable (exports, uploads, concat list, detection scratch, CakePHP cache).

## Upgrade safety
- `ZM_DIR_TEMP` lives in `config.php` under `/usr/share` (a regular file, not a conffile), so it's replaced on upgrade and the new path is active immediately — no dpkg prompt.
- `/var/cache/zoneminder/temp` is already in the packaging `.dirs` (was provisioned but unused), so it exists and is `www-data`-owned on every install — no creation gap.
- No migration: temp contents are regenerable. CakePHP recreates its `cache/sessions/logs` on demand (as it already does under `/var/tmp`); one-time effect is a CakePHP cache/session reset. `ZM_UPLOAD_LOC_DIR` is a DB Config option (default-off FTP upload filter) that self-creates its dir, so existing installs are unaffected.

## Not covered (out of scope, separate follow-ups)
- The official Debian package on salsa (`ZM_TMPDIR=/tmp/zm`, `ZM_CONTENTDIR=/var/cache`) — maintained downstream, needs a Debian-side change.
- Moving events off `/var/cache` → `/var/lib` (the events FHS wart) — separate from temp.

refs #2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)