### PR TITLE
style: remove dead ul.tabList CSS from classic skin

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -211,49 +211,6 @@ hr {
     background-color: var(--colorBackgroundButtons);
 }
 
-/*
- * Tabbed headings
- */
-ul.tabList {
-    float: left;
-    list-style: none;
-    padding: 0;
-    margin: 0 0 -4px 0;
-    white-space: nowrap;
-    text-align: left;
-}
-
-ul.tabList li {
-    float: left;
-    border: 1px solid;
-    color: #333333;
-    border: #ccc solid 1px;
-    border-bottom-width: 0;
-    margin: 0 2px 0 0;
-    background: #eee;
-    text-align: center;
-    padding: 5px 10px;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-}
-
-ul.tabList li a {
-    text-decoration: none;
-}
-
-ul.tabList li:hover {
-    background-color: #eeeeee;
-}
-
-ul.tabList li.active {
-    background-color: #ffffff;
-    border-bottom: #7f7fb2 dotted 1px;
-}
-
-ul.tabList li.active a {
-  font-weight: bold;
-}
-
 #content {
   display: flex;
   flex-direction: column;

--- a/web/skins/classic/css/classic/skin.css
+++ b/web/skins/classic/css/classic/skin.css
@@ -121,47 +121,6 @@ hr {
 }
 
 /*
- * Tabbed headings
- */
-ul.tabList {
-    float: left;
-    list-style: none;
-    padding: 0;
-    margin: 0 0 -4px 0;
-    white-space: nowrap;
-    text-align: left;
-}
-
-ul.tabList li {
-    float: left;
-    border: 1px solid;
-    color: #333333;
-    border: #7f7fb2 solid 1px;
-    border-bottom-width: 0;
-    margin: 0 2px 0 0;
-    background: #dddddd;
-    text-align: center;
-    padding: 3px 4px;
-}
-
-ul.tabList li a {
-    text-decoration: none;
-}
-
-ul.tabList li:hover {
-    background-color: #eeeeee;
-}
-
-ul.tabList li.active {
-    background-color: #ffffff;
-    border-bottom: #7f7fb2 dotted 1px;
-}
-
-ul.tabList li.active a {
-    font-weight: bold;
-}
-
-/*
  * Major league table for multiple inputs or presentation
  */
 

--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -65,21 +65,6 @@ img.normal {
     border: #cccccc solid 1px;
 }
 
-ul.tabList li {
-    color: #8f8fc2;
-    border: #8f8fc2 solid 1px;
-    background: #444444;
-}
-
-ul.tabList li:hover {
-    background-color: #dddddd;
-}
-
-ul.tabList li.active {
-    background-color: #222222;
-    border-bottom: #8f8fc2 dotted 1px;
-}
-
 #content::backdrop {
   background-color: black;
 }


### PR DESCRIPTION
Removes the `ul.tabList` rule blocks from the three classic-skin stylesheets (`css/base/skin.css`, `css/classic/skin.css`, `css/dark/skin.css`). These selectors match no elements — nothing in the codebase sets `class="tabList"`, and the tabbed-heading navigation they used to style is gone.

The only remaining `tabList` token is the `role="tabList"` ARIA attribute on the controlcap pills list (`controlcap.php:156`), which the `ul.tabList` **class** selector never matched. That ARIA role is separately invalid (should be lowercase `tablist`) but is left untouched here — correcting it properly needs a small ARIA pass on the `nav nav-pills` markup, which is out of scope for a dead-CSS removal.

No visual change. 99 deletions, CSS only.

fixes #4360

🤖 Generated with [Claude Code](https://claude.com/claude-code)