### PR TITLE
fix: correct thumbnail aspect ratio for high-resolution monitors (refs #3443)

### DIFF
--- a/web/includes/Event.php
+++ b/web/includes/Event.php
@@ -389,12 +389,14 @@ class Event extends ZM_Object {
     if ( ! ( property_exists($this, 'ThumbnailWidth') ) ) {
       if ( ZM_WEB_LIST_THUMB_WIDTH ) {
         $this->{'ThumbnailWidth'} = ZM_WEB_LIST_THUMB_WIDTH;
-        $scale = intval((SCALE_BASE*ZM_WEB_LIST_THUMB_WIDTH)/$this->{'Width'});
-        $this->{'ThumbnailHeight'} = reScale( $this->{'Height'}, $scale );
+        // Derive the height directly from the aspect ratio. Using an integer
+        // SCALE_BASE scale truncated to 0/1 for high-resolution monitors (e.g.
+        // 2688 wide -> scale 1), producing a squashed, wrong-aspect thumbnail
+        // (and a distorted hover-overlay). refs #3443
+        $this->{'ThumbnailHeight'} = (int)round($this->{'Height'} * ZM_WEB_LIST_THUMB_WIDTH / $this->{'Width'});
       } elseif ( ZM_WEB_LIST_THUMB_HEIGHT ) {
         $this->{'ThumbnailHeight'} = ZM_WEB_LIST_THUMB_HEIGHT;
-        $scale = intval((SCALE_BASE*ZM_WEB_LIST_THUMB_HEIGHT)/$this->{'Height'});
-        $this->{'ThumbnailWidth'} = reScale( $this->{'Width'}, $scale );
+        $this->{'ThumbnailWidth'} = (int)round($this->{'Width'} * ZM_WEB_LIST_THUMB_HEIGHT / $this->{'Height'});
       } else {
         Fatal( "No thumbnail width or height specified, please check in Options->Web" );
       }
@@ -406,12 +408,14 @@ class Event extends ZM_Object {
     if ( ! ( property_exists($this, 'ThumbnailHeight') ) ) {
       if ( ZM_WEB_LIST_THUMB_WIDTH ) {
         $this->{'ThumbnailWidth'} = ZM_WEB_LIST_THUMB_WIDTH;
-        $scale = intval((SCALE_BASE*ZM_WEB_LIST_THUMB_WIDTH)/$this->{'Width'});
-        $this->{'ThumbnailHeight'} = reScale( $this->{'Height'}, $scale );
+        // Derive the height directly from the aspect ratio. Using an integer
+        // SCALE_BASE scale truncated to 0/1 for high-resolution monitors (e.g.
+        // 2688 wide -> scale 1), producing a squashed, wrong-aspect thumbnail
+        // (and a distorted hover-overlay). refs #3443
+        $this->{'ThumbnailHeight'} = (int)round($this->{'Height'} * ZM_WEB_LIST_THUMB_WIDTH / $this->{'Width'});
       } elseif ( ZM_WEB_LIST_THUMB_HEIGHT ) {
         $this->{'ThumbnailHeight'} = ZM_WEB_LIST_THUMB_HEIGHT;
-        $scale = intval((SCALE_BASE*ZM_WEB_LIST_THUMB_HEIGHT)/$this->{'Height'});
-        $this->{'ThumbnailWidth'} = reScale( $this->{'Width'}, $scale );
+        $this->{'ThumbnailWidth'} = (int)round($this->{'Width'} * ZM_WEB_LIST_THUMB_HEIGHT / $this->{'Height'});
       } else {
         Fatal( "No thumbnail width or height specified, please check in Options->Web" );
       }


### PR DESCRIPTION
## Summary

Part of #3443. `Event::ThumbnailWidth()`/`ThumbnailHeight()` derived the secondary dimension through a **truncated integer scale**:

```php
$scale = intval((SCALE_BASE * ZM_WEB_LIST_THUMB_WIDTH) / $this->Width);
$this->ThumbnailHeight = reScale($this->Height, $scale);
```

For a high-resolution monitor the scale factor is small, and `intval()` truncates it. A **2688×1520** monitor with `WEB_LIST_THUMB_WIDTH=48` gives `scale = intval(100*48/2688) = intval(1.78) = 1`, so the height becomes **15 instead of 27** — a 3.2:1 thumbnail instead of 16:9. The events-list hover overlay sizes its container from that thumbnail and `object-fit: cover`-crops the (correct-aspect) video into the squashed box, which appears as a **"long narrow" popout**.

Low-res monitors avoid it because the scale factor is large enough that truncation is a negligible error — this only bites modern multi-megapixel cameras.
<img width="3410" height="1428" alt="B25BAB8F-E898-4A5C-8E66-E7FB94026E45" src="https://github.com/user-attachments/assets/c0a65494-30d6-430d-9b3a-247a527fec15" />


## Fix

Compute the secondary dimension directly from the aspect ratio, with no intermediate integer scale:

```php
$this->ThumbnailHeight = (int)round($this->Height * ZM_WEB_LIST_THUMB_WIDTH / $this->Width);
```

This also brings `Event.php` in line with `createListThumbnail()` in `functions.php`, which already computed it correctly (it kept the scale as a float and only rounded the final dimension).

<img width="3346" height="1732" alt="56FA1B20-69F6-42C3-AD7A-6CD0F9FE1B09" src="https://github.com/user-attachments/assets/ec72cb41-a574-4d5a-b950-57441a4c6405" />


## Testing

Reproduced and verified on a live 2688×1520 passthrough monitor: the events-list thumbnail went from a generated **48×15** (aspect 3.20) to **48×27** (aspect 1.78 ≈ the event's 1.77), and the hover popout renders at the correct aspect instead of long-and-narrow (maintainer confirmed visually). `php -l` clean; PHP is interpreted so no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)