### PR TITLE
Add left padding to sidebar for better layout on Watch page

### DIFF
--- a/web/skins/classic/css/base/views/watch.css
+++ b/web/skins/classic/css/base/views/watch.css
@@ -22,6 +22,7 @@
 #sidebar {
   min-width: 140px;
   padding-right: 1px;
+  padding-left: 15px;
 }
 
 #sidebar .nav {


### PR DESCRIPTION
This is necessary so that the block looks better when the DOM loads (before the bootstrap styles are fully loaded and the ".col-sm-3" style is applied), since this block loads the fastest and doesn't look very nice on a slow connection.
**Before:**
<img width="1083" height="888" alt="Before1" src="https://github.com/user-attachments/assets/e71a13d2-0def-45c5-a2e7-d8cb3acccc36" />

**After**
<img width="1077" height="886" alt="After1" src="https://github.com/user-attachments/assets/046ac477-1605-4cf7-8b90-99009580e61a" />