### PR TITLE
fix: use method call for System permission check in ConfigsController

### DIFF
--- a/web/api/app/Controller/ConfigsController.php
+++ b/web/api/app/Controller/ConfigsController.php
@@ -105,7 +105,7 @@ class ConfigsController extends AppController {
  */
 	public function edit($id = null) {
 		global $user;
-		$canEdit = (!$user) || ($user['System'] == 'Edit');
+		$canEdit = (!$user) || ($user->System() == 'Edit');
 		if (!$canEdit) {
 			throw new UnauthorizedException(__('Insufficient privileges'));
 			return;
@@ -143,7 +143,7 @@ class ConfigsController extends AppController {
  */
 	public function delete($id = null) {
 		global $user;
-		$canEdit = (!$user) || ($user['System'] == 'Edit');
+		$canEdit = (!$user) || ($user->System() == 'Edit');
 		if (!$canEdit) {
 			throw new UnauthorizedException(__('Insufficient privileges'));
 			return;


### PR DESCRIPTION
The config-api RCE fix guards `edit()` and `delete()` with `($user['System'] == 'Edit')`, but `$user` is a `ZM\User` object that does not implement `ArrayAccess` and whose `System` property is protected. Array access on it raises `Error: Cannot use object of type ZM\User as array`, so the endpoint returns HTTP 500 for every authenticated user.

That blocks the RCE only by accident, and it also breaks config editing for legitimate `System=Edit` admins.

Use `$user->System()`, matching the idiom in every other API controller (States, Servers, Monitors, Users, ...).

Refs GHSA-mvj8-mqqq-2w5f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
