### PR TITLE
Rename JS logger globals to zm-prefixed names (fixes #4981)

### DIFF
--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -115,21 +115,29 @@ function logReport( level, message, file, line ) {
 // third-party libraries (hls.js, jquery, moment, bootstrap, ...). A bare
 // global Error() in particular used to shadow window.Error, breaking every
 // `new Error()` in bundled libraries. See issue #4981.
+// Build a real Error so we can log a stack trace with the message. Now that we
+// no longer shadow the native constructor this captures where the call
+// originated, which the bare-message logging could not.
+function stackFor(message) {
+  const err = (message instanceof Error) ? message : new Error(message);
+  return err.stack ? err.stack : String(message);
+}
+
 function zmPanic(message) {
   console.error(message);
-  logReport("PNC", message);
+  logReport("PNC", stackFor(message));
   alert("PANIC: "+message);
 }
 
 function zmFatal(message) {
   console.error(message);
-  logReport("FAT", message);
+  logReport("FAT", stackFor(message));
   alert("FATAL: "+message);
 }
 
 function zmError(message) {
   console.error(message);
-  logReport("ERR", message);
+  logReport("ERR", stackFor(message));
 }
 
 function zmWarning(message) {

--- a/web/js/logger.js
+++ b/web/js/logger.js
@@ -110,39 +110,44 @@ function logReport( level, message, file, line ) {
   $j.post(thisUrl, data, null, 'json');
 }
 
-function Panic(message) {
+// These logging helpers are named with a "zm" prefix so they do not collide
+// with the native JS Error constructor or with functions of the same name in
+// third-party libraries (hls.js, jquery, moment, bootstrap, ...). A bare
+// global Error() in particular used to shadow window.Error, breaking every
+// `new Error()` in bundled libraries. See issue #4981.
+function zmPanic(message) {
   console.error(message);
   logReport("PNC", message);
   alert("PANIC: "+message);
 }
 
-function Fatal(message) {
+function zmFatal(message) {
   console.error(message);
   logReport("FAT", message);
   alert("FATAL: "+message);
 }
 
-function Error(message) {
+function zmError(message) {
   console.error(message);
   logReport("ERR", message);
 }
 
-function Warning(message) {
+function zmWarning(message) {
   console.warn(message);
   logReport("WAR", message);
 }
 
-function Info(message) {
+function zmInfo(message) {
   console.info(message);
   logReport("INF", message);
 }
 
-function Debug(message) {
+function zmDebug(message) {
   console.debug(message);
   //logReport("DBG", message);
 }
 
-function Dump(value, label) {
+function zmDump(value, label) {
   if (label) console.debug(label+" => ");
   console.debug(value);
 }

--- a/web/skins/classic/js/montage_common.js
+++ b/web/skins/classic/js/montage_common.js
@@ -38,7 +38,7 @@ function saveSort() {
 
   const server = Servers[serverId];
   if (!server) {
-    Error("Unknown server "+serverId);
+    zmError("Unknown server "+serverId);
     return;
   }
   $j.ajax({

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -548,16 +548,16 @@ if ( currentView != 'none' && currentView != 'login' ) {
 //Shows a message if there is an error in the streamObj or the stream doesn't exist.  Returns true if error, false otherwise.
 function checkStreamForErrors(funcName, streamObj) {
   if ( !streamObj ) {
-    Error(funcName+': stream object was null');
+    zmError(funcName+': stream object was null');
     return true;
   }
   if ( streamObj.responseJSON ) {
     if (streamObj.responseJSON.result == "Error") {
-      Error(funcName+' stream error: '+streamObj.responseJSON.message);
+      zmError(funcName+' stream error: '+streamObj.responseJSON.message);
       return true;
     }
   } else if ( streamObj.result == "Error" ) {
-    Error(funcName+' stream error: '+streamObj.message);
+    zmError(funcName+' stream error: '+streamObj.message);
     return true;
   }
   return false;

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -168,9 +168,9 @@ function initialAlarmCues(eventId) {
 
 function setAlarmCues(data) {
   if (!data) {
-    Error('No data in setAlarmCues for event ' + eventData.Id);
+    zmError('No data in setAlarmCues for event ' + eventData.Id);
   } else if (!data.frames) {
-    Error('No data.frames in setAlarmCues for event ' + eventData.Id);
+    zmError('No data.frames in setAlarmCues for event ' + eventData.Id);
   } else {
     cueFrames = data.frames;
     const alarmSpans = renderAlarmCues(vid ? $j("#videoobj") : $j("#evtStream"));//use videojs width or zms width


### PR DESCRIPTION
## Summary

The JS logger (`web/js/logger.js`) defined seven global functions with very common names: `Panic, Fatal, Error, Warning, Info, Debug, Dump`. The `Error()` one **shadowed the native `window.Error` constructor**, so once `logger.js` loaded, every `new Error()` in the bundled third-party libraries (hls.js, jquery, moment, bootstrap, …) was silently hijacked — returning our stub (an empty object) and firing a spurious `logReport`. This is the collision reported in #4981 (hls.js's `Error()` being overridden). The other six names polluted the global namespace and could collide with plugins.

This renames the definitions to `zmPanic, zmFatal, zmError, zmWarning, zmInfo, zmDebug, zmDump`.

## Changes

**Commit 1 — rename**
- `web/js/logger.js`: rename the seven function definitions.
- Update the only ZM call sites (all were calls to the former `Error()`):
  - `web/skins/classic/js/montage_common.js`
  - `web/skins/classic/views/js/event.js`
  - `web/skins/classic/js/skin.js`

**Commit 2 — stack traces**
- `zmError/zmFatal/zmPanic` now build a real `Error` from the message and report its `.stack` via `logReport`, so the log records where the call originated. Console output and `alert()` behaviour are unchanged. This is only safe *because* we stopped shadowing native `Error`.

## Notes on scope

- Native `new Error()`, `throw Error()` and `reject(Error())` uses are intentionally left untouched.
- The `Error(`/`Debug(`/`Warning(` calls in `.php`/`.js.php` files are the **PHP-side** logger (`ZM\Error()` / `web/includes/logger.php`) — a separate namespace, left alone.
- No back-compat alias for `Error()` is added, because that would reintroduce the shadowing bug.

## Testing

- `npx eslint` passes clean on all touched JS files.
- Grep confirms no remaining ZM-context calls to the old global names.

fixes #4981