### PR TITLE
Fix: Select an available player before setting a player in the stream, not after on the Watch page.

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -853,11 +853,11 @@ function handleMouseLeave(event) {
 function streamStart(monitor = null) {
   monitorStream = new MonitorStream(monitor ? monitor : monitorData[monIdx]);
 
+  monitorStream.manageAvailablePlayers();
   monitorStream.setPlayer($j('#player').val());
   monitorStream.setBottomElement(document.getElementById('bottomBlock'));
   const cookieMuted = getCookie('zmWatchMuted');
   monitorStream.muted = (cookieMuted === null || cookieMuted === 'true') ? true : false; // default to muted
-  monitorStream.manageAvailablePlayers();
   setChannelStream();
   // Start the fps and status updates. give a random delay so that we don't assault the server
   //monitorStream.setScale($j('#scale').val(), $j('#width').val(), $j('#height').val());


### PR DESCRIPTION
This behavior is especially noticeable when using looping playback if a specific player was selected, but it is supported in the next monitor you switch to.