### PR TITLE
Fix: When Go2RTC generates an error message (not a Go2RTC error itself!), also register the error using the streamErrorRegistration() method and restart the stream.  (video-stream.js)

### DIFF
--- a/web/js/video-stream.js
+++ b/web/js/video-stream.js
@@ -83,6 +83,14 @@ class VideoStream extends VideoRTC {
             switch (msg.type) {
                 case 'error':
                     this.divError = msg.value;
+                    const liveStream = this.closest('[id ^= "liveStream"]');
+                    if (liveStream) {
+                        const monitorStream = getMonitorStream(stringToNumber(liveStream.id));
+                        if (monitorStream) {
+                            monitorStream.streamErrorRegistration();
+                            monitorStream.restart(monitorStream.currentChannelStream);
+                        }
+                    }
                     break;
                 case 'mse':
                 case 'hls':


### PR DESCRIPTION
Fix: #4953