### PR TITLE
docs: explain how Event Start/End Command are actually executed

### DIFF
--- a/docs/userguide/definemonitor/definemonitor_recording.rst
+++ b/docs/userguide/definemonitor/definemonitor_recording.rst
@@ -32,5 +32,12 @@ Recording Tab
 - **Output Container**: Leaving at Auto allows ZoneMinder to use mp4. Other choices are mkv and webm.
 - **Optional Encoding Parameters**: Mostly useful when encoding as each encoder takes different parameters. Consult the `FFmpeg documentation <https://ffmpeg.org/ffmpeg-formats.html>`__ for available parameters for each encoder.
 - **Recording Audio**: Check the box in order to save audio (if available) when events are recorded.
-- **Event Start Command**: When a recording event starts, you can run a system command. The parameters to the command will be the event id and the monitor id.
-- **Event End Command**: When a recording event ends, you can run a system command. The parameters to the command will be the event id and the monitor id.
+- **Event Start Command**: When a recording event starts, you can run a system command.
+- **Event End Command**: When a recording event ends, you can run a system command. It runs after the event has been finalized, so the event's video file is complete and its database records are in place.
+
+    How these commands are executed depends on whether the command string contains a ``%`` character:
+
+    - **Without** ``%``, the whole string is treated as the path of a single executable (no shell is involved), and two arguments are appended to it: the event id and the monitor id. You cannot pass your own arguments this way — a value like ``/usr/local/bin/notify.sh start`` is looked up as one file named ``notify.sh start`` and fails.
+    - **With** ``%``, the string is run through ``/bin/sh -c`` after token substitution, and no arguments are appended automatically. Available tokens are ``%EID%`` (event id), ``%MID%`` (monitor id) and, for the start command only, ``%EC%`` (the shell-escaped event cause). So to combine your own arguments with the event id, write e.g. ``/usr/local/bin/notify.sh start %EID%``.
+
+    The command runs in the background as the same user as the capture process (normally the web user), with all file descriptors closed — anything it prints goes nowhere, so redirect output inside your script if you need to see it. A failure to execute the command is logged by the capture process (zmc).


### PR DESCRIPTION
## What

The Recording-tab documentation for **Event Start Command** / **Event End Command** currently says only that *"the parameters to the command will be the event id and the monitor id"*. That is true only when the command contains no `%`, and it hides behaviour that is easy to trip over. This PR documents the actual semantics (from `Monitor::openEvent` / the `closeEvent` thread in `src/zm_monitor.cpp`):

- **Without `%`** the whole string is `execlp()`-ed as **one executable path** with the event id and monitor id appended. Inline arguments are impossible: `/usr/local/bin/notify.sh start` is looked up as a single file named `notify.sh start` and fails.
- **With `%`** the string runs via `/bin/sh -c` after token substitution — `%EID%`, `%MID%`, and (start command only) `%EC%` — and **nothing is appended automatically**. So combining your own arguments with the event id looks like `/usr/local/bin/notify.sh start %EID%`.
- The child runs in the background as the capture-process user with **all file descriptors closed**, so any output silently disappears unless the script redirects it itself.
- The end command fires **after the event is finalized** — the video file is complete and the DB records exist by then.

## Why

Ran into every one of these while wiring an `EventStartCommand`/`EventEndCommand`-based Telegram notifier: a command with an inline argument fails with no visible error (ENOENT happens after the fds are closed), and nothing in the docs explains the two execution modes or the `%EC%` token. Verified against current `master` sources and on a live ZoneMinder 1.38.3 install.

Docs-only change: `docs/userguide/definemonitor/definemonitor_recording.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real-world example

These semantics are exercised end-to-end by [zm-telegram-morph](https://github.com/anton-vinogradov/zm-telegram-morph) — a small MIT-licensed notifier built on exactly the two commands documented here. It turns each event into a single Telegram message that upgrades itself: `EventStartCommand` posts an instant text placeholder (and morphs it into the first alarm frame ~1s later), `EventEndCommand` morphs the same message into the finished video, with an offline queue re-delivering anything that fails. Its monitor wiring is the documented `%`-form:

```
Event Start Command:  /usr/local/bin/zm-telegram-morph <name> start %EID%
Event End Command:    /usr/local/bin/zm-telegram-morph <name> end %EID%
```

Every pitfall listed in this doc change was hit for real while building it.
