### PR TITLE
feat: configurable logging of browser-extension errors (refs #3340, builds on #4914)

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -1383,6 +1383,20 @@ our @options = (
     type        => $types{boolean},
     category    => 'logging',
   },
+  {
+    name        => 'ZM_LOG_BROWSER_EXTENSIONS',
+    default     => 'no',
+    description => 'Log Javascript errors and CSP violations from browser extensions',
+    help        => q`
+       Browser extensions (ad blockers, password managers, etc.) inject scripts into
+       every page. Their Javascript errors and Content-Security-Policy violations are
+       not ZoneMinder's code and normally just spam the web_js log, so by default they
+       are ignored. Enable this if you want to see when a browser extension is touching
+       the ZoneMinder tab, at the cost of noisier logs.
+      `,
+    type        => $types{boolean},
+    category    => 'logging',
+  },
 {
     name        => 'ZM_LOG_DEBUG',
     default     => 'no',

--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -36,14 +36,21 @@ if (!window.console) {
 
 // Browser extensions (ad blockers, password managers, etc.) inject scripts
 // into every page; their errors and CSP violations are not ZoneMinder's and
-// would otherwise spam the log. Ignore anything sourced from an extension.
+// would otherwise spam the log. Ignore anything sourced from an extension,
+// unless ZM_LOG_BROWSER_EXTENSIONS is enabled (useful to detect a plugin
+// touching the ZoneMinder tab).
+// ZM_LOG_BROWSER_EXTENSIONS is emitted as the string '0'/'1' (boolean config),
+// matching the ZM_LOG_INJECT convention above.
+const logExtensionSources =
+  (typeof ZM_LOG_BROWSER_EXTENSIONS !== 'undefined') && (ZM_LOG_BROWSER_EXTENSIONS !== '0');
+
 function isExtensionSource(url) {
   return (typeof url === 'string') &&
     /^(moz-extension|chrome-extension|safari-web-extension|safari-extension|webkit-masked-url)(:|$)/.test(url);
 }
 
 window.onerror = function(message, url, line, col, error) {
-  if (isExtensionSource(url)) return;
+  if (!logExtensionSources && isExtensionSource(url)) return;
   if (!message || message === 'Script error.') {
     message = 'Script error (no details available, possibly cross-origin)';
   }
@@ -55,7 +62,7 @@ window.onerror = function(message, url, line, col, error) {
 };
 
 window.addEventListener("securitypolicyviolation", function logCSP(evt) {
-  if (isExtensionSource(evt.sourceFile) || isExtensionSource(evt.blockedURI)) return;
+  if (!logExtensionSources && (isExtensionSource(evt.sourceFile) || isExtensionSource(evt.blockedURI))) return;
   const level = evt.disposition == "enforce" ? "ERR" : "DBG";
   let message = evt.blockedURI + " violated CSP " + evt.violatedDirective;
 


### PR DESCRIPTION
## Summary

Builds on #4914 (merged into this branch) and addresses the review request there: instead of *always* dropping Javascript errors and CSP violations that originate from browser extensions, make it configurable so operators can choose to see when a plugin is touching the ZoneMinder tab.

> My thought on this is: I kinda want to know if a plugin is trying to access my zm tab. Maybe we should add a config entry for it. — #4914

## Changes

- **New config `ZM_LOG_BROWSER_EXTENSIONS`** (boolean, default `no`, `logging` category) in `ConfigData.pm.in`.
- `logger.js` only filters extension-sourced `window.onerror` / `securitypolicyviolation` reports when the option is **disabled**. When enabled, extension errors and CSP violations are logged too.

No `skin.js.php` change is needed: it already emits every non-private config to JS (the loop near the bottom), so `ZM_LOG_BROWSER_EXTENSIONS` is available as the string `'0'`/`'1'` — the same convention `ZM_LOG_INJECT` uses, hence the `!== '0'` test. When the config isn't present yet (DB not synced), `typeof` is `undefined` and filtering stays on, matching #4914's default.

## Relationship to #4914

This branch merges #4914 and adds the config on top. If #4914 is merged first, this can be rebased to drop the merge commit; otherwise this PR delivers both together.

## Testing

- `npx eslint web/js/logger.js` clean; `node --check` clean.
- Verified in the dev DB that boolean configs store `'0'`/`'1'` (e.g. `ZM_LOG_INJECT=0`), confirming the JS comparison.
- Config entry follows the existing `ZM_LOG_INJECT` pattern in the same category; no DB migration needed (config is synced from `ConfigData.pm.in`).
- Not reproduced live (needs a browser extension injecting an inline script).
