### PR TITLE
Fix: Display the log page refresh status as "stopped" only while processing selected lines, not when a new request occurs on Log page

### DIFF
--- a/web/skins/classic/views/js/log.js
+++ b/web/skins/classic/views/js/log.js
@@ -40,7 +40,6 @@ function ajaxRequest(params) {
     // We won't automatically refresh to avoid disturbing the user who has selected rows.
     console.debug("The user selected rows in the table, and the AJAX request was rejected.");
     requestMissed = true;
-    updateHeaderRequestStatus("stopped");
     return;
   }
   if (ajax && (ajax.readyState !== 4 && ajax.readyState !== 0)) {
@@ -423,10 +422,12 @@ function manageClearButtonAvailability(enable = null) {
 
   if (selections.length) {
     allowRequest = false; // We'll prevent table updates from interfering with the user who has selected rows.
+    updateHeaderRequestStatus("stopped");
     if (ajax && (ajax.readyState !== 4 && ajax.readyState !== 0)) {
       ajax.abort("plannedAbort"); // There may already be a previous request that hasn't completed.
     }
   } else {
+    if (readHeaderRequestStatus() === "stopped") updateHeaderRequestStatus("awaiting");
     if (requestMissed === true) {
       // A scheduled AJAX update was missed. We'll execute it out of order.
       allowRequest = true;
@@ -436,6 +437,10 @@ function manageClearButtonAvailability(enable = null) {
       updateHeaderRequestStatus("in process");
     }
   }
+}
+
+function readHeaderRequestStatus() {
+  return $j('#requestStatus').text().replace(/(\[|\])/g, '').trim();
 }
 
 function updateHeaderRequestStatus(text) {


### PR DESCRIPTION
First, this will speed up the display of the actual status. Second, it will prevent incorrect status indication if rows were selected while executing the next AJAX request.

Also, update the status to "awaiting" only if the previous status was "stopped." This will ensure the status is displayed correctly on the first page refresh.