### PR TITLE
fix: enforce per-monitor ACL on direct event, frame and zone API endpoints

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -348,6 +348,18 @@ class EventsController extends AppController {
       throw new NotFoundException(__('Invalid event'));
     }
 
+    # Events=Edit is coarse. Enforce the per-monitor ACL too, otherwise a user
+    # denied a monitor can still mutate that monitor's events by direct Id.
+    $this->Event->recursive = -1;
+    $event = $this->Event->find('first', array(
+      'conditions' => array('Event.' . $this->Event->primaryKey => $id)
+    ));
+    $EventObj = new ZM\Event($event['Event']);
+    if ( !$EventObj->canEdit() ) {
+      throw new UnauthorizedException(__('Insufficient Privileges'));
+      return;
+    }
+
     if ( $this->Event->save($this->request->data) ) {
       $message = 'Saved';
     } else {
@@ -379,6 +391,19 @@ class EventsController extends AppController {
       throw new NotFoundException(__('Invalid event'));
     }
     $this->request->allowMethod('post', 'delete');
+
+    # Events=Edit is coarse. Enforce the per-monitor ACL too, otherwise a user
+    # denied a monitor can still delete that monitor's events by direct Id.
+    $this->Event->recursive = -1;
+    $event = $this->Event->find('first', array(
+      'conditions' => array('Event.' . $this->Event->primaryKey => $id)
+    ));
+    $EventObj = new ZM\Event($event['Event']);
+    if ( !$EventObj->canEdit() ) {
+      throw new UnauthorizedException(__('Insufficient Privileges'));
+      return;
+    }
+
     if ( $this->Event->delete() ) {
       //$this->loadModel('Frame');
       //$this->Event->Frame->delete();

--- a/web/api/app/Controller/FramesController.php
+++ b/web/api/app/Controller/FramesController.php
@@ -26,6 +26,40 @@ class FramesController extends AppController {
     }
   }
 
+  # Frames are addressed by their own Id, so the parent Event's per-monitor ACL
+  # has to be resolved explicitly. Without this a user denied a monitor can
+  # reach that monitor's frames by guessing frame Ids.
+  private function eventForFrame($id) {
+    $this->Frame->recursive = -1;
+    $frame = $this->Frame->find('first', array(
+      'conditions' => array('Frame.' . $this->Frame->primaryKey => $id)
+    ));
+    if (!$frame) {
+      throw new NotFoundException(__('Invalid frame'));
+    }
+    $this->loadModel('Event');
+    $this->Event->recursive = -1;
+    $event = $this->Event->find('first', array(
+      'conditions' => array('Event.Id' => $frame['Frame']['EventId'])
+    ));
+    if (!$event) {
+      throw new NotFoundException(__('Invalid event'));
+    }
+    return new ZM\Event($event['Event']);
+  }
+
+  # Frame mutation is an Event mutation, so require Events=Edit as well as the
+  # per-monitor ACL. beforeFilter() only guarantees Events != None.
+  private function requireFrameEdit($id) {
+    global $user;
+    if ($user and ($user->Events() != 'Edit')) {
+      throw new UnauthorizedException(__('Insufficient Privileges'));
+    }
+    if (!$this->eventForFrame($id)->canEdit()) {
+      throw new UnauthorizedException(__('Insufficient Privileges'));
+    }
+  }
+
 /**
  * index method
  * @return void
@@ -67,6 +101,9 @@ class FramesController extends AppController {
 		if (!$this->Frame->exists($id)) {
 			throw new NotFoundException(__('Invalid frame'));
 		}
+		if (!$this->eventForFrame($id)->canView()) {
+			throw new UnauthorizedException(__('Insufficient Privileges'));
+		}
 		$options = array('conditions' => array('Frame.' . $this->Frame->primaryKey => $id));
 		$frame = $this->Frame->find('first', $options);
 		$this->set(array(
@@ -102,6 +139,7 @@ class FramesController extends AppController {
 		if (!$this->Frame->exists($id)) {
 			throw new NotFoundException(__('Invalid frame'));
 		}
+		$this->requireFrameEdit($id);
 		if ($this->request->is(array('post', 'put'))) {
 			if ($this->Frame->save($this->request->data)) {
 				return $this->flash(__('The frame has been saved.'), array('action' => 'index'));
@@ -127,6 +165,7 @@ class FramesController extends AppController {
 			throw new NotFoundException(__('Invalid frame'));
 		}
 		$this->request->allowMethod('post', 'delete');
+		$this->requireFrameEdit($id);
 		if ($this->Frame->delete()) {
 			return $this->flash(__('The frame has been deleted.'), array('action' => 'index'));
 		} else {

--- a/web/api/app/Controller/ZonesController.php
+++ b/web/api/app/Controller/ZonesController.php
@@ -31,6 +31,19 @@ class ZonesController extends AppController {
     if ( !$this->Monitor->exists($id) ) {
       throw new NotFoundException(__('Invalid monitor'));
     }
+
+    # Monitors=View is coarse. Enforce the per-monitor ACL so zones of a monitor
+    # the user is denied are not listed by direct monitor Id.
+    $this->Monitor->recursive = -1;
+    $monitor = $this->Monitor->find('first', array(
+      'conditions' => array('Monitor.Id' => $id)
+    ));
+    $MonitorObj = new ZM\Monitor($monitor['Monitor']);
+    if ( !$MonitorObj->canView() ) {
+      throw new UnauthorizedException(__('Insufficient Privileges'));
+      return;
+    }
+
     $this->Zone->recursive = -1;
     $zones = $this->Zone->find('all', array(
       'conditions' => array('MonitorId' => $id)


### PR DESCRIPTION
Several API endpoints checked only the coarse `Events`/`Monitors` permission and not the per-monitor object ACL, so a user explicitly denied a monitor could still reach that monitor's objects by addressing them directly:

- `EventsController::edit()` and `::delete()` checked `Events=Edit` but never called `canEdit()` on the event, so any event could be mutated or deleted by Id.
- `FramesController` only guaranteed `Events != None` in `beforeFilter()`. `view()` returned any frame by Id, and `edit()`/`delete()` mutated frames without requiring `Events=Edit` or checking the parent event at all.
- `ZonesController::forMonitor()` listed zones for any monitor Id.

This resolves the owning object and applies the same `canView()`/`canEdit()` checks the normal read paths already use. Frames are addressed by their own Id, so the parent event is looked up to reach the monitor ACL.

Refs GHSA-hw39-qpjw-p7cg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
