### PR TITLE
fix: handle flips in passthrough orientation, fix uninitialized display matrix (fixes #3399)

### DIFF
--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -165,16 +165,30 @@ bool VideoStore::open() {
       if (orientation > 1) { // 1 is ROTATE_0
 #if LIBAVCODEC_VERSION_CHECK(59, 37, 100, 37, 100)
         int32_t* displaymatrix = static_cast<int32_t*>(av_malloc(sizeof(int32_t)*9));
+        // Initialise to identity so the matrix is always fully written before
+        // it is attached as side data; av_display_rotation_set(.,0) yields the
+        // identity matrix.
+        av_display_rotation_set(displaymatrix, 0);
         Debug(3, "Have orientation %d", orientation);
-        if (orientation == Monitor::ROTATE_0) {
-        } else if (orientation == Monitor::ROTATE_90) {
-          av_display_rotation_set(displaymatrix, 90);
-        } else if (orientation == Monitor::ROTATE_180) {
-          av_display_rotation_set(displaymatrix, 180);
-        } else if (orientation == Monitor::ROTATE_270) {
-          av_display_rotation_set(displaymatrix, 270);
-        } else {
-          Warning("Unsupported Orientation(%d)", orientation);
+        switch (orientation) {
+          case Monitor::ROTATE_90:
+            av_display_rotation_set(displaymatrix, 90);
+            break;
+          case Monitor::ROTATE_180:
+            av_display_rotation_set(displaymatrix, 180);
+            break;
+          case Monitor::ROTATE_270:
+            av_display_rotation_set(displaymatrix, 270);
+            break;
+          case Monitor::FLIP_HORI:
+            av_display_matrix_flip(displaymatrix, 1, 0);
+            break;
+          case Monitor::FLIP_VERT:
+            av_display_matrix_flip(displaymatrix, 0, 1);
+            break;
+          default:
+            Warning("Unsupported Orientation(%d)", orientation);
+            break;
         }
 #endif
 #if LIBAVCODEC_VERSION_CHECK(60, 31, 102, 31, 102)
@@ -191,18 +205,23 @@ bool VideoStore::open() {
 					sizeof(int32_t) * 9);
 #endif
 #endif
-        if (orientation == Monitor::ROTATE_0) {
-        } else if (orientation == Monitor::ROTATE_90) {
-          ret = av_dict_set(&video_out_stream->metadata, "rotate", "90", 0);
-          if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
-        } else if (orientation == Monitor::ROTATE_180) {
-          ret = av_dict_set(&video_out_stream->metadata, "rotate", "180", 0);
-          if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
-        } else if (orientation == Monitor::ROTATE_270) {
-          ret = av_dict_set(&video_out_stream->metadata, "rotate", "270", 0);
-          if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
-        } else {
-          Warning("Unsupported Orientation(%d)", orientation);
+        // The legacy "rotate" metadata tag only expresses rotation. Flips are
+        // carried by the display matrix side data above, so don't warn for them.
+        switch (orientation) {
+          case Monitor::ROTATE_90:
+            ret = av_dict_set(&video_out_stream->metadata, "rotate", "90", 0);
+            if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
+            break;
+          case Monitor::ROTATE_180:
+            ret = av_dict_set(&video_out_stream->metadata, "rotate", "180", 0);
+            if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
+            break;
+          case Monitor::ROTATE_270:
+            ret = av_dict_set(&video_out_stream->metadata, "rotate", "270", 0);
+            if (ret < 0) Warning("%s:%d: title set failed", __FILE__, __LINE__);
+            break;
+          default:
+            break;
         }
       } // end if orientation
 


### PR DESCRIPTION
## Summary

Fixes #3399. In passthrough mode `zm_videostore.cpp` writes orientation as a display-matrix side data (+ legacy `rotate` tag) instead of decoding/re-encoding. Only rotations were handled; flips (`FLIP_HORI`/`FLIP_VERT`) hit an "Unsupported Orientation" warning.

There was also a latent bug: `displaymatrix` is `av_malloc`'d and was only written in the rotation branches, but the side data is added unconditionally — so a **flipped passthrough monitor attached an uninitialized matrix** (garbage rotation metadata) to the MP4.

## Change

- Initialise the matrix to identity (`av_display_rotation_set(., 0)`) so it is always fully written before being attached — fixes the uninitialized-matrix bug.
- Express flips with `av_display_matrix_flip(matrix, hflip, vflip)`, so rotation and flips are both carried losslessly in the display matrix (no decode / re-encode).
- The legacy `rotate` tag only expresses rotation, so it no longer warns for flips.

## Testing (live, on real hardware)

Built a 1.39.16 package from this branch, installed it, and set a passthrough monitor (HIKVISION, normally ROTATE_0) to **Flipped Horizontally**. The recorded event MP4 then carries:

```
displaymatrix = [-65536 0 0 / 0 65536 0 / 0 0 1073741824]   rotation=-180
```

— a correct horizontal mirror (negated X axis), not the previous garbage. Playing that MP4 in a desktop player shows the image (and the on-screen clock) correctly **mirrored**. A control ROTATE_90 monitor produces the expected `[0 65536 0 / -65536 0 0 / …]` (rotation=-90), confirming rotation still works, and ROTATE_0 events have no matrix written at all (unchanged).

<img width="558" height="436" alt="image" src="https://github.com/user-attachments/assets/c7bec7de-1866-47fb-a362-cff6015e3e8a" />


## Note on the web player

The rotation component of the display matrix is honored by HTML5 `<video>`, but the **reflection** (mirror) component is inconsistently rendered by browsers, and ZM's web event viewer uses `<video>`. So flips are correct in the file and in desktop players (VLC/QuickTime); if the web event player doesn't render the mirror, a CSS `transform: scaleX(-1)` companion in the player would finish it. Live view is unaffected (it flips the decoded image already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)