### PR TITLE
Fix borrowed yplane linesize rotate flip

### DIFF
--- a/docs/superpowers/plans/2026-06-08-per-column-event-sort.md
+++ b/docs/superpowers/plans/2026-06-08-per-column-event-sort.md
@@ -1,0 +1,357 @@
+# Per-Column ASC/DESC Event Sort — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let event sort specs carry per-column direction (`StartDateTime DESC, Id ASC`), built safely into `ORDER BY`, with direction-less parts inheriting the request's global `$order`.
+
+**Architecture:** Add a `buildSortSql` static method (and a shared grammar constant) to `ZM\Filter`, alongside the existing `isValidSortExpression`. `web/ajax/events.php` calls `Filter::buildSortSql` with a whitelist/alias resolver closure. No frontend changes, no new class.
+
+**Tech Stack:** PHP. Test is a CLI **integration** test that bootstraps ZM's config/DB stack (run as `www-data`), because `Filter` extends the `ZM_Object` ORM base and loading it pulls in ZM's DB-stored config.
+
+**Context:** Work happens on branch `events-sort-expressions` (already checked out, based on `master`). The branch currently has the prior "comma-separated sort parsing" work **uncommitted** in `web/ajax/events.php` and `web/includes/Filter.php`, plus the untracked design spec.
+
+**Grammar (per comma-separated part):** `<Column> [IS [NOT] NULL] [ASC|DESC]`
+Shared regex (used for both validation and parsing):
+```
+/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?(\s+(?:ASC|DESC))?\s*$/i
+```
+
+---
+
+## File structure
+
+- **Modify** `web/includes/Filter.php` — add `const SORT_PART_RE`; rewrite `isValidSortExpression` to use it (and accept direction); add static `buildSortSql($sort, $order, $resolve_column)`.
+- **Modify** `web/ajax/events.php` — replace the inline parse/alias block in `queryRequest()` with a resolver closure + the `EndDateTime` nulls-last pre-rewrite + `Filter::buildSortSql()`; remove the trailing `$order` append in the `ORDER BY` splice.
+- **Create** `tests/php/event_sort_test.php` — CLI integration test that bootstraps the repo's `config.php` then `Filter.php` and asserts `buildSortSql`/`isValidSortExpression` output.
+
+---
+
+## Task 1: Baseline commit (existing moved work + design docs)
+
+**Files:** (commit only — no code changes)
+
+- [ ] **Step 1: Confirm branch and the uncommitted baseline**
+
+Run: `cd /home/iconnor/sandbox/ZoneMinder && git branch --show-current && git status --short`
+Expected: branch `events-sort-expressions`; `web/ajax/events.php` and `web/includes/Filter.php` modified (` M`); the design spec/plan under `docs/superpowers/` untracked.
+
+- [ ] **Step 2: Lint the baseline files**
+
+Run: `php -l web/ajax/events.php && php -l web/includes/Filter.php`
+Expected: `No syntax errors detected` for both.
+
+- [ ] **Step 3: Commit the baseline feature**
+
+```bash
+cd /home/iconnor/sandbox/ZoneMinder
+git add web/ajax/events.php web/includes/Filter.php
+git commit -m "feat: parse comma-separated event sort expressions with NULLs-last idiom"
+```
+
+- [ ] **Step 4: Commit the design docs**
+
+```bash
+cd /home/iconnor/sandbox/ZoneMinder
+git add docs/superpowers/specs/2026-06-08-per-column-event-sort-design.md docs/superpowers/plans/2026-06-08-per-column-event-sort.md
+git commit -m "docs: add per-column event sort design and plan"
+```
+
+---
+
+## Task 2: Add grammar const + `buildSortSql` to `Filter` (TDD)
+
+**Files:**
+- Create: `tests/php/event_sort_test.php`
+- Modify: `web/includes/Filter.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/php/event_sort_test.php`:
+```php
+<?php
+// Integration test for ZM\Filter sort helpers. Filter extends the ZM_Object ORM
+// base, so loading it pulls in ZM's DB-stored config; we therefore bootstrap
+// config.php (DB connect) BEFORE Filter.php. The tested methods are pure.
+// Run: sudo -u www-data php tests/php/event_sort_test.php   (from the repo root)
+set_include_path(__DIR__.'/../../web/includes'.PATH_SEPARATOR.get_include_path());
+require_once('config.php');   // connects to DB + loads config; must precede Filter
+require_once('Filter.php');
+
+$failures = 0;
+function check($label, $got, $want) {
+  global $failures;
+  $ok = ($got === $want);
+  if (!$ok) $failures++;
+  printf("[%s] %s\n        got:  %s\n        want: %s\n",
+    $ok ? 'PASS' : 'FAIL', $label, var_export($got, true), var_export($want, true));
+}
+
+// Resolver mirrors web/ajax/events.php: whitelist + alias, null if not allowed.
+$resolve = function($col) {
+  $cols = array('Id', 'Name', 'StartDateTime', 'EndDateTime', 'Monitor', 'Tags');
+  if (!in_array($col, $cols)) return null;
+  if ($col == 'Tags') return 'Tags';
+  if ($col == 'Monitor') return 'M.Name';
+  return 'E.'.$col;
+};
+$B = function($sort, $order) use ($resolve) { return \ZM\Filter::buildSortSql($sort, $order, $resolve); };
+
+// buildSortSql
+check('empty -> empty',              $B('', 'ASC'),                              '');
+check('bare inherits DESC',          $B('Id', 'DESC'),                           'E.Id DESC');
+check('bare inherits ASC',           $B('Id', 'ASC'),                            'E.Id ASC');
+check('monitor alias',               $B('Monitor', 'ASC'),                       'M.Name ASC');
+check('tags alias',                  $B('Tags', 'ASC'),                          'Tags ASC');
+check('mixed explicit+default',      $B('StartDateTime DESC, Id', 'ASC'),        'E.StartDateTime DESC, E.Id ASC');
+check('all explicit ignores global', $B('StartDateTime DESC, Id ASC', 'DESC'),   'E.StartDateTime DESC, E.Id ASC');
+check('endDateTime ASC rewrite form',$B('EndDateTime IS NULL ASC, EndDateTime ASC', 'ASC'),
+                                                                                 'E.EndDateTime IS NULL ASC, E.EndDateTime ASC');
+check('endDateTime DESC rewrite form',$B('EndDateTime IS NOT NULL ASC, EndDateTime DESC', 'DESC'),
+                                                                                 'E.EndDateTime IS NOT NULL ASC, E.EndDateTime DESC');
+check('is null inherits order',      $B('EndDateTime IS NULL', 'ASC'),           'E.EndDateTime IS NULL ASC');
+check('keyword case normalized',     $B('EndDateTime is null desc', 'ASC'),      'E.EndDateTime IS NULL DESC');
+check('not whitelisted -> empty',    $B('Bogus', 'ASC'),                         '');
+check('injection -> empty',          $B('Id; DROP TABLE Events', 'ASC'),         '');
+check('one bad part fails whole',    $B('Id, Bogus', 'ASC'),                     '');
+
+// isValidSortExpression (structural only — does NOT whitelist)
+check('valid empty',      \ZM\Filter::isValidSortExpression(''),                              true);
+check('valid bare',       \ZM\Filter::isValidSortExpression('Id'),                            true);
+check('valid directional',\ZM\Filter::isValidSortExpression('StartDateTime DESC, Id ASC'),    true);
+check('valid is null',    \ZM\Filter::isValidSortExpression('EndDateTime IS NOT NULL, EndDateTime'), true);
+check('invalid inject',   \ZM\Filter::isValidSortExpression('Id; DROP TABLE'),                false);
+check('invalid two dirs', \ZM\Filter::isValidSortExpression('Id ASC DESC'),                   false);
+check('invalid nonstring',\ZM\Filter::isValidSortExpression(123),                             false);
+
+echo $failures ? "\n$failures FAILURE(S)\n" : "\nALL PASS\n";
+exit($failures ? 1 : 0);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/iconnor/sandbox/ZoneMinder && sudo -u www-data php tests/php/event_sort_test.php 2>&1 | grep -v 'INIT block'`
+Expected: FAIL — the `buildSortSql` cases error/fail because `ZM\Filter::buildSortSql` does not exist yet (PHP: `Call to undefined method ZM\Filter::buildSortSql()`). A benign `Warning, overriding installed zm.conf ...` line and `REMOTE_ADDR` notice may appear — ignore them.
+
+- [ ] **Step 3: Add the grammar const and `buildSortSql`; update `isValidSortExpression`**
+
+In `web/includes/Filter.php`, replace the existing `isValidSortExpression` method:
+```php
+  public static function isValidSortExpression($sf) {
+    if ($sf === '' || $sf === null) return true;
+    if (!is_string($sf)) return false;
+    foreach (explode(',', $sf) as $part) {
+      if (!preg_match('/^\s*[A-Za-z][A-Za-z0-9_]*(?:\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part)) {
+        return false;
+      }
+    }
+    return true;
+  }
+```
+with this (a shared const + the updated validator + the new builder):
+```php
+  // Single source of truth for the sort grammar, shared by validation and
+  // building. Each comma-separated part: <Column> [IS [NOT] NULL] [ASC|DESC].
+  const SORT_PART_RE = '/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?(\s+(?:ASC|DESC))?\s*$/i';
+
+  public static function isValidSortExpression($sf) {
+    if ($sf === '' || $sf === null) return true;
+    if (!is_string($sf)) return false;
+    foreach (explode(',', $sf) as $part) {
+      if (!preg_match(self::SORT_PART_RE, $part)) return false;
+    }
+    return true;
+  }
+
+  // Build a safe ORDER BY body (without the "ORDER BY" keyword) from a sort
+  // spec. $order is the global default direction ('ASC'|'DESC') used for parts
+  // that omit an explicit ASC/DESC. $resolve_column is callable($col): ?string
+  // returning the column's SQL (e.g. 'E.Id', 'M.Name') or null if not allowed.
+  // Returns '' if the spec is empty or any part is invalid/not allowed.
+  public static function buildSortSql($sort, $order, $resolve_column) {
+    if ($sort === '' || $sort === null) return '';
+    $out = array();
+    foreach (explode(',', $sort) as $part) {
+      if (!preg_match(self::SORT_PART_RE, $part, $m)) return '';
+      $col_sql = call_user_func($resolve_column, $m[1]);
+      if ($col_sql === null) return '';
+      $null_expr = '';
+      if (isset($m[2]) && trim($m[2]) !== '') {
+        $null_expr = (stripos($m[2], 'NOT') !== false) ? ' IS NOT NULL' : ' IS NULL';
+      }
+      $dir = (isset($m[3]) && trim($m[3]) !== '') ? strtoupper(trim($m[3])) : $order;
+      $out[] = $col_sql.$null_expr.' '.$dir;
+    }
+    return implode(', ', $out);
+  }
+```
+(Leave the existing explanatory comment block above `isValidSortExpression` in place.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /home/iconnor/sandbox/ZoneMinder && sudo -u www-data php tests/php/event_sort_test.php 2>&1 | grep -v 'INIT block'`
+Expected: every assertion `[PASS] ...` and final `ALL PASS` (exit 0). If any `[FAIL]`, fix `buildSortSql` until all pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd /home/iconnor/sandbox/ZoneMinder
+php -l web/includes/Filter.php
+git add web/includes/Filter.php tests/php/event_sort_test.php
+git commit -m "feat: add Filter::buildSortSql for directional event sort specs with integration test"
+```
+
+---
+
+## Task 3: Rewire `web/ajax/events.php` to use `Filter::buildSortSql`
+
+**Files:**
+- Modify: `web/ajax/events.php`
+
+- [ ] **Step 1: Replace the inline sort-parsing block**
+
+In `web/ajax/events.php`, inside `queryRequest()`, find this exact block:
+```php
+  if ( $sort != '' ) {
+    // Parse as a comma-separated list of <Column> [IS [NOT] NULL] parts so
+    // multi-expression sorts (e.g. the NULLs-last idiom) round-trip cleanly
+    // instead of being rejected wholesale. Each part's column name still has
+    // to be in the whitelist; once accepted we prefix with the appropriate
+    // alias before splicing into ORDER BY.
+    $whitelist = array_merge($columns, $col_alt);
+    $sql_parts = array();
+    $valid = ZM\Filter::isValidSortExpression($sort);
+    if ($valid) {
+      foreach (explode(',', $sort) as $part) {
+        if (!preg_match('/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part, $m)) {
+          $valid = false;
+          break;
+        }
+        $col = $m[1];
+        if (!in_array($col, $whitelist)) {
+          $valid = false;
+          break;
+        }
+        if ($col == 'Tags') {
+          $col_sql = 'Tags';
+        } else if ($col == 'Monitor') {
+          $col_sql = 'M.Name';
+        } else {
+          $col_sql = 'E.'.$col;
+        }
+        $sql_parts[] = $col_sql.(isset($m[2]) ? $m[2] : '');
+      }
+    }
+    if (!$valid) {
+      ZM\Warning('Invalid sort field, ignoring: '.$sort);
+      $sort = '';
+    } else if (count($sql_parts) == 1 && $sql_parts[0] == 'E.EndDateTime') {
+      // Implicit NULLs-last rewrite when sorting only by EndDateTime, so
+      // events without a recorded end (zmc crashed) don't bunch unpredictably.
+      $sort = ($order == 'ASC')
+        ? 'E.EndDateTime IS NULL, E.EndDateTime'
+        : 'E.EndDateTime IS NOT NULL, E.EndDateTime';
+    } else {
+      $sort = implode(', ', $sql_parts);
+    }
+  }
+```
+Replace the entire block with:
+```php
+  if ( $sort != '' ) {
+    // Resolve a whitelisted event column name to its SQL (alias), or null.
+    $whitelist = array_merge($columns, $col_alt);
+    $resolve = function($col) use ($whitelist) {
+      if (!in_array($col, $whitelist)) return null;
+      if ($col == 'Tags') return 'Tags';
+      if ($col == 'Monitor') return 'M.Name';
+      return 'E.'.$col;
+    };
+    // Implicit NULLs-last rewrite when sorting solely by EndDateTime, so events
+    // without a recorded end (zmc crashed) don't bunch unpredictably. Emitted
+    // with explicit directions so the IS NULL key keeps ASC ordering even when
+    // the global order is DESC, reproducing the historical SQL.
+    if (trim($sort) == 'EndDateTime') {
+      $sort = ($order == 'ASC')
+        ? 'EndDateTime IS NULL ASC, EndDateTime ASC'
+        : 'EndDateTime IS NOT NULL ASC, EndDateTime DESC';
+    }
+    // Build the per-part directional ORDER BY body. Parts without an explicit
+    // ASC/DESC inherit $order. An invalid/non-whitelisted spec yields '' and is
+    // dropped (no ORDER BY) rather than risking an injected fragment.
+    $sort = ZM\Filter::buildSortSql($sort, $order, $resolve);
+    if ($sort === '') {
+      ZM\Warning('Invalid sort field, ignoring');
+    }
+  }
+```
+
+- [ ] **Step 2: Fix the ORDER BY splice (direction now lives per-part)**
+
+In the same file, find:
+```php
+    WHERE '.$search_filter->sql().'
+    GROUP BY E.Id'
+    .($sort ? ' ORDER BY '.$sort.' '.$order : '');
+```
+Replace with:
+```php
+    WHERE '.$search_filter->sql().'
+    GROUP BY E.Id'
+    .($sort ? ' ORDER BY '.$sort : '');
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `cd /home/iconnor/sandbox/ZoneMinder && php -l web/ajax/events.php`
+Expected: `No syntax errors detected in web/ajax/events.php`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/iconnor/sandbox/ZoneMinder
+git add web/ajax/events.php
+git commit -m "feat: build per-column directional ORDER BY for event list via Filter::buildSortSql"
+```
+
+---
+
+## Task 4: Manual browser verification
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Deploy the changed PHP to the running install**
+
+The live site serves from `/usr/share/zoneminder/www` (real copies, not symlinks). Deploy the two changed files:
+```bash
+cd /home/iconnor/sandbox/ZoneMinder
+sudo install -m 644 web/includes/Filter.php /usr/share/zoneminder/www/includes/Filter.php
+sudo install -m 644 web/ajax/events.php      /usr/share/zoneminder/www/ajax/events.php
+```
+
+- [ ] **Step 2: Verify in the browser (pseudo.connortechnology.com, already logged in)**
+
+Open the Events list. Confirm:
+- Clicking the **Id** column header sorts ascending/descending (toggles) — unchanged single-column behavior.
+- Clicking the **Monitor** column sorts by monitor name (alias works).
+- Clicking the **End** (EndDateTime) column: events with no end time group at the expected end (nulls-last on ASC) and the toggle still works.
+
+- [ ] **Step 3: Confirm the generated SQL via the debug log**
+
+`queryRequest` logs the SQL at Debug. With debug logging on, trigger a sort and check:
+```bash
+sudo grep -E "matching search filter|ORDER BY" /var/log/zm/web_php.log 2>/dev/null | tail -3
+```
+Expected: an `ORDER BY` clause with per-part directions (e.g. `ORDER BY E.Id DESC`), and for an EndDateTime sort, `ORDER BY E.EndDateTime IS NULL ASC, E.EndDateTime ASC` (ASC) — no trailing bare `$order`, no SQL errors.
+
+- [ ] **Step 4: Re-run the integration test as a final regression check**
+
+Run: `cd /home/iconnor/sandbox/ZoneMinder && sudo -u www-data php tests/php/event_sort_test.php 2>&1 | grep -v 'INIT block'`
+Expected: `ALL PASS`.
+
+---
+
+## Self-review notes (spec coverage)
+
+- Grammar/builder (`buildSortSql`) + shared regex const: Task 2 (`Filter`). Direction resolution (explicit-or-global default): Task 2 `buildSortSql` + tests. `EndDateTime` nulls-last pre-rewrite: Task 3. Validation grammar update (shared const, accepts direction): Task 2. `events.php` integration + splice fix: Task 3. Testing: Task 2 (integration) + Task 4 (manual/browser). Whitelist/alias resolver: Task 3. Injection rejection: Task 2 tests.
+- Name consistency: `Filter::SORT_PART_RE`, `Filter::isValidSortExpression`, `Filter::buildSortSql($sort,$order,$resolve_column)`, and the `$resolve` closure are used consistently across Tasks 2–3 and the test.
+- Test loads the **repo** `Filter.php` (via `include_path` = `web/includes`), so it exercises the modified code, not the deployed copy. It needs a reachable DB and `www-data` (consistent with ZM's manual-PHP-testing reality; ZM CI runs no PHP tests).

--- a/docs/superpowers/specs/2026-06-08-per-column-event-sort-design.md
+++ b/docs/superpowers/specs/2026-06-08-per-column-event-sort-design.md
@@ -1,0 +1,167 @@
+# Per-Column ASC/DESC for Event Sort Specifications — Design
+
+Date: 2026-06-08
+Branch: `events-sort-expressions` (based on `master`)
+Status: Approved design, pending implementation plan
+
+## Problem
+
+The events AJAX endpoint (`web/ajax/events.php`, `queryRequest()`) already parses a
+sort spec as a comma-separated list of `<Column> [IS [NOT] NULL]` parts, but the
+sort **direction** is a single global `$order` (ASC/DESC) applied to the whole
+`ORDER BY`. There is no way to express per-column direction such as
+`StartDateTime DESC, Id ASC`. We want the backend grammar + SQL builder to support
+per-column direction. Scope is **backend only** — no frontend/UI changes; the
+bootstrap-table events list keeps emitting single-column sorts as today.
+
+## Goal
+
+Extend the sort grammar to `<Column> [IS [NOT] NULL] [ASC|DESC]` per part and build
+an `ORDER BY` where each part carries its own direction, while remaining fully
+backward compatible with existing single-column UI sorts and saved filters.
+
+## Non-goals
+
+- No frontend changes (no bootstrap-table multipleSort extension).
+- No saved-Filter persistence/editing of multi-column directional sorts.
+- No consolidation of unrelated validation paths beyond what this feature needs.
+
+## Key decisions (from brainstorming)
+
+- **Scope:** backend grammar + SQL only.
+- **Default direction:** a part without an explicit `ASC`/`DESC` inherits the
+  request's global `$order`. So a bare `Id` behaves exactly as today.
+
+## Architecture
+
+### `Filter::buildSortSql($sort, $order, $resolve_column)` (new, static)
+
+A pure, event-agnostic static helper on `Filter` that converts a sort spec into a
+safe `ORDER BY` body string. It lives alongside the existing
+`Filter::isValidSortExpression`; both use a shared grammar constant on `Filter`.
+
+Note on testability: `Filter.php` only fails to load standalone because of an
+include-ordering quirk — loading it first runs `config.php`'s `loadConfig()`
+(which reads ZM's settings from the DB `Config` table) before `database.php`
+reaches `dbConnect()`. Bootstrapping `config.php` **first** (which the web flow
+does, and the test will do) loads `Filter` cleanly. The test therefore runs as an
+integration test against the real `Filter` class (see Testing).
+
+- **Parameters:**
+  - `$sort` — raw spec string (may be empty).
+  - `$order` — global default direction, `'ASC'` or `'DESC'`.
+  - `$resolve_column` — `callable($col): ?string`. Returns the SQL for a validated
+    column name (e.g. `'E.Id'`, `'M.Name'`, `'Tags'`) or `null` if the column is
+    not permitted. This keeps event-specific whitelist/aliasing out of `Filter`.
+- **Returns:** the `ORDER BY` body without the `ORDER BY` keyword (e.g.
+  `M.Name ASC, E.Id DESC`), or `''` if `$sort` is empty or any part is invalid.
+- **Algorithm:**
+  1. If `$sort === ''` return `''`.
+  2. Split on `,`. For each part, match the grammar regex (the shared constant,
+     see below). On any match failure, return `''`.
+  3. Extract `column`, optional `IS [NOT] NULL`, optional `ASC|DESC`.
+  4. `$col_sql = $resolve_column($column)`; if `null`, return `''`.
+  5. `$dir` = the explicit direction if present, else `$order`.
+  6. Emit `$col_sql . (null-expr ? ' '.null-expr : '') . ' ' . $dir`.
+  7. Join parts with `', '` and return.
+
+### Shared grammar constant
+
+The grammar regex lives in **one** place — a private const/static on `Filter`
+(e.g. `Filter::SORT_PART_RE`) — used by both `buildSortSql` and
+`isValidSortExpression`, so the two cannot drift:
+
+```
+/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?(\s+(?:ASC|DESC))?\s*$/i
+```
+
+`isValidSortExpression` continues to be the structural-only gate used by
+`Filter::sort_field()`; it applies the same per-part regex (capturing groups
+ignored) and returns true/false.
+
+### `events.php` integration (`queryRequest`)
+
+Replace the current inline parse/validate/alias block with:
+
+1. Build the resolver closure from the existing `$columns` and `$col_alt`:
+   ```php
+   $whitelist = array_merge($columns, $col_alt);
+   $resolve = function($col) use ($whitelist) {
+     if (!in_array($col, $whitelist)) return null;
+     if ($col == 'Tags') return 'Tags';
+     if ($col == 'Monitor') return 'M.Name';
+     return 'E.'.$col;
+   };
+   ```
+2. Apply the implicit `EndDateTime` nulls-last pre-rewrite (preserves today's
+   behavior) when `$sort` is exactly the bare string `EndDateTime`:
+   - `$order == 'ASC'`  → `$sort = 'EndDateTime IS NULL ASC, EndDateTime ASC'`
+   - else               → `$sort = 'EndDateTime IS NOT NULL ASC, EndDateTime DESC'`
+   The explicit directions ensure the IS-NULL key keeps ASC ordering when the
+   global order is DESC, exactly reproducing the existing SQL.
+3. `$order_by = ZM\Filter::buildSortSql($sort, $order, $resolve);`
+4. If `$order_by === ''` and `$sort !== ''`, `ZM\Warning('Invalid sort field,
+   ignoring: '.$sort);`.
+5. Splice: `... GROUP BY E.Id' . ($order_by ? ' ORDER BY '.$order_by : '')`. The
+   previous single trailing `$order` append is removed.
+
+## Behavior / compatibility
+
+| Input `$sort` | `$order` | Resulting ORDER BY body |
+|---|---|---|
+| `Id` | DESC | `E.Id DESC` |
+| `Monitor` | ASC | `M.Name ASC` |
+| `Tags` | ASC | `Tags ASC` |
+| `StartDateTime DESC, Id` | ASC | `E.StartDateTime DESC, E.Id ASC` |
+| `StartDateTime DESC, Id ASC` | DESC | `E.StartDateTime DESC, E.Id ASC` |
+| `EndDateTime` (bare) | ASC | `E.EndDateTime IS NULL ASC, E.EndDateTime ASC` |
+| `EndDateTime` (bare) | DESC | `E.EndDateTime IS NOT NULL ASC, E.EndDateTime DESC` |
+| `` (empty) | any | `` (no ORDER BY) |
+| `Bogus` / not whitelisted | any | `` (warn, no ORDER BY) |
+| `Id; DROP TABLE` | any | `` (warn, no ORDER BY) |
+
+Existing single-column UI sorts (`sort=<field>&order=asc|desc`) are unchanged: a
+bare column inherits the global order, producing the same SQL as today.
+
+## Error handling
+
+- Any part failing the grammar regex, or any column the resolver rejects, makes
+  the whole spec invalid → `buildSortSql` returns `''` → caller warns and omits
+  `ORDER BY`. This matches the current fail-safe (drop the sort rather than risk
+  injecting a fragment).
+- `buildSortSql` never interpolates unresolved/unvalidated text into SQL; only
+  resolver-returned column SQL, the fixed `IS [NOT] NULL` token, and `ASC`/`DESC`
+  reach the output.
+
+## Testing
+
+ZM has no PHP unit harness and `Filter` requires the DB/config stack to load, so
+add a CLI **integration** test `tests/php/event_sort_test.php` that bootstraps the
+framework from the repo includes (sets `include_path` to `web/includes`,
+`require`s `config.php` then `Filter.php`) and is run as
+`sudo -u www-data php tests/php/event_sort_test.php` (needs a reachable DB; ZM CI
+runs no PHP tests, so this is a local/dev check, consistent with ZM's existing
+"manual PHP testing"). It defines a trivial resolver and asserts:
+
+- bare column inherits `$order` (both ASC and DESC);
+- `ColA ASC, ColB DESC` → exact body, independent of `$order`;
+- the bare-`EndDateTime` rewrite output for both orders (asserted in `events.php`
+  via the pre-rewrite string + builder, exercised by feeding the rewritten spec to
+  `buildSortSql`);
+- `IS NULL` / `IS NOT NULL` parts round-trip with direction;
+- whitelist rejection → `''`;
+- injection attempt (`Id; DROP TABLE Events`) → `''`;
+- `isValidSortExpression` accepts the new directional grammar and rejects garbage.
+
+The test asserts the exact `ORDER BY` body for each case and exits non-zero on any
+failure. It is the failing-test-first artifact and the regression guard. Manual
+verification: load the events list in the browser and confirm column-header sorts
+still work and produce expected ordering (esp. EndDateTime nulls placement).
+
+## Files touched
+
+- `web/includes/Filter.php` — add the shared grammar const and `buildSortSql`;
+  update `isValidSortExpression` to use the const (and accept direction).
+- `web/ajax/events.php` — replace inline sort block with resolver + pre-rewrite +
+  `Filter::buildSortSql` call; remove trailing `$order` append.
+- `tests/php/event_sort_test.php` — new CLI integration test.

--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Dahua_RPC.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Dahua_RPC.pm
@@ -143,7 +143,7 @@ sub login {
       loginType => 'Direct', authorityType => 'Default', passwordType => 'Default' },
     login => 1);
   if ($r and $r->{result}) {
-    Info('Dahua_RPC: logged in to '.$self->{host});
+    Debug('Dahua_RPC: logged in to '.$self->{host});
     return 1;
   }
   Error('Dahua_RPC: login failed: '.(($r and $r->{error}) ? $r->{error}{message} : 'no/!result response'));
@@ -336,13 +336,17 @@ sub lightStatus {
   return { WhiteLight => ($status ? $status->{WhiteLight} : undef) };
 }
 
-# Send a keepalive ping to prevent session expiry in long-running daemons.
-# Call periodically (every ~30s) from the control daemon's idle loop.
+# Send a keepalive ping to prevent idle session expiry in long-running daemons.
+# Call periodically (every ~30s) from the control daemon's idle loop. The
+# requested timeout must comfortably exceed the ping interval. Note: these
+# cameras also enforce an absolute session lifetime (~30 min) that keepAlive
+# cannot extend, so an occasional failure here is expected and simply triggers
+# a re-authentication.
 sub keepAlive {
   my $self = shift;
-  my $r = $self->rpc_call('global.keepAlive', { timeout => 20 });
+  my $r = $self->rpc_call('global.keepAlive', { timeout => 60 });
   if (!$r || !$r->{result}) {
-    Debug('Dahua_RPC: keepAlive failed, re-logging in');
+    Debug('Dahua_RPC: keepAlive did not confirm session, re-authenticating');
     $self->login();
   }
 }

--- a/src/zm_image.cpp
+++ b/src/zm_image.cpp
@@ -3221,6 +3221,14 @@ void Image::Rotate(int angle) {
     DumpBuffer(rotate_buffer, ZM_BUFTYPE_ZM);
     return;
   }
+  // av_image_fill_arrays re-derives the source stride at 32-byte alignment, but
+  // buffer may be a borrowed plane (e.g. get_y_image wraps a decoder Y plane)
+  // whose real stride is the Image's own linesize and can be smaller than
+  // FFALIGN(width,32). Using the assumed stride would read past the end of that
+  // plane. For ZM-allocated images linesize == src_strides[0], so this is a
+  // no-op there. Only plane 0 is overridden: the only borrowed case is a
+  // single-plane GRAY8 Y image, and planar ZM images are self-consistent.
+  src_strides[0] = linesize;
 
   const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(imagePixFormat);
   if (!desc) {
@@ -3291,7 +3299,18 @@ void flip_plane(const uint8_t *src, int src_linesize,
 
 /* RGB32 compatible: complete; planar YUV (YUV420P/J420P/YUV422P/J422P) flipped per-plane */
 void Image::Flip( bool leftright ) {
-  uint8_t* flip_buffer = AllocBuffer(size);
+  // Size the destination from the 32-aligned layout the planes are written at,
+  // not from this->size: a borrowed source (get_y_image wraps a decoder Y
+  // plane) records a tight size from its real linesize, which is smaller than
+  // the aligned destination needs. For ZM-allocated images this equals size.
+  int flip_size_signed = av_image_get_buffer_size(imagePixFormat, width, height, 32);
+  if (flip_size_signed < 0) {
+    Error("Flip: av_image_get_buffer_size failed for %s %ux%u",
+          av_get_pix_fmt_name(imagePixFormat), width, height);
+    return;
+  }
+  const size_t flip_size = static_cast<size_t>(flip_size_signed);
+  uint8_t* flip_buffer = AllocBuffer(flip_size);
 
   uint8_t *src_planes[4] = {nullptr, nullptr, nullptr, nullptr};
   int src_strides[4] = {0, 0, 0, 0};
@@ -3303,6 +3322,10 @@ void Image::Flip( bool leftright ) {
     DumpBuffer(flip_buffer, ZM_BUFTYPE_ZM);
     return;
   }
+  // Use the Image's real stride for the borrowed-plane source rather than the
+  // 32-aligned stride av_image_fill_arrays assumes. See Image::Rotate for the
+  // rationale; no-op for self-consistent ZM-allocated images.
+  src_strides[0] = linesize;
 
   const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(imagePixFormat);
   if (!desc) {
@@ -3334,7 +3357,7 @@ void Image::Flip( bool leftright ) {
                dst_planes[0], dst_strides[0], bpp, leftright);
   }
 
-  AssignDirect(width, height, colours, subpixelorder, flip_buffer, size, ZM_BUFTYPE_ZM);
+  AssignDirect(width, height, colours, subpixelorder, flip_buffer, flip_size, ZM_BUFTYPE_ZM);
 }
 
 void Image::Scale(const unsigned int new_width, const unsigned int new_height) {

--- a/src/zm_packet.cpp
+++ b/src/zm_packet.cpp
@@ -299,7 +299,12 @@ Image *ZMPacket::get_y_image() {
       return nullptr;
     }
 
-    y_image = new Image(in_frame->width, in_frame->height, 1, ZM_SUBPIX_ORDER_NONE, in_frame->data[0], 0, 0);
+    // Wrap the decoder's Y plane with its real stride (linesize[0]). The plane
+    // is packed at the decoder's alignment, which may be smaller than the
+    // FFALIGN(width,32) a plain Image would assume; recording the true stride
+    // keeps stride-aware reads (motion analysis) and Rotate/Flip correct.
+    y_image = new Image(in_frame->width, in_frame->linesize[0], in_frame->height,
+                        1, ZM_SUBPIX_ORDER_NONE, in_frame->data[0], 0);
   }
   return y_image;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ set(TEST_SOURCES
   zm_time.cpp
   zm_utils.cpp
   zm_vector2.cpp
-  zm_zone.cpp)
+  zm_zone.cpp
+  zm_image_linesize.cpp)
 
 add_executable(tests main.cpp ${TEST_SOURCES})
 

--- a/tests/php/event_sort_test.php
+++ b/tests/php/event_sort_test.php
@@ -1,0 +1,59 @@
+<?php
+// Integration test for ZM\Filter sort helpers. Filter extends the ZM_Object ORM
+// base, so loading it pulls in ZM's DB-stored config; we therefore bootstrap
+// config.php (DB connect) BEFORE Filter.php. The tested methods are pure.
+// Run: sudo -u www-data php tests/php/event_sort_test.php   (from the repo root)
+set_include_path(__DIR__.'/../../web/includes'.PATH_SEPARATOR.get_include_path());
+require_once('config.php');   // connects to DB + loads config; must precede Filter
+require_once('Filter.php');
+
+$failures = 0;
+function check($label, $got, $want) {
+  global $failures;
+  $ok = ($got === $want);
+  if (!$ok) $failures++;
+  printf("[%s] %s\n        got:  %s\n        want: %s\n",
+    $ok ? 'PASS' : 'FAIL', $label, var_export($got, true), var_export($want, true));
+}
+
+// Resolver mirrors web/ajax/events.php: whitelist + alias, null if not allowed.
+$resolve = function($col) {
+  $cols = array('Id', 'Name', 'StartDateTime', 'EndDateTime', 'Monitor', 'Tags');
+  if (!in_array($col, $cols)) return null;
+  if ($col == 'Tags') return 'Tags';
+  if ($col == 'Monitor') return 'M.Name';
+  return 'E.'.$col;
+};
+$B = function($sort, $order) use ($resolve) { return \ZM\Filter::buildSortSql($sort, $order, $resolve); };
+
+// buildSortSql
+check('empty -> empty',              $B('', 'ASC'),                              '');
+check('bare inherits DESC',          $B('Id', 'DESC'),                           'E.Id DESC');
+check('bare inherits ASC',           $B('Id', 'ASC'),                            'E.Id ASC');
+check('monitor alias',               $B('Monitor', 'ASC'),                       'M.Name ASC');
+check('tags alias',                  $B('Tags', 'ASC'),                          'Tags ASC');
+check('mixed explicit+default',      $B('StartDateTime DESC, Id', 'ASC'),        'E.StartDateTime DESC, E.Id ASC');
+check('all explicit ignores global', $B('StartDateTime DESC, Id ASC', 'DESC'),   'E.StartDateTime DESC, E.Id ASC');
+check('endDateTime ASC rewrite form',$B('EndDateTime IS NULL ASC, EndDateTime ASC', 'ASC'),
+                                                                                 'E.EndDateTime IS NULL ASC, E.EndDateTime ASC');
+check('endDateTime DESC rewrite form',$B('EndDateTime IS NOT NULL ASC, EndDateTime DESC', 'DESC'),
+                                                                                 'E.EndDateTime IS NOT NULL ASC, E.EndDateTime DESC');
+check('is null inherits order',      $B('EndDateTime IS NULL', 'ASC'),           'E.EndDateTime IS NULL ASC');
+check('keyword case normalized',     $B('EndDateTime is null desc', 'ASC'),      'E.EndDateTime IS NULL DESC');
+check('not whitelisted -> empty',    $B('Bogus', 'ASC'),                         '');
+check('injection -> empty',          $B('Id; DROP TABLE Events', 'ASC'),         '');
+check('one bad part fails whole',    $B('Id, Bogus', 'ASC'),                     '');
+check('bad order -> empty',          $B('Id', 'SLEEP(5)--'),                     '');
+check('lowercase order normalized',  $B('Id', 'asc'),                            'E.Id ASC');
+
+// isValidSortExpression (structural only — does NOT whitelist)
+check('valid empty',      \ZM\Filter::isValidSortExpression(''),                              true);
+check('valid bare',       \ZM\Filter::isValidSortExpression('Id'),                            true);
+check('valid directional',\ZM\Filter::isValidSortExpression('StartDateTime DESC, Id ASC'),    true);
+check('valid is null',    \ZM\Filter::isValidSortExpression('EndDateTime IS NOT NULL, EndDateTime'), true);
+check('invalid inject',   \ZM\Filter::isValidSortExpression('Id; DROP TABLE'),                false);
+check('invalid two dirs', \ZM\Filter::isValidSortExpression('Id ASC DESC'),                   false);
+check('invalid nonstring',\ZM\Filter::isValidSortExpression(123),                             false);
+
+echo $failures ? "\n$failures FAILURE(S)\n" : "\nALL PASS\n";
+exit($failures ? 1 : 0);

--- a/tests/zm_image_linesize.cpp
+++ b/tests/zm_image_linesize.cpp
@@ -1,0 +1,145 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_config.h"
+#include "zm_image.h"
+#include "zm_rgb.h"
+
+#include <cstdint>
+#include <vector>
+
+// get_y_image() wraps a decoder Y plane whose real stride (linesize[0]) can be
+// smaller than FFALIGN(width,32). Image::Rotate/Flip must use the source
+// Image's own linesize, not a re-derived 32-aligned stride, or they read past
+// the end of the borrowed plane (crash) and skew the output. Width 15 is
+// deliberately not a multiple of 32 (FFALIGN(15,32)=32) and the source is
+// packed tight (linesize == width), exactly like the decoder's Y plane.
+// width*height=150 keeps every pixel value distinct in a byte so any stride
+// drift is detectable.
+namespace {
+constexpr unsigned int kW = 15;
+constexpr unsigned int kH = 10;
+
+// Image::Initialise() dereferences config.font_file_location, which is null in
+// the unit-test harness (no zm.conf loaded). Give it a non-null value so the
+// first Image construction doesn't throw before exercising the rotate/flip code.
+void EnsureImageInit() {
+  if (!config.font_file_location) config.font_file_location = "";
+}
+
+// Backing allocation larger than the tight 15x10 plane so that a regression
+// (an over-read using stride FFALIGN(15,32)=32) stays inside our allocation and
+// corrupts the result rather than segfaulting the test runner.
+std::vector<uint8_t> MakeTightGray8Plane() {
+  std::vector<uint8_t> backing(32 * kH + 64, 0);
+  for (unsigned int y = 0; y < kH; y++)
+    for (unsigned int x = 0; x < kW; x++)
+      backing[y * kW + x] = static_cast<uint8_t>(y * kW + x);
+  return backing;
+}
+}  // namespace
+
+TEST_CASE("Image::Rotate 180 honors a non-32-aligned source linesize", "[Image]") {
+  EnsureImageInit();
+  std::vector<uint8_t> backing = MakeTightGray8Plane();
+  Image img(kW, /*linesize*/ kW, kH, /*colours*/ 1, ZM_SUBPIX_ORDER_NONE, backing.data(), /*padding*/ 0);
+
+  img.Rotate(180);
+
+  REQUIRE(img.Width() == kW);
+  REQUIRE(img.Height() == kH);
+  for (unsigned int y = 0; y < kH; y++) {
+    for (unsigned int x = 0; x < kW; x++) {
+      const uint8_t expected = static_cast<uint8_t>((kH - 1 - y) * kW + (kW - 1 - x));
+      REQUIRE(*img.Buffer(x, y) == expected);
+    }
+  }
+}
+
+TEST_CASE("Image::Flip horizontal honors a non-32-aligned source linesize", "[Image]") {
+  EnsureImageInit();
+  std::vector<uint8_t> backing = MakeTightGray8Plane();
+  Image img(kW, /*linesize*/ kW, kH, /*colours*/ 1, ZM_SUBPIX_ORDER_NONE, backing.data(), /*padding*/ 0);
+
+  img.Flip(true);
+
+  REQUIRE(img.Width() == kW);
+  REQUIRE(img.Height() == kH);
+  for (unsigned int y = 0; y < kH; y++) {
+    for (unsigned int x = 0; x < kW; x++) {
+      const uint8_t expected = static_cast<uint8_t>(y * kW + (kW - 1 - x));
+      REQUIRE(*img.Buffer(x, y) == expected);
+    }
+  }
+}
+
+TEST_CASE("Image::Flip vertical honors a non-32-aligned source linesize", "[Image]") {
+  EnsureImageInit();
+  std::vector<uint8_t> backing = MakeTightGray8Plane();
+  Image img(kW, /*linesize*/ kW, kH, /*colours*/ 1, ZM_SUBPIX_ORDER_NONE, backing.data(), /*padding*/ 0);
+
+  img.Flip(false);
+
+  REQUIRE(img.Width() == kW);
+  REQUIRE(img.Height() == kH);
+  for (unsigned int y = 0; y < kH; y++) {
+    for (unsigned int x = 0; x < kW; x++) {
+      const uint8_t expected = static_cast<uint8_t>((kH - 1 - y) * kW + x);
+      REQUIRE(*img.Buffer(x, y) == expected);
+    }
+  }
+}
+
+// 90/270 also swap dimensions (dst is kH wide x kW tall), exercising both the
+// source-stride fix and the destination dimension/stride handling.
+TEST_CASE("Image::Rotate 90 honors a non-32-aligned source linesize", "[Image]") {
+  EnsureImageInit();
+  std::vector<uint8_t> backing = MakeTightGray8Plane();
+  Image img(kW, /*linesize*/ kW, kH, /*colours*/ 1, ZM_SUBPIX_ORDER_NONE, backing.data(), /*padding*/ 0);
+
+  img.Rotate(90);
+
+  REQUIRE(img.Width() == kH);
+  REQUIRE(img.Height() == kW);
+  // 90deg: dst(X,Y) == src(x=Y, y=kH-1-X)
+  for (unsigned int Y = 0; Y < kW; Y++) {
+    for (unsigned int X = 0; X < kH; X++) {
+      const uint8_t expected = static_cast<uint8_t>((kH - 1 - X) * kW + Y);
+      REQUIRE(*img.Buffer(X, Y) == expected);
+    }
+  }
+}
+
+TEST_CASE("Image::Rotate 270 honors a non-32-aligned source linesize", "[Image]") {
+  EnsureImageInit();
+  std::vector<uint8_t> backing = MakeTightGray8Plane();
+  Image img(kW, /*linesize*/ kW, kH, /*colours*/ 1, ZM_SUBPIX_ORDER_NONE, backing.data(), /*padding*/ 0);
+
+  img.Rotate(270);
+
+  REQUIRE(img.Width() == kH);
+  REQUIRE(img.Height() == kW);
+  // 270deg: dst(X,Y) == src(x=kW-1-Y, y=X)
+  for (unsigned int Y = 0; Y < kW; Y++) {
+    for (unsigned int X = 0; X < kH; X++) {
+      const uint8_t expected = static_cast<uint8_t>(X * kW + (kW - 1 - Y));
+      REQUIRE(*img.Buffer(X, Y) == expected);
+    }
+  }
+}

--- a/web/ajax/events.php
+++ b/web/ajax/events.php
@@ -185,46 +185,32 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
   $col_alt = array('Monitor', 'Tags', 'Storage');
 
   if ( $sort != '' ) {
-    // Parse as a comma-separated list of <Column> [IS [NOT] NULL] parts so
-    // multi-expression sorts (e.g. the NULLs-last idiom) round-trip cleanly
-    // instead of being rejected wholesale. Each part's column name still has
-    // to be in the whitelist; once accepted we prefix with the appropriate
-    // alias before splicing into ORDER BY.
+    // Canonicalize the global direction once so the EndDateTime rewrite below
+    // (which branches on $order) and buildSortSql see the same value.
+    $order = strtoupper(trim($order));
+    // Resolve a whitelisted event column name to its SQL (alias), or null.
     $whitelist = array_merge($columns, $col_alt);
-    $sql_parts = array();
-    $valid = ZM\Filter::isValidSortExpression($sort);
-    if ($valid) {
-      foreach (explode(',', $sort) as $part) {
-        if (!preg_match('/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part, $m)) {
-          $valid = false;
-          break;
-        }
-        $col = $m[1];
-        if (!in_array($col, $whitelist)) {
-          $valid = false;
-          break;
-        }
-        if ($col == 'Tags') {
-          $col_sql = 'Tags';
-        } else if ($col == 'Monitor') {
-          $col_sql = 'M.Name';
-        } else {
-          $col_sql = 'E.'.$col;
-        }
-        $sql_parts[] = $col_sql.(isset($m[2]) ? $m[2] : '');
-      }
-    }
-    if (!$valid) {
-      ZM\Warning('Invalid sort field, ignoring: '.$sort);
-      $sort = '';
-    } else if (count($sql_parts) == 1 && $sql_parts[0] == 'E.EndDateTime') {
-      // Implicit NULLs-last rewrite when sorting only by EndDateTime, so
-      // events without a recorded end (zmc crashed) don't bunch unpredictably.
+    $resolve = function($col) use ($whitelist) {
+      if (!in_array($col, $whitelist)) return null;
+      if ($col == 'Tags') return 'Tags';
+      if ($col == 'Monitor') return 'M.Name';
+      return 'E.'.$col;
+    };
+    // Implicit NULLs-last rewrite when sorting solely by EndDateTime, so events
+    // without a recorded end (zmc crashed) don't bunch unpredictably. Emitted
+    // with explicit directions so the IS NULL key keeps ASC ordering even when
+    // the global order is DESC, reproducing the historical SQL.
+    if (trim($sort) == 'EndDateTime') {
       $sort = ($order == 'ASC')
-        ? 'E.EndDateTime IS NULL, E.EndDateTime'
-        : 'E.EndDateTime IS NOT NULL, E.EndDateTime';
-    } else {
-      $sort = implode(', ', $sql_parts);
+        ? 'EndDateTime IS NULL ASC, EndDateTime ASC'
+        : 'EndDateTime IS NOT NULL ASC, EndDateTime DESC';
+    }
+    // Build the per-part directional ORDER BY body. Parts without an explicit
+    // ASC/DESC inherit $order. An invalid/non-whitelisted spec yields '' and is
+    // dropped (no ORDER BY) rather than risking an injected fragment.
+    $sort = ZM\Filter::buildSortSql($sort, $order, $resolve);
+    if ($sort === '') {
+      ZM\Warning('Invalid sort field, ignoring');
     }
   }
 
@@ -262,7 +248,7 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
   LEFT JOIN Tags AS T ON T.Id = ET.TagId 
   '.$where.' 
   GROUP BY E.Id, Monitor
-  '.($sort?' ORDER BY '.$sort.' '.$order:'');
+  '.($sort?' ORDER BY '.$sort:'');
 
   if ((int)($filter->limit()) and !$has_post_sql_conditions) {
     $sql .= ' LIMIT '.(int)($filter->limit());
@@ -339,7 +325,7 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
     LEFT JOIN Tags AS T ON T.Id = ET.TagId 
     WHERE '.$search_filter->sql().'
     GROUP BY E.Id'
-    .($sort ? ' ORDER BY '.$sort.' '.$order : '');
+    .($sort ? ' ORDER BY '.$sort : '');
 
     $filtered_rows = dbFetchAll($sql);
     ZM\Debug('Have ' . count($filtered_rows) . ' events matching search filter: '.$sql);

--- a/web/ajax/events.php
+++ b/web/ajax/events.php
@@ -185,21 +185,46 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
   $col_alt = array('Monitor', 'Tags', 'Storage');
 
   if ( $sort != '' ) {
-    if (!in_array($sort, array_merge($columns, $col_alt))) {
-      ZM\Error('Invalid sort field: ' . $sort);
-      $sort = '';
-    } else if ( $sort == 'Tags' ) {
-       $sort = 'Tags';
-    } else if ( $sort == 'Monitor' ) {
-      $sort = 'M.Name';
-    } else if ($sort == 'EndDateTime') {
-      if ($order == 'ASC') {
-        $sort = 'E.EndDateTime IS NULL, E.EndDateTime';
-      } else {
-        $sort = 'E.EndDateTime IS NOT NULL, E.EndDateTime';
+    // Parse as a comma-separated list of <Column> [IS [NOT] NULL] parts so
+    // multi-expression sorts (e.g. the NULLs-last idiom) round-trip cleanly
+    // instead of being rejected wholesale. Each part's column name still has
+    // to be in the whitelist; once accepted we prefix with the appropriate
+    // alias before splicing into ORDER BY.
+    $whitelist = array_merge($columns, $col_alt);
+    $sql_parts = array();
+    $valid = ZM\Filter::isValidSortExpression($sort);
+    if ($valid) {
+      foreach (explode(',', $sort) as $part) {
+        if (!preg_match('/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part, $m)) {
+          $valid = false;
+          break;
+        }
+        $col = $m[1];
+        if (!in_array($col, $whitelist)) {
+          $valid = false;
+          break;
+        }
+        if ($col == 'Tags') {
+          $col_sql = 'Tags';
+        } else if ($col == 'Monitor') {
+          $col_sql = 'M.Name';
+        } else {
+          $col_sql = 'E.'.$col;
+        }
+        $sql_parts[] = $col_sql.(isset($m[2]) ? $m[2] : '');
       }
+    }
+    if (!$valid) {
+      ZM\Warning('Invalid sort field, ignoring: '.$sort);
+      $sort = '';
+    } else if (count($sql_parts) == 1 && $sql_parts[0] == 'E.EndDateTime') {
+      // Implicit NULLs-last rewrite when sorting only by EndDateTime, so
+      // events without a recorded end (zmc crashed) don't bunch unpredictably.
+      $sort = ($order == 'ASC')
+        ? 'E.EndDateTime IS NULL, E.EndDateTime'
+        : 'E.EndDateTime IS NOT NULL, E.EndDateTime';
     } else {
-      $sort = 'E.'.$sort;
+      $sort = implode(', ', $sql_parts);
     }
   }
 
@@ -312,9 +337,9 @@ function queryRequest($filter, $search, $advsearch, $sort, $offset, $order, $lim
     INNER JOIN Monitors AS M ON E.MonitorId = M.Id 
     LEFT JOIN Events_Tags AS ET ON E.Id = ET.EventId 
     LEFT JOIN Tags AS T ON T.Id = ET.TagId 
-    WHERE '.$search_filter->sql().' 
-    GROUP BY E.Id 
-    ORDER BY ' .$sort. ' ' .$order;
+    WHERE '.$search_filter->sql().'
+    GROUP BY E.Id'
+    .($sort ? ' ORDER BY '.$sort.' '.$order : '');
 
     $filtered_rows = dbFetchAll($sql);
     ZM\Debug('Have ' . count($filtered_rows) . ' events matching search filter: '.$sql);

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -160,18 +160,47 @@ class Filter extends ZM_Object {
   }
 
   // Accepts: empty string, a bare identifier, or a comma-separated list of
-  // <Column> [IS [NOT] NULL] expressions. Structural check only — callers
-  // that know which columns are legal should additionally whitelist them
-  // after a successful match.
+  // <Column> [IS [NOT] NULL] [ASC|DESC] expressions. Structural check only —
+  // callers that know which columns are legal should additionally whitelist
+  // them after a successful match.
+
+  // Single source of truth for the sort grammar, shared by validation and
+  // building. Each comma-separated part: <Column> [IS [NOT] NULL] [ASC|DESC].
+  const SORT_PART_RE = '/^\s*([A-Za-z][A-Za-z0-9_]*)(\s+IS\s+(?:NOT\s+)?NULL)?(\s+(?:ASC|DESC))?\s*$/i';
+
   public static function isValidSortExpression($sf) {
     if ($sf === '' || $sf === null) return true;
     if (!is_string($sf)) return false;
     foreach (explode(',', $sf) as $part) {
-      if (!preg_match('/^\s*[A-Za-z][A-Za-z0-9_]*(?:\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part)) {
-        return false;
-      }
+      if (!preg_match(self::SORT_PART_RE, $part)) return false;
     }
     return true;
+  }
+
+  // Build a safe ORDER BY body (without the "ORDER BY" keyword) from a sort
+  // spec. $order is the global default direction ('ASC'|'DESC') used for parts
+  // that omit an explicit ASC/DESC. $resolve_column is callable($col): ?string
+  // returning the column's SQL (e.g. 'E.Id', 'M.Name') or null if not allowed.
+  // Returns '' if the spec is empty or any part is invalid/not allowed.
+  public static function buildSortSql($sort, $order, $resolve_column) {
+    if ($sort === '' || $sort === null) return '';
+    // Defend the "safe" contract: only ASC/DESC may reach the SQL as a default
+    // direction, regardless of what a caller passes.
+    $order = strtoupper(trim($order));
+    if ($order !== 'ASC' && $order !== 'DESC') return '';
+    $out = array();
+    foreach (explode(',', $sort) as $part) {
+      if (!preg_match(self::SORT_PART_RE, $part, $m)) return '';
+      $col_sql = call_user_func($resolve_column, $m[1]);
+      if ($col_sql === null) return '';
+      $null_expr = '';
+      if (isset($m[2]) && trim($m[2]) !== '') {
+        $null_expr = (stripos($m[2], 'NOT') !== false) ? ' IS NOT NULL' : ' IS NULL';
+      }
+      $dir = (isset($m[3]) && trim($m[3]) !== '') ? strtoupper(trim($m[3])) : $order;
+      $out[] = $col_sql.$null_expr.' '.$dir;
+    }
+    return implode(', ', $out);
   }
 
   # If no storage areas are specified in the terms, then return all

--- a/web/includes/Filter.php
+++ b/web/includes/Filter.php
@@ -159,6 +159,21 @@ class Filter extends ZM_Object {
     return $filter;
   }
 
+  // Accepts: empty string, a bare identifier, or a comma-separated list of
+  // <Column> [IS [NOT] NULL] expressions. Structural check only — callers
+  // that know which columns are legal should additionally whitelist them
+  // after a successful match.
+  public static function isValidSortExpression($sf) {
+    if ($sf === '' || $sf === null) return true;
+    if (!is_string($sf)) return false;
+    foreach (explode(',', $sf) as $part) {
+      if (!preg_match('/^\s*[A-Za-z][A-Za-z0-9_]*(?:\s+IS\s+(?:NOT\s+)?NULL)?\s*$/i', $part)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   # If no storage areas are specified in the terms, then return all
   public function get_StorageAreas() {
     $storage_ids = array();
@@ -244,7 +259,18 @@ class Filter extends ZM_Object {
       $this->Query($Query);
     }
     if (isset($this->Query()['sort_field'])) {
-      return $this->{'Query'}['sort_field'];
+      $sf = $this->{'Query'}['sort_field'];
+      // Accept either a bare column name or a comma-separated list of
+      // <Column> [IS [NOT] NULL] expressions — the latter lets the NULLs-last
+      // idiom (e.g. "EndDateTime IS NOT NULL, EndDateTime") round-trip cleanly.
+      // The filter UI today only emits a single column; if/when it gains
+      // multi-column sort, the same shape will continue to validate. Anything
+      // outside this grammar is dropped so a stale URL/cookie/DB row can't
+      // leak SQL fragments into data-sort-name.
+      if (self::isValidSortExpression($sf)) {
+        return $sf;
+      }
+      Warning('Ignoring malformed Filter sort_field "'.$sf.'"');
     }
     return ZM_WEB_EVENT_SORT_FIELD;
     #return $this->defaults{'sort_field'};

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -1479,13 +1479,15 @@ function initPage() {
       const server = Servers[monitorServerId[monId]] || Servers[0];
       let scale = parseInt(100 * monitorCanvasObj[monId].width / monitorWidth[monId]);
       scale = Math.max(10, 10 * parseInt(scale / 10));
+      console.log(monId, monitorData);
+      const monitor = monitorData[i];
 
       eventStreams[monId] = new EventStream({
         monitorId: monId,
         monitorWidth: monitorWidth[monId],
         monitorHeight: monitorHeight[monId],
         url: thisUrl,
-        url_to_zms: server.PathToZMS,
+        url_to_zms: monitor?monitor.UrlToZMS:server.PathToZMS,
         canvas: monitorCanvasObj[monId],
         scale: scale
       });

--- a/web/skins/classic/views/js/montagereview.js.php
+++ b/web/skins/classic/views/js/montagereview.js.php
@@ -107,7 +107,7 @@ monitorData[monitorData.length] = {
   'Height':<?php echo $monitor->ViewHeight() ?>,
   'JanusEnabled':<?php echo $monitor->JanusEnabled() ?>,
   'Url': '<?php echo $monitor->UrlToIndex( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
-  'UrlToZms': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
+  'UrlToZMS': '<?php echo $monitor->UrlToZMS( ZM_MIN_STREAMING_PORT ? ($monitor->Id() + ZM_MIN_STREAMING_PORT) : '') ?>',
   'onclick': function(){window.location.assign( '?view=watch&mid=<?php echo $monitor->Id() ?>' );},
   'Type': '<?php echo $monitor->Type() ?>',
   'Refresh': '<?php echo $monitor->Refresh() ?>',


### PR DESCRIPTION
  fix: Rotate/Flip honor borrowed source linesize; size Flip dest for 32-aligned planes
    
    get_y_image() wraps the decoder Y plane zero-copy but recorded
    FFALIGN(width,32) as the Image stride instead of the frame's real
    linesize[0]. For widths that are not a multiple of 32 the decoder packs
    the plane tighter than FFALIGN, so:
    
    - Image::Rotate/Flip re-derived the source stride via
      av_image_fill_arrays(...,32) and read past the end of the borrowed
      plane (and skewed Y-channel motion analysis, which reads the same
      buffer).
    - Image::Flip sized its destination from this->size, which is tight for a
      borrowed plane and smaller than the 32-aligned layout the planes are
      written at, overrunning the destination.
    
    Record the frame's real linesize in get_y_image(); use the Image's own
    linesize for the source plane-0 stride in Rotate/Flip; size Flip's
    destination from av_image_get_buffer_size(...,32). All are no-ops for
    self-consistent ZM-allocated (32-aligned) images.
    
    tests/zm_image_linesize.cpp: Rotate 90/180/270 and Flip H/V over a tight,
    non-32-aligned GRAY8 source verifying correct output.
    
    refs #4788
