### PR TITLE
More correct handling of audioMotionAnalyzer

### DIFF
--- a/web/skins/classic/js/audioMotionAnalyzer.js
+++ b/web/skins/classic/js/audioMotionAnalyzer.js
@@ -3,6 +3,7 @@
 * IgorA100 2026
 */
 
+"use strict";
 window.SUPPORTED_AUDIO_MOTION_ANALYZER_VERSION = '4.5.4';
 
 var AudioMotionAnalyzer = null;
@@ -208,7 +209,7 @@ export class _AudioMotionAnalyzer extends HTMLElement {
           showScaleX: false, // Removes frequency signatures.
           showScaleY: false,
           overlay: true, // Makes the background transparent.
-          bgAlpha: .5, // Background transparency only works with overlay: true.
+          bgAlpha: .9, // Background transparency only works with overlay: true.
           ansiBands: true,
           barSpace: .5,
           //channelLayout: 'single',
@@ -368,6 +369,12 @@ export class _AudioMotionAnalyzer extends HTMLElement {
   };
 
   listenerVolumechange = function(_this, event) { // Adjust the visualization level according to the stream's volume level
+    const audioCtx = _this.audioMotion.audioCtx;
+    if (audioCtx && audioCtx.state !== 'running') {
+      audioCtx.resume();
+      _this.connectToMediaStreamSource();
+    }
+
     if (event.target.muted === true) {
       _this.gainNode.gain.value = 0;
     } else {


### PR DESCRIPTION
- Use strict mode
- Change the transparency of the Canvas tag. This will improve contrast in the light theme.
- Fixed a bug where the analyzer would sometimes not display. This most often occurred in Firefox when automatic audio stream playback was disabled, due to the AudioContext remaining in the "suspended" state.