### PR TITLE
fix: don't log browser-extension errors and CSP violations (fixes #3340)

### DIFF
--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -39,7 +39,7 @@ if (!window.console) {
 // would otherwise spam the log. Ignore anything sourced from an extension.
 function isExtensionSource(url) {
   return (typeof url === 'string') &&
-    /^(moz-extension|chrome-extension|safari-web-extension|safari-extension|webkit-masked-url):/.test(url);
+    /^(moz-extension|chrome-extension|safari-web-extension|safari-extension|webkit-masked-url)(:|$)/.test(url);
 }
 
 window.onerror = function(message, url, line, col, error) {

--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -34,7 +34,16 @@ if (!window.console) {
   console.debug = console.log;
 }
 
+// Browser extensions (ad blockers, password managers, etc.) inject scripts
+// into every page; their errors and CSP violations are not ZoneMinder's and
+// would otherwise spam the log. Ignore anything sourced from an extension.
+function isExtensionSource(url) {
+  return (typeof url === 'string') &&
+    /^(moz-extension|chrome-extension|safari-web-extension|safari-extension|webkit-masked-url):/.test(url);
+}
+
 window.onerror = function(message, url, line, col, error) {
+  if (isExtensionSource(url)) return;
   if (!message || message === 'Script error.') {
     message = 'Script error (no details available, possibly cross-origin)';
   }
@@ -46,6 +55,7 @@ window.onerror = function(message, url, line, col, error) {
 };
 
 window.addEventListener("securitypolicyviolation", function logCSP(evt) {
+  if (isExtensionSource(evt.sourceFile) || isExtensionSource(evt.blockedURI)) return;
   const level = evt.disposition == "enforce" ? "ERR" : "DBG";
   let message = evt.blockedURI + " violated CSP " + evt.violatedDirective;
 


### PR DESCRIPTION
## Summary

Fixes #3340. The client-side logger (`web/js/logger.js`) reported every `window.onerror` and `securitypolicyviolation` event — including ones injected by browser extensions (ad blockers, password managers, etc.). Those fire on every page, aren't ZoneMinder's code, and spam the `web_js` log, e.g.:

```
[inline violated CSP script-src] at moz-extension line 46
```

(`moz-extension://` is a Firefox extension; Chrome/Safari have equivalents.)

## Change

Ignore reports whose source is a browser extension, checking the error/source URL and the CSP `sourceFile`/`blockedURI`:

```js
function isExtensionSource(url) {
  return (typeof url === 'string') &&
    /^(moz-extension|chrome-extension|safari-web-extension|safari-extension|webkit-masked-url):/.test(url);
}
```

`window.onerror` returns early if `url` is an extension source; the CSP handler returns early if `sourceFile` or `blockedURI` is. Legitimate same-origin errors and CSP violations are still logged unchanged.

## Testing

- `node --check` clean; unit-tested `isExtensionSource` against extension schemes, same-origin URLs, `inline`, empty, and null/undefined.
- Not reproduced live (it needs a browser extension that injects an inline script). Anyone on the issue thread who can reproduce the original `moz-extension … violated CSP` log spam: building this branch and confirming those entries stop while normal logging still works would validate it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)