### PR TITLE
For live playback (when hovering over thumbs) using RTSP2Web and Go2RTC, use the actual video aspect ratio, not the thumbs image.

### DIFF
--- a/web/js/video-stream.js
+++ b/web/js/video-stream.js
@@ -48,10 +48,19 @@ class VideoStream extends VideoRTC {
 
     onplay() {
         const liveStream = this.closest('[id ^= "liveStream"]');
+        const container = document.getElementById('monitor-thumb-overlay');
         if (liveStream) {
             const monitorStream = getMonitorStream(stringToNumber(liveStream.id));
             if (monitorStream) {
                 monitorStream.streamStartTime = (Date.now() / 1000).toFixed(2);
+            }
+        }
+
+        if (container) {
+            const dimensions = calculateOverlayDimensions(this.video);
+            if (dimensions) {
+                container.style.width = dimensions.width+'px';
+                container.style.height = dimensions.height+'px';
             }
         }
         super.onplay();

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1387,9 +1387,13 @@ function determineOverlaySrc(img, streamType, monitorId, useGo2rtc, m3u8Exists) 
   return streamSrc;
 }
 
-function calculateOverlayDimensions(img) {
-  const imgWidth = img.naturalWidth || img.width;
-  const imgHeight = img.naturalHeight || img.height;
+/*
+* obj - an object of type VIDEO or IMG. VIDEO takes precedence.
+*/
+function calculateOverlayDimensions(obj) {
+  const imgWidth = obj.videoWidth || obj.naturalWidth || obj.width;
+  const imgHeight = obj.videoHeight || obj.naturalHeight || obj.height;
+
   if (!imgWidth || !imgHeight) return null;
 
   const aspectRatio = imgWidth / imgHeight;
@@ -1638,6 +1642,14 @@ function createRtsp2webStream(container, img, monitorId, fallbackToMjpeg, eventS
 function thumbnailVideoPlay(video, currentMode, eventStart, statusBar) {
   const infoStatusBar = (statusBar) ? statusBar.querySelector("#info-status-bar") : null;
   video.play().then(() => {
+    if (currentMode == 'RTSP2Web') {
+      const container = document.getElementById('monitor-thumb-overlay');
+      if (container) {
+        const dimensions = calculateOverlayDimensions(video);
+        container.style.width = dimensions.width+'px';
+        container.style.height = dimensions.height+'px';
+      }
+    }
     if (infoStatusBar && currentMode) infoStatusBar.innerHTML = ' [' + currentMode + '] ';
     console.debug(currentMode + " video player started playing");
     if (eventStart && statusBar) updateTimeWallClock(video, eventStart, statusBar);

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1646,8 +1646,10 @@ function thumbnailVideoPlay(video, currentMode, eventStart, statusBar) {
       const container = document.getElementById('monitor-thumb-overlay');
       if (container) {
         const dimensions = calculateOverlayDimensions(video);
-        container.style.width = dimensions.width+'px';
-        container.style.height = dimensions.height+'px';
+        if (dimensions) {
+          container.style.width = dimensions.width+'px';
+          container.style.height = dimensions.height+'px';
+        }
       }
     }
     if (infoStatusBar && currentMode) infoStatusBar.innerHTML = ' [' + currentMode + '] ';


### PR DESCRIPTION
Solution to Problem №1 in #4949