### PR TITLE
feat: add ZM_DB_SSL_VERIFY_SERVER_CERT option (portable across MySQL/MariaDB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ set(ZM_DB_USER "zmuser" CACHE STRING
   "Name of the ZoneMinder database user, default: zmuser")
 set(ZM_DB_PASS "zmpass" CACHE STRING
   "Password of the ZoneMinder database user, default: zmpass")
+set(ZM_DB_SSL_VERIFY_SERVER_CERT "1" CACHE STRING
+  "Verify the database server's SSL certificate against the CA when ZM_DB_SSL_CA_CERT is set.
+     Set to 0 to allow a self-signed server certificate. default: 1")
 set(ZM_WEB_USER "" CACHE STRING
   "The user apache or the local web server runs on. Leave empty for automatic detection.
      If that fails, you can use this variable to force")
@@ -547,6 +550,18 @@ if(MYSQLCLIENT_LIBRARIES)
   if(NOT HAVE_MYSQL_H)
     message(FATAL_ERROR "ZoneMinder requires MySQL headers - check that MySQL development packages are installed")
   endif()
+  # The option controlling server-certificate verification differs by client:
+  # MySQL 8.0 removed MYSQL_OPT_SSL_VERIFY_SERVER_CERT in favour of
+  # MYSQL_OPT_SSL_MODE, while older MariaDB/MySQL only have the former. These are
+  # enum values, not macros, so detect them by compiling rather than with #ifdef.
+  check_cxx_source_compiles("
+    #include <mysql.h>
+    int main() { enum mysql_option opt = MYSQL_OPT_SSL_MODE; (void)opt; return 0; }
+  " HAVE_MYSQL_OPT_SSL_MODE)
+  check_cxx_source_compiles("
+    #include <mysql.h>
+    int main() { enum mysql_option opt = MYSQL_OPT_SSL_VERIFY_SERVER_CERT; (void)opt; return 0; }
+  " HAVE_MYSQL_OPT_SSL_VERIFY_SERVER_CERT)
 else()
   message(FATAL_ERROR "ZoneMinder requires mysqlclient but it was not found on your system")
 endif()

--- a/cmakecacheimport.sh
+++ b/cmakecacheimport.sh
@@ -58,6 +58,7 @@ echo "Database password          : Not shown"
 echo "Database SSL CA Cert       : $ZM_DB_SSL_CA_CERT"
 echo "Database SSL Client Key    : $ZM_DB_SSL_CLIENT_KEY"
 echo "Database SSL Client Cert   : $ZM_DB_SSL_CLIENT_CERT"
+echo "Database SSL Verify Cert   : $ZM_DB_SSL_VERIFY_SERVER_CERT"
 
 
 CMPATH="CACHE PATH \"Imported by cmakecacheimport.sh\" FORCE"
@@ -78,6 +79,7 @@ echo "set(ZM_DB_PASS \"$ZM_DB_PASS\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CA_CERT \"$ZM_DB_SSL_CA_CERT\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CLIENT_KEY \"$ZM_DB_SSL_CLIENT_KEY\" $CMSTRING)">>zm_conf.cmake
 echo "set(ZM_DB_SSL_CLIENT_CERT \"$ZM_DB_SSL_CLIENT_CERT\" $CMSTRING)">>zm_conf.cmake
+echo "set(ZM_DB_SSL_VERIFY_SERVER_CERT \"$ZM_DB_SSL_VERIFY_SERVER_CERT\" $CMSTRING)">>zm_conf.cmake
 
 echo ""
 echo "Wrote zm_conf.cmake"

--- a/docs/userguide/configfiles.rst
+++ b/docs/userguide/configfiles.rst
@@ -45,3 +45,88 @@ Database Specific Configuration
 .. todo:: do we really need to have this section? Not sure if its generic and not specific to ZM
 
 While the ZoneMinder specific database config entries reside in ``/etc/zm/zm.conf`` and related customizations discussed above, general database configuration items can be tweaked in ``/etc/mysql`` (or whichever path your DB server is installed)
+
+ZoneMinder finds its database using the following ``zm.conf`` settings. The
+defaults match what the standard packages install, so most users never need to
+change them; a remote database or custom credentials is the usual reason to.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Setting
+     - Default
+     - Description
+   * - ``ZM_DB_TYPE``
+     - ``mysql``
+     - Database server type.
+   * - ``ZM_DB_HOST``
+     - ``localhost``
+     - Hostname or IP of the database server. A port can be appended as
+       ``host:port``, or a local socket as ``host:/path/to/socket``.
+   * - ``ZM_DB_NAME``
+     - ``zm``
+     - Name of the ZoneMinder database.
+   * - ``ZM_DB_USER``
+     - ``zmuser``
+     - Database user ZoneMinder connects as.
+   * - ``ZM_DB_PASS``
+     - ``zmpass``
+     - Password for that database user.
+
+As with the SSL settings below, override these in a ``conf.d`` file rather than
+editing ``zm.conf`` directly, so your changes survive an upgrade.
+
+Connecting to the Database over SSL/TLS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ZoneMinder can connect to its database over an encrypted SSL/TLS connection,
+which is useful when the database runs on a separate host. The connection is
+controlled by the following settings:
+
+==================================  ============================================================
+Setting                             Description
+==================================  ============================================================
+``ZM_DB_SSL_CA_CERT``               Path to the CA certificate that signed the database
+                                    server's certificate. Setting this is what enables SSL;
+                                    leave it empty for an unencrypted connection.
+``ZM_DB_SSL_CLIENT_KEY``            Path to the client private key, for mutual TLS where the
+                                    server also authenticates the client.
+``ZM_DB_SSL_CLIENT_CERT``           Path to the client certificate, for mutual TLS.
+``ZM_DB_SSL_VERIFY_SERVER_CERT``    Whether to verify the server's certificate. Defaults to ``1``
+                                    (verify). Verification is by *identity*: the certificate must
+                                    chain to ``ZM_DB_SSL_CA_CERT`` **and** its CN/SAN must match the
+                                    host in ``ZM_DB_HOST``. Set to ``0`` (or ``false``/``no``/``off``)
+                                    to allow a self-signed or non-matching server certificate.
+==================================  ============================================================
+
+These settings apply to every ZoneMinder component that talks to the database:
+the C++ daemons, the PHP web interface, the CakePHP API and the Perl scripts.
+
+Although these entries exist in ``/etc/zm/zm.conf``, that file may be overwritten
+on an upgrade, so put your values in a ``conf.d`` override file instead. For
+example, ``/etc/zm/conf.d/04-database-ssl.conf``::
+
+  ZM_DB_SSL_CA_CERT=/etc/zm/ssl/ca.pem
+  ZM_DB_SSL_CLIENT_KEY=/etc/zm/ssl/client-key.pem
+  ZM_DB_SSL_CLIENT_CERT=/etc/zm/ssl/client-cert.pem
+
+.. note::
+
+   ``ZM_DB_SSL_VERIFY_SERVER_CERT`` only has an effect when ``ZM_DB_SSL_CA_CERT``
+   is set, and applies consistently across the C++ daemons, the PHP web
+   interface, the API and the Perl scripts. Verification includes a hostname
+   check, so the server certificate's CN/SAN must match the value of
+   ``ZM_DB_HOST``. A common gotcha: if ``ZM_DB_HOST`` is an IP address but the
+   certificate was issued for a hostname, verification fails — connect by the
+   hostname the certificate was issued for, add that IP to the certificate's
+   SAN, or set ``ZM_DB_SSL_VERIFY_SERVER_CERT=0``. Likewise a self-signed
+   certificate will fail verification; set the option to ``0`` to allow it.
+   Disabling verification means the server's identity is no longer checked, so
+   only do this on a trusted network.
+
+   Leaving the value empty (rather than ``1`` or ``0``) leaves the database
+   client library's own default in place. Fresh installs default to ``1``;
+   an empty value is mainly relevant to installs upgraded from a version that
+   predates this option, whose connection behaviour is then unchanged until the
+   value is set explicitly.

--- a/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Database.pm
@@ -104,6 +104,14 @@ sub zmDbConnect {
           'mysql_ssl_client_key='.$ZoneMinder::Config::Config{ZM_DB_SSL_CLIENT_KEY},
           'mysql_ssl_client_cert='.$ZoneMinder::Config::Config{ZM_DB_SSL_CLIENT_CERT}
           );
+      # Identity-verify the server certificate when ZM_DB_SSL_VERIFY_SERVER_CERT
+      # is set: truthy verifies, false-y (0/false/no/off) allows a self-signed or
+      # non-matching cert. An empty/unset value leaves the driver default so
+      # existing installs are unchanged on upgrade.
+      my $verify = $ZoneMinder::Config::Config{ZM_DB_SSL_VERIFY_SERVER_CERT};
+      if ( defined($verify) and ($verify ne '') ) {
+        $sslOptions .= ';mysql_ssl_verify_server_cert=' . ((lc($verify) =~ /^(0|false|no|off)$/) ? '0' : '1');
+      }
     }
 
     eval {

--- a/src/zm_config.cpp
+++ b/src/zm_config.cpp
@@ -169,6 +169,8 @@ void process_configfile(char const *configFile) {
       staticConfig.DB_SSL_CLIENT_KEY = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_DB_SSL_CLIENT_CERT") == 0 )
       staticConfig.DB_SSL_CLIENT_CERT = std::string(val_ptr);
+    else if ( strcasecmp(name_ptr, "ZM_DB_SSL_VERIFY_SERVER_CERT") == 0 )
+      staticConfig.DB_SSL_VERIFY_SERVER_CERT = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_PATH_WEB") == 0 )
       staticConfig.PATH_WEB = std::string(val_ptr);
     else if ( strcasecmp(name_ptr, "ZM_SERVER_HOST") == 0 )

--- a/src/zm_config.h
+++ b/src/zm_config.h
@@ -53,6 +53,7 @@ struct StaticConfig {
   std::string DB_SSL_CA_CERT;
   std::string DB_SSL_CLIENT_KEY;
   std::string DB_SSL_CLIENT_CERT;
+  std::string DB_SSL_VERIFY_SERVER_CERT;
   std::string PATH_WEB;
   std::string SERVER_NAME;
   unsigned int SERVER_ID;

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -71,7 +71,9 @@ bool zmDbConnect() {
       unsigned int ssl_mode = verify_server_cert ? SSL_MODE_VERIFY_IDENTITY : SSL_MODE_REQUIRED;
       mysql_options(&dbconn, MYSQL_OPT_SSL_MODE, &ssl_mode);
 #elif defined(HAVE_MYSQL_OPT_SSL_VERIFY_SERVER_CERT)
-      char verify_flag = verify_server_cert ? 1 : 0;
+      // This branch only compiles on clients without MYSQL_OPT_SSL_MODE (older
+      // MariaDB/MySQL), where my_bool is the expected argument type and defined.
+      my_bool verify_flag = verify_server_cert ? 1 : 0;
       mysql_options(&dbconn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify_flag);
 #endif
     }

--- a/src/zm_db.cpp
+++ b/src/zm_db.cpp
@@ -20,6 +20,8 @@
 
 #include "zm_logger.h"
 #include "zm_signal.h"
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <unistd.h>
 
@@ -47,6 +49,32 @@ bool zmDbConnect() {
     mysql_options(&dbconn, MYSQL_OPT_SSL_KEY,    staticConfig.DB_SSL_CLIENT_KEY.c_str());
     mysql_options(&dbconn, MYSQL_OPT_SSL_CERT,   staticConfig.DB_SSL_CLIENT_CERT.c_str());
     mysql_options(&dbconn, MYSQL_OPT_SSL_CA,     staticConfig.DB_SSL_CA_CERT.c_str());
+
+    // Whether to verify the server certificate. When enabled this is full
+    // identity verification (the certificate must chain to the CA and its
+    // CN/SAN must match the host we connect to), matching the PHP and Perl
+    // layers which only offer an identity-checking verify flag. Set
+    // ZM_DB_SSL_VERIFY_SERVER_CERT to 0/false/no/off to allow a self-signed or
+    // non-matching server certificate. An empty/unset value leaves the client
+    // library default in place so existing installs are not changed on upgrade.
+    // The controlling option differs by client library: MySQL 8.0 removed
+    // MYSQL_OPT_SSL_VERIFY_SERVER_CERT in favour of MYSQL_OPT_SSL_MODE, while
+    // older MariaDB/MySQL only have the former, so CMake feature-detects which
+    // is available.
+    std::string verify_value = staticConfig.DB_SSL_VERIFY_SERVER_CERT;
+    std::transform(verify_value.begin(), verify_value.end(), verify_value.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    if (!verify_value.empty()) {
+      bool verify_server_cert = !(verify_value == "0" || verify_value == "false"
+          || verify_value == "no" || verify_value == "off");
+#if defined(HAVE_MYSQL_OPT_SSL_MODE)
+      unsigned int ssl_mode = verify_server_cert ? SSL_MODE_VERIFY_IDENTITY : SSL_MODE_REQUIRED;
+      mysql_options(&dbconn, MYSQL_OPT_SSL_MODE, &ssl_mode);
+#elif defined(HAVE_MYSQL_OPT_SSL_VERIFY_SERVER_CERT)
+      char verify_flag = verify_server_cert ? 1 : 0;
+      mysql_options(&dbconn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify_flag);
+#endif
+    }
   }
 
   std::string::size_type colonIndex = staticConfig.DB_HOST.find(":");

--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -100,5 +100,16 @@ class DATABASE_CONFIG {
 		else:
 			$this->default['host'] = ZM_DB_HOST;
 		endif;
+
+		// Identity-verify the server cert when ZM_DB_SSL_VERIFY_SERVER_CERT is
+		// set: truthy verifies, false-y (0/false/no/off) allows a self-signed or
+		// non-matching cert. Empty/unset leaves the default so existing installs
+		// are unchanged on upgrade. The Mysql datasource merges 'flags' into the
+		// PDO connection options. Refs #3816.
+		if (defined('ZM_DB_SSL_VERIFY_SERVER_CERT') and (ZM_DB_SSL_VERIFY_SERVER_CERT !== '')):
+			$this->default['flags'] = array(
+				PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => !in_array(strtolower(ZM_DB_SSL_VERIFY_SERVER_CERT), array('0', 'false', 'no', 'off'))
+			);
+		endif;
 	}
 }

--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -104,12 +104,17 @@ class DATABASE_CONFIG {
 		// Identity-verify the server cert when ZM_DB_SSL_VERIFY_SERVER_CERT is
 		// set: truthy verifies, false-y (0/false/no/off) allows a self-signed or
 		// non-matching cert. Empty/unset leaves the default so existing installs
-		// are unchanged on upgrade. The Mysql datasource merges 'flags' into the
-		// PDO connection options. Refs #3816.
-		if (defined('ZM_DB_SSL_VERIFY_SERVER_CERT') and (ZM_DB_SSL_VERIFY_SERVER_CERT !== '')):
-			$this->default['flags'] = array(
-				PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => !in_array(strtolower(ZM_DB_SSL_VERIFY_SERVER_CERT), array('0', 'false', 'no', 'off'))
-			);
+		// are unchanged on upgrade. Only applies when SSL is actually configured
+		// (ZM_DB_SSL_CA_CERT set), matching the other layers, so a fresh install's
+		// default does not set the flag on a non-SSL connection. The Mysql
+		// datasource merges 'flags' into the PDO connection options. Refs #3816.
+		if (defined('ZM_DB_SSL_CA_CERT') and ZM_DB_SSL_CA_CERT and defined('ZM_DB_SSL_VERIFY_SERVER_CERT')):
+			$verify_value = strtolower(trim((string)ZM_DB_SSL_VERIFY_SERVER_CERT));
+			if ($verify_value !== ''):
+				$this->default['flags'] = array(
+					PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => !in_array($verify_value, array('0', 'false', 'no', 'off'), true)
+				);
+			endif;
 		endif;
 	}
 }

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -62,9 +62,12 @@ function dbConnect() {
       // so existing installs are not changed on upgrade. Guarded with defined()
       // so an upgraded zm.conf that predates this option does not fatal on PHP 8.
       // Refs #3816.
-      if ( defined('ZM_DB_SSL_VERIFY_SERVER_CERT') and (ZM_DB_SSL_VERIFY_SERVER_CERT !== '') ) {
-        $dbOptions[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] =
-          !in_array(strtolower(ZM_DB_SSL_VERIFY_SERVER_CERT), array('0', 'false', 'no', 'off'));
+      if ( defined('ZM_DB_SSL_VERIFY_SERVER_CERT') ) {
+        $verify_value = strtolower(trim((string)ZM_DB_SSL_VERIFY_SERVER_CERT));
+        if ( $verify_value !== '' ) {
+          $dbOptions[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] =
+            !in_array($verify_value, array('0', 'false', 'no', 'off'), true);
+        }
       }
       $dbConn = new PDO($dsn, ZM_DB_USER, ZM_DB_PASS, $dbOptions);
     } else {

--- a/web/includes/database.php
+++ b/web/includes/database.php
@@ -56,6 +56,16 @@ function dbConnect() {
         PDO::MYSQL_ATTR_SSL_KEY  => ZM_DB_SSL_CLIENT_KEY,
         PDO::MYSQL_ATTR_SSL_CERT => ZM_DB_SSL_CLIENT_CERT,
       );
+      // Identity-verify the server certificate when ZM_DB_SSL_VERIFY_SERVER_CERT
+      // is set: truthy verifies, false-y (0/false/no/off) allows a self-signed
+      // or non-matching cert. An empty/unset value leaves PDO's default in place
+      // so existing installs are not changed on upgrade. Guarded with defined()
+      // so an upgraded zm.conf that predates this option does not fatal on PHP 8.
+      // Refs #3816.
+      if ( defined('ZM_DB_SSL_VERIFY_SERVER_CERT') and (ZM_DB_SSL_VERIFY_SERVER_CERT !== '') ) {
+        $dbOptions[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] =
+          !in_array(strtolower(ZM_DB_SSL_VERIFY_SERVER_CERT), array('0', 'false', 'no', 'off'));
+      }
       $dbConn = new PDO($dsn, ZM_DB_USER, ZM_DB_PASS, $dbOptions);
     } else {
       $dbConn = new PDO($dsn, ZM_DB_USER, ZM_DB_PASS);

--- a/zm.conf.in
+++ b/zm.conf.in
@@ -59,6 +59,10 @@ ZM_DB_SSL_CLIENT_KEY=@ZM_DB_SSL_CLIENT_KEY@
 # SSL client cert for ZoneMinder database
 ZM_DB_SSL_CLIENT_CERT=@ZM_DB_SSL_CLIENT_CERT@
 
+# Verify the database server's SSL certificate against the CA (only applies when
+# ZM_DB_SSL_CA_CERT is set). Set to 0 to allow a self-signed server certificate.
+ZM_DB_SSL_VERIFY_SERVER_CERT=@ZM_DB_SSL_VERIFY_SERVER_CERT@
+
 # Do NOT set ZM_SERVER_HOST if you are not using Multi-Server
 # You have been warned
 #

--- a/zoneminder-config.cmake
+++ b/zoneminder-config.cmake
@@ -35,6 +35,8 @@
 #cmakedefine HAVE_LIBGNUTLS 1
 #cmakedefine HAVE_LIBMYSQLCLIENT 1
 #cmakedefine HAVE_MYSQL_H 1
+#cmakedefine HAVE_MYSQL_OPT_SSL_MODE 1
+#cmakedefine HAVE_MYSQL_OPT_SSL_VERIFY_SERVER_CERT 1
 #cmakedefine HAVE_LIBAVUTIL_HWCONTEXT_H 1
 #cmakedefine HAVE_LIBVLC 1
 #cmakedefine HAVE_VLC_VLC_H 1


### PR DESCRIPTION
## Problem

A database connection configured with `ZM_DB_SSL_CA_CERT` can't connect to a server with a self-signed (or otherwise non-CA-validatable) certificate — `SQLSTATE[HY000] [2002] Cannot connect to MySQL using SSL`. There was no way to relax server-cert verification.

## Why #3817 was reverted

The original fix called `mysql_options(MYSQL_OPT_SSL_VERIFY_SERVER_CERT, …)`, but that enum was **removed from the MySQL 8.0 C client** (replaced by `MYSQL_OPT_SSL_MODE`), so it failed to compile on MySQL 8 — it still compiled on MariaDB, which kept the symbol, which is why it slipped through initially. It also passed a `c_str()` where a `my_bool*` was expected, and referenced the new PHP constant unconditionally (fatal on PHP 8 for upgraded installs).

## Fix

Adds `ZM_DB_SSL_VERIFY_SERVER_CERT`. When enabled, verification is by **identity** (the cert must chain to the CA **and** its CN/SAN must match `ZM_DB_HOST`), consistent across the C++ daemons, the PHP web UI, the CakePHP API and the Perl scripts.

- **Portability:** the controlling option differs by client library and the symbols are enum values (not macros), so CMake **feature-detects** them by compiling — `MYSQL_OPT_SSL_MODE` (MySQL 5.7.11+/8.0, MariaDB Connector/C 3.1+) → `SSL_MODE_VERIFY_IDENTITY` / `SSL_MODE_REQUIRED`; otherwise it falls back to `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` with a proper `my_bool`.
- **Three-way value** in every layer: a truthy value verifies, `0`/`false`/`no`/`off` skips verification, and an **empty/unset value leaves the client-library default in place** so existing installs are not changed on upgrade. Fresh installs default to `1`. PHP, the API datasource and the Perl DSN are all `defined()`-guarded.
- Documents the full `ZM_DB_*` connection and SSL settings, including the connect-by-IP hostname gotcha, in `docs/userguide/configfiles.rst`.

## Backwards compatibility

No change to existing installs. The new block is only reached when `ZM_DB_SSL_CA_CERT` is set, and with the option empty/unset (the state of any upgraded `zm.conf`) every layer leaves the client default untouched — so non-SSL connections and existing SSL connections behave exactly as before.

## Testing

Built and deployed on Ubuntu 24.04 / MySQL 8.0.46, validated against a live server across **all three connection paths** (libmysqlclient daemon, PHP PDO, Perl DBD::mysql):

| Scenario | C++ daemon | PHP PDO | Perl DBD |
|---|:--:|:--:|:--:|
| verify ON, cert matches host | connect | connect | connect |
| verify ON, by IP (no SAN match) | fail | fail | fail |
| verify ON, wrong/self-signed CA | fail | fail | — (same lib) |
| verify OFF | connect | connect | connect |
| mutual TLS (client cert) with / without | connect / fail | connect / fail | — |

All three layers behave identically, confirming the identity semantics are consistent. Non-SSL connections are unaffected.

### Still to test

The **MariaDB client** path has **not** been exercised yet — this build host only has the MySQL 8 client headers, so only the `MYSQL_OPT_SSL_MODE` branch was compiled and run. The `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` fallback branch (older MariaDB / MySQL clients) needs a build + runtime check against `libmariadb-dev` in CI. This is purely a verification gap — the feature detection and three-way logic mean it should not change behaviour for any current install regardless of client.

fixes #3816
