### PR TITLE
fix: match Function=None monitors in the NotRunning status filter

### DIFF
--- a/web/skins/classic/views/_monitor_filters.php
+++ b/web/skins/classic/views/_monitor_filters.php
@@ -131,11 +131,15 @@ function buildMonitorsFilters() {
   foreach ( array('ServerId','StorageId','Status','Capturing','Analysing','Recording') as $filter ) {
     $filterValue = getFilterSelection($filter);
     if ( $filterValue ) {
+      # Function=None monitors have no Monitor_Status row, so the LEFT JOIN leaves
+      # S.Status NULL. Treat a missing status as NotRunning so that filter matches
+      # them, mirroring the NULL->NotRunning coalesce used for display in console.php.
+      $column = ($filter == 'Status') ? "COALESCE(`Status`, 'NotRunning')" : '`'.$filter.'`';
       if ( is_array($filterValue) ) {
-        $conditions[] = '`'.$filter . '` IN ('.implode(',', array_map(function(){return '?';}, $filterValue)).')';
+        $conditions[] = $column.' IN ('.implode(',', array_map(function(){return '?';}, $filterValue)).')';
         $values = array_merge($values, $filterValue);
       } else {
-        $conditions[] = '`'.$filter . '`=?';
+        $conditions[] = $column.'=?';
         $values[] = $filterValue;
       }
     }


### PR DESCRIPTION
## Problem

Selecting the **Not Running** status filter in the console returns no monitors, even when `Function=None` (not running) monitors exist. Filtering by **Capturing** works. (#4225)

## Cause

`Function=None` monitors have no `Monitor_Status` row, so the `LEFT JOIN` to `Monitor_Status` leaves `S.Status` NULL. The filter condition `Status = 'NotRunning'` therefore never matches them — `NULL = 'NotRunning'` is not true.

## Fix

In `web/skins/classic/views/_monitor_filters.php`, coalesce a missing status to `NotRunning` in the filter condition:

```php
$column = ($filter == 'Status') ? "COALESCE(`Status`, 'NotRunning')" : '`'.$filter.'`';
```

applied to both the `IN (…)` and `=?` branches. This mirrors the NULL→NotRunning handling already used for *display* in `console.php`, so the filter and the displayed status agree.

## Testing

- `php -l` clean.
- Verified at the SQL level on a live DB: with the old condition a `Function=None` monitor (NULL status) is excluded from the NotRunning filter; with `COALESCE(`Status`, 'NotRunning')` it is matched. Other status values (Capturing, etc.) are unaffected.

fixes #4225