### PR TITLE
feat(decoder): DecoderHWAccelName accepts a comma-separated priority list

### DIFF
--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -675,8 +675,10 @@ int FfmpegCamera::OpenFfmpeg() {
       // Build the list of hw device types to try. A DecoderHWAccelName of
       // "auto" probes every hwaccel libav offers and uses the first that both
       // the decoder supports and whose device can be created; any other value
-      // is treated as an explicit device-type name (e.g. "vaapi", "cuda").
-      // If nothing usable is found we transparently fall back to software.
+      // is a comma-separated priority list of device-type names, tried in
+      // order (e.g. "cuda,vaapi"; a single name like "vaapi" is just the
+      // one-element case and behaves as before). If nothing usable is found
+      // we transparently fall back to software.
       std::vector<enum AVHWDeviceType> candidate_types;
       bool auto_detect = (hwaccel_name == "auto");
       enum AVHWDeviceType it = AV_HWDEVICE_TYPE_NONE;
@@ -685,11 +687,15 @@ int FfmpegCamera::OpenFfmpeg() {
         if (auto_detect) candidate_types.push_back(it);
       }
       if (!auto_detect) {
-        enum AVHWDeviceType named = av_hwdevice_find_type_by_name(hwaccel_name.c_str());
-        if (named == AV_HWDEVICE_TYPE_NONE)
-          Debug(1, "Device type %s is not supported.", hwaccel_name.c_str());
-        else
-          candidate_types.push_back(named);
+        for (const std::string &token : Split(hwaccel_name, ',')) {
+          std::string name = TrimSpaces(token);
+          if (name.empty()) continue;
+          enum AVHWDeviceType named = av_hwdevice_find_type_by_name(name.c_str());
+          if (named == AV_HWDEVICE_TYPE_NONE)
+            Warning("Unknown hwaccel device type '%s', skipping.", name.c_str());
+          else
+            candidate_types.push_back(named);
+        }
       }
 
       for (enum AVHWDeviceType type : candidate_types) {


### PR DESCRIPTION
## What

Follow-up to #4984, implementing the idea from [@connortechnology's comment](https://github.com/ZoneMinder/zoneminder/pull/4984#issuecomment): besides `auto` (probe everything) and a single device-type name, `DecoderHWAccelName` now accepts a **comma-separated priority list**, e.g. `cuda,vaapi` — each name is tried in order, and the first type that both the decoder supports and whose device can actually be created wins. The existing transparent software fallback still applies when none work.

## Behaviour

| `DecoderHWAccelName` | result |
| --- | --- |
| `auto` | probe every hwaccel libav offers (unchanged) |
| `vaapi` | single name, exactly as before (one-element list) |
| `cuda,vaapi` | try cuda first, fall back to vaapi, then software |
| `cuda, vaapi` | whitespace around commas is ignored |
| `nonsense,vaapi` | unknown names are skipped with a `Warning`, the rest of the list still works |

No schema or config changes — it is still the same string field; single names and `auto` behave exactly as before, so the change is fully backward-compatible. Uses the existing `Split`/`TrimSpaces` helpers from `zm_utils`.

## Testing

Compiles cleanly against current `master` (`zmc`).

Runtime-validated on an Intel Celeron N5105 iGPU (iHD/VAAPI, no NVIDIA present) with a standalone probe reproducing the selection loop and then decoding real HEVC event footage with `av_hwframe_transfer_data`:

| scenario | selected | frames |
| --- | --- | --- |
| `cuda,vaapi` (cuda device-create fails) | `vaapi` | 216/216 hw-decoded |
| `vaapi,cuda` | `vaapi` | 216/216 hw |
| `vdpau,cuda` (both unavailable) | software | 216 sw frames, no crash |
| `nonsense,vaapi` | `vaapi` | 216/216 hw |
| `cuda, vaapi` (spaces) | `vaapi` | 216/216 hw |
| `vaapi` (single name, compat) | `vaapi` | 216/216 hw |
| `auto` (regression check) | `vaapi` | 216/216 hw |
