### PR TITLE
fix: make monitors API index portable under ONLY_FULL_GROUP_BY

### DIFF
--- a/web/api/app/Controller/MonitorsController.php
+++ b/web/api/app/Controller/MonitorsController.php
@@ -38,10 +38,28 @@ class MonitorsController extends AppController {
       $conditions = array();
     }
 
+    // Only join Groups_Monitors when the request actually filters by group, so
+    // a bare GroupId named param can resolve against that table. Joining it
+    // unconditionally multiplied rows for monitors in multiple groups, which we
+    // used to collapse with GROUP BY `Monitor`.`Id`. That GROUP BY fails under
+    // ONLY_FULL_GROUP_BY on engines without functional-dependency detection
+    // (e.g. MariaDB), which rejects the non-grouped SELECT columns. Refs #3633.
+    $group_filter = false;
+    foreach ($conditions as $key => $value) {
+      if (strpos((string)$key, 'GroupId') !== false) { $group_filter = true; break; }
+      if (is_array($value)) {
+        foreach ($value as $sub_key => $sub_value) {
+          if (strpos((string)$sub_key, 'GroupId') !== false) { $group_filter = true; break 2; }
+        }
+      }
+    }
+
     $find_array = array(
       'conditions' => &$conditions,
       'contain'    => array('Group'),
-      'joins'      => array(
+    );
+    if ($group_filter) {
+      $find_array['joins'] = array(
         array(
           'table' => 'Groups_Monitors',
           'type'  => 'left',
@@ -49,13 +67,19 @@ class MonitorsController extends AppController {
             'Groups_Monitors.MonitorId = Monitor.Id',
           ),
         ),
-      ),
-      'group' => '`Monitor`.`Id`'
-    );
+      );
+    }
+
     $monitors = $this->Monitor->find('all', $find_array);
     $allowed_monitors = [];
+    $seen_monitor_ids = [];
     require_once __DIR__ .'/../../../includes/Monitor.php';
     foreach ($monitors as $m) {
+      // A monitor matching multiple GroupId values appears once per match;
+      // collapse those here rather than with a GROUP BY (see note above).
+      $monitor_id = $m['Monitor']['Id'];
+      if (isset($seen_monitor_ids[$monitor_id])) continue;
+      $seen_monitor_ids[$monitor_id] = true;
       $monitor = new ZM\Monitor($m['Monitor']);
       if (!$monitor->canView()) continue;
       array_push($allowed_monitors, $m);


### PR DESCRIPTION
## Problem

`/api/monitors.json` returns a 500 under MySQL/MariaDB `ONLY_FULL_GROUP_BY` (the default sql_mode):

```
SQLSTATE[42000]: Syntax error or access violation: 1055 'zm.Monitor.Name' isn't in GROUP BY
```

`/api/monitors/<id>.json` works fine. Reported in #3633 on MariaDB 10.9.

## Cause

`MonitorsController::index()` unconditionally LEFT JOINed `Groups_Monitors` and collapsed the duplicate rows (monitors belonging to more than one group) with `GROUP BY \`Monitor\`.\`Id\``. Under `ONLY_FULL_GROUP_BY`, selecting the other `Monitor` columns while grouping only by the primary key is only allowed on engines that implement functional-dependency detection (MySQL 5.7+/8.0). MariaDB does not implement it, so it rejects `Monitor.Name` and every other non-grouped column. That is why it reproduces on MariaDB but not on MySQL.

The join itself is only load-bearing when the request filters by group (a bare `GroupId` named param resolves against `Groups_Monitors`). The original commit that added it (6270408c8) even guarded it with a now-commented-out `if (GroupId)`.

## Fix

- Only add the `Groups_Monitors` join when the request actually filters by group, matching the existing `EventsController` pattern.
- Drop the `GROUP BY` entirely — so no functional-dependency assumption is made and the 1055 cannot occur on any engine.
- Dedupe by monitor Id in the existing result loop to cover multi-value `GroupId` filters (e.g. `GroupId IN (a,b)` for a monitor in both groups).

No schema change, no behavioural change on MySQL.

## Testing

Verified against a live API on MySQL 8.0.46 with `ONLY_FULL_GROUP_BY` enabled:

- default `monitors.json` returns all monitors, unique Ids
- `monitors/<id>.json` unchanged
- monitor placed in two groups appears once with no filter (dedup)
- `GroupId:<g>` returns the monitors in that group (conditional join engages)
- `GroupId IN (<a>,<b>)` for a monitor in both groups returns it once (multi-value dedup)
- `Group` containment unchanged

refs #3633