### PR TITLE
Fix: AudioMotion is displayed when playing a recorded event using the HLS player with Autoplay enabled in Firefox (event.js)

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1383,12 +1383,23 @@ function initPage() {
     vid = videojs('videoobj');
     addVideoTimingTrack(vid, LabelFormat, eventData.MonitorName, eventData.Length, eventData.StartDateTime);
     //$j('.vjs-progress-control').append('<div id="alarmCues" class="alarmCues"></div>');//add a place for videojs only on first load
-    vid.on('ended', vjsReplay);
+    vid.on('ended', function(event) {
+      vjsReplay();
+      eventData._playng = false;
+    });
     vid.on('play', function(event) {
       streamPlay();
-      connectAudioMotion(eventData.MonitorId);
+      if (!eventData._playng) connectAudioMotion(eventData.MonitorId);
+      eventData._playng = true;
     });
-    vid.on('pause', streamPause);
+    vid.on('playing', function(event) { // Required for HLS with AUTOPLAY in Firefox, as on.play doesn't work in this case.
+      if (!eventData._playng) connectAudioMotion(eventData.MonitorId);
+      eventData._playng = true;
+    });
+    vid.on('pause', function(event) {
+      streamPause();
+      eventData._playng = false;
+    });
     vid.on('click', function(event) {
       handleClick(event);
     });


### PR DESCRIPTION
The problem is that if autoplay with sound is enabled in Firefox, the 'play' event in hls.js doesn't fire. And as far as I understand, this is normal for Firefox.

We now analyze the 'playing' event, which is definitely triggered when the player is playing a video.

We also use the new "_playng" attribute, which is necessary to execute connectAudioMotion() only when necessary, rather than with every call to "_playng."