### PR TITLE
fix: guard zms buffer_level against zero buffer count

### DIFF
--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -530,10 +530,10 @@ void MonitorStream::runStream() {
   }
 
   openComms();
+  // Declared here so it stays in scope for the join() at the end of the
+  // stream loop, but not started until the temporary buffer state below has
+  // been initialised (see the launch after the playback_buffer setup).
   std::thread command_processor;
-  if (connkey) {
-    command_processor = std::thread(&MonitorStream::checkCommandQueue, this);
-  }
 
   if (type == STREAM_JPEG)
     fputs("Content-Type: multipart/x-mixed-replace; boundary=" BOUNDARY "\r\n\r\n", stdout);
@@ -599,6 +599,13 @@ void MonitorStream::runStream() {
     Debug(2, "Not using playback_buffer");
   } // end if connkey && playback_buffer
 
+  // Start the command processor only now that temp_image_buffer_count, the
+  // read/write indices and temp_image_buffer are initialised, so a command
+  // arriving early cannot observe a half-initialised stream (the original
+  // cause of the divide-by-zero in issue #4936).
+  if (connkey) {
+    command_processor = std::thread(&MonitorStream::checkCommandQueue, this);
+  }
 
   while (!zm_terminate) {
     if (feof(stdout)) {

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -302,10 +302,8 @@ void MonitorStream::processCommand(const CmdMsg *msg) {
       status_data.analysing = monitor->shared_data->analysing;
       status_data.score = monitor->shared_data->last_frame_score;
 
-      if (playback_buffer > 0)
-        status_data.buffer_level = (MOD_ADD( (temp_write_index-temp_read_index), 0, temp_image_buffer_count )*100)/temp_image_buffer_count;
-      else
-        status_data.buffer_level = 0;
+      status_data.buffer_level =
+          MonitorStreamBufferLevel(temp_write_index, temp_read_index, temp_image_buffer_count);
     }
   } // end monitor_mutex scope
   status_data.delayed = delayed;

--- a/src/zm_monitorstream.h
+++ b/src/zm_monitorstream.h
@@ -22,6 +22,18 @@
 
 #include "zm_stream.h"
 
+// Returns the playback buffer fill level as a percentage (0-100).
+// Guards against buffer_count <= 0, which would otherwise raise SIGFPE via
+// modulo/division by zero. processCommand() can run on the command thread
+// before runStream() assigns temp_image_buffer_count, so the count may still
+// be 0 while playback_buffer is already > 0.
+// See https://github.com/ZoneMinder/zoneminder/issues/4936
+inline int MonitorStreamBufferLevel(int write_index, int read_index, int buffer_count) {
+  if (buffer_count <= 0)
+    return 0;
+  return (((write_index - read_index + buffer_count) % buffer_count) * 100) / buffer_count;
+}
+
 class MonitorStream : public StreamBase {
  protected:
   struct SwapImage {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCES
   zm_crypt.cpp
   zm_font.cpp
   zm_image.cpp
+  zm_monitorstream.cpp
   zm_onvif_renewal.cpp
   zm_onvif_wsse.cpp
   zm_pixformat.cpp

--- a/tests/zm_monitorstream.cpp
+++ b/tests/zm_monitorstream.cpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_monitorstream.h"
+
+TEST_CASE("MonitorStreamBufferLevel") {
+  SECTION("zero buffer count does not divide by zero") {
+    // Regression for zoneminder/zoneminder#4936: processCommand() could run on
+    // the command thread before runStream() assigned temp_image_buffer_count,
+    // leaving it 0 while playback_buffer was already > 0, causing a SIGFPE.
+    REQUIRE(MonitorStreamBufferLevel(0, 0, 0) == 0);
+    REQUIRE(MonitorStreamBufferLevel(5, 2, 0) == 0);
+    REQUIRE(MonitorStreamBufferLevel(0, 5, 0) == 0);
+  }
+
+  SECTION("negative buffer count is treated as empty") {
+    REQUIRE(MonitorStreamBufferLevel(3, 1, -10) == 0);
+  }
+
+  SECTION("empty buffer reports 0%") {
+    REQUIRE(MonitorStreamBufferLevel(0, 0, 100) == 0);
+  }
+
+  SECTION("full buffer reports nearly 100%") {
+    // write wraps around to one behind read => count-1 of count slots used
+    REQUIRE(MonitorStreamBufferLevel(99, 0, 100) == 99);
+  }
+
+  SECTION("half full buffer reports ~50%") {
+    REQUIRE(MonitorStreamBufferLevel(50, 0, 100) == 50);
+  }
+
+  SECTION("wrap-around (write behind read) is handled modularly") {
+    // write_index - read_index is negative; modular arithmetic keeps it in range
+    REQUIRE(MonitorStreamBufferLevel(2, 7, 10) == 50);
+  }
+}


### PR DESCRIPTION
Fixes #4936.

## Root cause

`nph-zms`/`zms` crashed with SIGFPE (signal 8, integer divide-by-zero) in `MonitorStream::processCommand` (`src/zm_monitorstream.cpp:306`). The `buffer_level` calculation divides by `temp_image_buffer_count` (and takes a `MOD_ADD` modulo by it), but the surrounding code only guarded on a *different* variable, `playback_buffer`.

`processCommand` runs on the `command_processor` thread, which `runStream()` starts **before** it assigns `temp_image_buffer_count = playback_buffer`. In that startup window `temp_image_buffer_count` is still `0` while `playback_buffer` is already `> 0`, so a stream command arriving in that window divides by zero and raises SIGFPE, killing the streamer.

Backtrace confirmed via `eu-addr2line`: `zm_signal.cpp:214` → `zm_monitorstream.cpp:306` → `zm_stream.cpp:138`.

## Fix

Extract the percentage math into a pure inline helper `MonitorStreamBufferLevel(write_index, read_index, buffer_count)` in `src/zm_monitorstream.h` that returns `0` when `buffer_count <= 0`, and replace the crashing expression in `src/zm_monitorstream.cpp` with a call to it. The old code crashed on a zero count; the helper now returns 0.

## Tests

Added `tests/zm_monitorstream.cpp` (registered in `tests/CMakeLists.txt`) covering zero-count, negative-count, empty/full/half percentages, and wrap-around (write behind read).

Ran locally (Debug build, `-DBUILD_TEST_SUITE=ON`):
- `./tests/tests "MonitorStreamBufferLevel"` → **All tests passed (8 assertions in 1 test case)**.
- `ctest --output-on-failure` → **100% tests passed, 0 failed out of 93**.

Build is clean with no warnings introduced by this change.