### PR TITLE
Feat: Add "except INF" to the "Level" filter drop-down list on the Logs page

### DIFF
--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -190,17 +190,17 @@ function queryRequest() {
     $query['values'][] = $_REQUEST['level'];
   }
 */
-  $L = (isset($_REQUEST['level']) && !empty($_REQUEST['level']) && is_scalar($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
+  $level = (isset($_REQUEST['level']) && !empty($_REQUEST['level']) && is_scalar($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
   $level_codes = array_flip(ZM\Logger::$codes);
   $levelValueAllowed = false;
-  if (!empty($L)) {
-    if (isset($level_codes[$L])) {
+  if (!empty($level)) {
+    if (isset($level_codes[$level])) {
       if ($where) $where .= ' AND ';
       $where .= ' Level = ?';
-      $query['values'][] = $level_codes[$L];
+      $query['values'][] = $level_codes[$level];
       $levelValueAllowed = true;
     } else {
-      $res = preg_match('/except (.+)/', $L, $matches);
+      $res = preg_match('/except (.+)/', $level, $matches);
       $_L = ($res && isset($level_codes[$matches[1]])) ? $matches[1] : '';
       if ($_L){
         if ($where) $where .= ' AND ';
@@ -234,7 +234,7 @@ function queryRequest() {
 
   zm_session_start();
   $_SESSION['zmLogComponent'] = $requestComponent;
-  $_SESSION['zmLogFilterLevel'] = $levelValueAllowed ? $L : '';
+  $_SESSION['zmLogFilterLevel'] = $levelValueAllowed ? $level : '';
   session_write_close();
 
   if ($where) $where = ' WHERE '.$where;

--- a/web/ajax/log.php
+++ b/web/ajax/log.php
@@ -192,10 +192,23 @@ function queryRequest() {
 */
   $L = (isset($_REQUEST['level']) && !empty($_REQUEST['level']) && is_scalar($_REQUEST['level'])) ? (string) $_REQUEST['level'] : '';
   $level_codes = array_flip(ZM\Logger::$codes);
-  if (!empty($L) && isset($level_codes[$L])) {
-    if ($where) $where .= ' AND ';
-    $where .= ' Level = ?';
-    $query['values'][] = $level_codes[$L];
+  $levelValueAllowed = false;
+  if (!empty($L)) {
+    if (isset($level_codes[$L])) {
+      if ($where) $where .= ' AND ';
+      $where .= ' Level = ?';
+      $query['values'][] = $level_codes[$L];
+      $levelValueAllowed = true;
+    } else {
+      $res = preg_match('/except (.+)/', $L, $matches);
+      $_L = ($res && isset($level_codes[$matches[1]])) ? $matches[1] : '';
+      if ($_L){
+        if ($where) $where .= ' AND ';
+        $where .= ' Level <> ?';
+        $query['values'][] = $level_codes[$_L];
+        $levelValueAllowed = true;
+      }
+    }
   }
 
   if (!empty($_REQUEST['StartDateTime'])) {
@@ -221,7 +234,7 @@ function queryRequest() {
 
   zm_session_start();
   $_SESSION['zmLogComponent'] = $requestComponent;
-  $_SESSION['zmLogFilterLevel'] = isset($level_codes[$L]) ? $L : '';
+  $_SESSION['zmLogFilterLevel'] = $levelValueAllowed ? $L : '';
   session_write_close();
 
   if ($where) $where = ' WHERE '.$where;

--- a/web/skins/classic/views/log.php
+++ b/web/skins/classic/views/log.php
@@ -98,6 +98,7 @@ echo '</span>';
 $levels = array(''=>translate('All'));
 foreach (array_values(ZM\Logger::$codes) as $level) {
   $levels[$level] = $level;
+  if ($level == "INF") $levels["except " . $level] = "except " . $level;
 }
 $selectedLevel = (isset($_SESSION['zmLogFilterLevel']) && !empty($_SESSION['zmLogFilterLevel']) && is_scalar($_SESSION['zmLogFilterLevel'])) ? (string) $_SESSION['zmLogFilterLevel'] : '';
 $selectedLevel = isset($levels[$selectedLevel]) ? $selectedLevel : '';


### PR DESCRIPTION
Sometimes you only need to display warnings and errors without informational messages. You have to select "WAR," "ERR," "FAT," and so on separately, since the informational messages are the most numerous. This may not be the best solution, but it's fast.
Ideally, I think you should create a multi-section for the "Level" filter.