### PR TITLE
fix: parse Grandstream control address with guess_credentials

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/Control/Grandstream.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/Control/Grandstream.pm
@@ -102,40 +102,27 @@ sub open {
   my $self = shift;
   $self->loadMonitor();
 
-  if ($self->{Monitor}{ControlAddress}
-      and
-    $self->{Monitor}{ControlAddress} ne 'user:pass@ip'
-      and
-    $self->{Monitor}{ControlAddress} ne 'user:port@ip'
-  ) {
-    Debug("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): Getting connection details from ControlAddress ".$self->{Monitor}->{ControlAddress});
-    if (($self->{Monitor}->{ControlAddress} =~ /^(?<PROTOCOL>https?:\/\/)?(?<USERNAME>[^:@]+)?:?(?<PASSWORD>[^\/@]+)?@?(?<ADDRESS>.*)$/)) {
-      $PROTOCOL = $+{PROTOCOL} if $+{PROTOCOL};
-      $USERNAME = $+{USERNAME} if $+{USERNAME};
-      $PASSWORD = $+{PASSWORD} if $+{PASSWORD};
-      $ADDRESS = $+{ADDRESS} if $+{ADDRESS};
-    }
-  } elsif ($self->{Monitor}->{Path}) {
-    Debug("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): Getting connection details from Path ".$self->{Monitor}->{Path});
-    if (($self->{Monitor}->{Path} =~ /^(?<PROTOCOL>(https?|rtsp):\/\/)?(?<USERNAME>[^:@]+)?:?(?<PASSWORD>[^\/@]+)?@?(?<ADDRESS>[^:\/]+)/)) {
-      $USERNAME = $+{USERNAME} if $+{USERNAME};
-      $PASSWORD = $+{PASSWORD} if $+{PASSWORD};
-      $ADDRESS = $+{ADDRESS} if $+{ADDRESS};
-    }
-    Debug("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): username:$USERNAME password:$PASSWORD address:$ADDRESS");
-  } else {
-    Error("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): Failed to parse auth from address ".$self->{Monitor}->{ControlAddress});
-    $ADDRESS = $self->{Monitor}->{ControlAddress};
-  }
-  $BASE_URL = $PROTOCOL.$ADDRESS;
-  $$self{host} = $ADDRESS; # For use with ping
-
   use LWP::UserAgent;
   $self->{ua} = LWP::UserAgent->new;
   $self->{ua}->agent('ZoneMinder Control Agent/'.ZoneMinder::Base::ZM_VERSION);
   $self->{ua}->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0x00);
   $self->{ua}->cookie_jar( {} );
 
+  # Use the shared URI-based parser (Control.pm) instead of a hand-rolled regex.
+  # The old regex mis-parsed stream Paths such as rtsp://host:554/path: the host
+  # was consumed as the username, the port as the password, and ADDRESS
+  # backtracked to a single digit, producing failures like "Can't connect to 4:80".
+  if (!$self->guess_credentials()) {
+    Error("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): Failed to parse connection details from ControlAddress '".($self->{Monitor}{ControlAddress} // '')."' or Path '".($self->{Monitor}{Path} // '')."'");
+    return 0;
+  }
+  $USERNAME = $self->{username} if $self->{username};
+  $PASSWORD = $self->{password} if defined $self->{password};
+  $ADDRESS = $self->{host};
+  # guess_credentials sets $self->{host} for ping. Keep the https:// default for
+  # the control API; the camera's HTTP/HTTPS port is independent of the stream port.
+  $BASE_URL = $PROTOCOL.$ADDRESS;
+  Debug("Monitor $self->{Monitor}{Id} ($self->{Monitor}{Name}): base url $BASE_URL user $USERNAME");
 
   my $url = $BASE_URL.'/goform/login?cmd=login&type=0&user='.$USERNAME;
   my $response = $self->get($url);


### PR DESCRIPTION
## Problem

The Grandstream control module's `open()` parsed the connection details with a hand-rolled regex. For a stream `Path` that carries no embedded credentials, e.g. `rtsp://10.0.0.4:554/cam`, the greedy `[^:@]+` consumed the host as the username, `554` as the password, and the `ADDRESS` group backtracked to the single digit `4`. The daemon then dialled `http://...@4`, giving:

```
ERR [Grandstream old-style connection failed: 500 Can't connect to 4:80 (Connection timed out)]
```

Reproduced:
```
OLD regex  -> user=10.0.0.4 pass=55 ADDRESS=4
URI parser -> host=10.0.0.4 port=80
```

## Fix

Replace the regex with the shared URI-based `Control.pm` `guess_credentials()`, which already handles both `ControlAddress` and `Path`, converts `rtsp` to `http`, and falls back to the Monitor `User`/`Pass`. The `LWP::UserAgent` is created before parsing because `guess_credentials()` sets credentials on it. The Grandstream login wire protocol (challenge/authcode and the old-style fallback) is unchanged.

Verified `guess_credentials`-equivalent parsing returns the correct host for the common `ControlAddress`/`Path` forms (with/without scheme, with/without userinfo, custom ports). `perl -c` clean (with ZoneMinder deps stubbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)