### PR TITLE
ci: exclude vendored third-party JavaScript from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,12 @@
 paths-ignore:
   - dep/
+  # Vendored third-party JavaScript that ZoneMinder ships but does not
+  # maintain. CodeQL flags coding patterns internal to these libraries
+  # (unsafe-jquery-plugin, insecure-randomness, etc.) that are not ZoneMinder
+  # bugs and cannot be fixed here. ZM-authored files in these trees (skin.js,
+  # MonitorStream.js, views/js/*.js, ...) are NOT listed and remain analysed.
+  - web/skins/classic/assets/
+  - web/skins/classic/js/jquery-ui-1.13.2/
+  - web/skins/classic/js/dateTimePicker/
+  - web/skins/classic/js/bootstrap-4.5.0.js
+  - web/js/hls-1.6.13/


### PR DESCRIPTION
## Summary

The majority of CodeQL's open JavaScript alerts are inside bundled third-party libraries, not ZoneMinder code. They flag patterns internal to those libraries (`js/unsafe-jquery-plugin`, `js/insecure-randomness`, `js/incomplete-sanitization`, ...) that we can't fix without forking the dependency — jQuery UI 1.13.2 is at its final release, and Bootstrap 4's jQuery-plugin pattern only goes away in Bootstrap 5. The noise drowns out findings in our own code.

This adds the vendored library trees to `paths-ignore` in `.github/codeql/codeql-config.yml`.

## What's excluded

- `web/skins/classic/assets/` — bootstrap-table, gridstack, panzoom, etc. (all vendored)
- `web/skins/classic/js/jquery-ui-1.13.2/`
- `web/skins/classic/js/dateTimePicker/` (jQuery UI timepicker addon)
- `web/skins/classic/js/bootstrap-4.5.0.js`
- `web/js/hls-1.6.13/`

## What's deliberately *not* excluded

- **ZoneMinder-authored JS** in these trees (`skin.js`, `MonitorStream.js`, `views/js/*.js`, ...) — not listed, still analysed. The three ZM-authored alerts were fixed in #4931.
- **`moment.js`** — left out on purpose. Its remaining call sites (`skin.js`, `montagereview.js`, `report_event_audit.js`) will migrate to luxon (already bundled), after which moment is deleted. That alert will be resolved by removal, not suppression.
- No blanket `**/*.min.js` rule — the list is explicit so it's clear exactly what's suppressed.

## Effect

Clears the ~74 vendored-library alerts and stops them recurring on every dependency bump, leaving CodeQL focused on first-party code.