### PR TITLE
fix: escape Zone, Event and Server names on output

### DIFF
--- a/web/ajax/modals/server.php
+++ b/web/ajax/modals/server.php
@@ -20,7 +20,7 @@ if ( $sid and ! $Server->Id() ) return;
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><?php echo translate('Server') .' - '. $Server->Name() ?></h5>
+        <h5 class="modal-title"><?php echo translate('Server') .' - '. validHtmlStr($Server->Name()) ?></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/web/includes/Zone.php
+++ b/web/includes/Zone.php
@@ -79,7 +79,7 @@ class Zone extends ZM_Object {
         $areaCoords = preg_replace('/\s+/', ',', pointsToCoords($points));
       }
     }
-    return '<polygon points="'.$areaCoords.'" class="'.$this->Type().'" data-mid="'.$this->MonitorId().'" data-zid="'.$this->Id().'"><title>'.$this->Name().'</title></polygon>';
+    return '<polygon points="'.$areaCoords.'" class="'.$this->Type().'" data-mid="'.$this->MonitorId().'" data-zid="'.$this->Id().'"><title>'.validHtmlStr($this->Name()).'</title></polygon>';
   }
 } # end class Zone
 ?>

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -21,12 +21,12 @@ var connKey = '<?php echo $connkey ?>';
 var eventData = {
 <?php if ( $Event->Id() ) { ?>
     Id: '<?php echo $Event->Id() ?>',
-    Name: '<?php echo $Event->Name() ?>',
+    Name: <?php echo json_encode($Event->Name(), JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP) ?>,
     MonitorId: '<?php echo $Event->MonitorId() ?>',
     MonitorName: '<?php echo validJsStr($monitor->Name()) ?>',
     Cause: '<?php echo validHtmlStr($Event->Cause()) ?>',
     <!-- Tags: '<?php echo validHtmlStr(implode(', ', array_map(function($t){return $t->Name();}, $Event->Tags()))); ?>', -->
-    Notes: `<?php echo $Event->Notes()?>`,
+    Notes: <?php echo json_encode($Event->Notes(), JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP) ?>,
     Width: '<?php echo $Event->Width() ?>',
     Height: '<?php echo $Event->Height() ?>',
     Length: '<?php echo $Event->Length() ?>',

--- a/web/skins/classic/views/plugin.php
+++ b/web/skins/classic/views/plugin.php
@@ -103,7 +103,7 @@ echo getNavBarHTML();
 ?>
   <div id="page">
     <div id="header">
-      <h2><?php echo translate('Monitor') ?> <?php echo $monitor->Name() ?> - <?php echo translate('Zone') ?> <?php echo $newZone['Name'] ?> - <?php echo translate('Plugin') ?> <?php echo validHtmlStr($plugin) ?></h2>
+      <h2><?php echo translate('Monitor') ?> <?php echo validHtmlStr($monitor->Name()) ?> - <?php echo translate('Zone') ?> <?php echo validHtmlStr($newZone['Name']) ?> - <?php echo translate('Plugin') ?> <?php echo validHtmlStr($plugin) ?></h2>
     </div>
     <div id="content">
       <form name="pluginForm" id="pluginForm" method="post" action="?">

--- a/web/skins/classic/views/zone.php
+++ b/web/skins/classic/views/zone.php
@@ -140,7 +140,7 @@ echo getNavBarHTML();
         <button type="button" id="refreshBtn" class="btn btn-normal" data-toggle="tooltip" data-placement="top" title="<?php echo translate('Refresh') ?>" ><i class="fa fa-refresh"></i></button>
       </div>
       <div class="w-100 pt-2">
-        <h2><?php echo translate('Monitor').' '.$monitor->Name().' - '.translate('Zone').' '.$zone['Name'] ?></h2>
+        <h2><?php echo translate('Monitor').' '.validHtmlStr($monitor->Name()).' - '.translate('Zone').' '.validHtmlStr($zone['Name']) ?></h2>
       </div>
     </div>
     <div id="content">


### PR DESCRIPTION
`Zone.Name`, `Event.Name`, `Event.Notes` and `Server.Name` are persisted user-controllable strings that were emitted without escaping, so a user with edit rights on the object could store markup that runs in the browser of anyone who later views the page, including an administrator. Zone and Server save through `getFormChanges` + raw SQL, so they never pass the object `filter_regexp` layer that strips markup elsewhere.

HTML and SVG sinks now use `validHtmlStr()`:
- `Zone::svg_polygon()` escapes the `<title>`, covering every caller (event view, montage and stream).
- `views/zone.php` and `views/plugin.php` headings.
- `ajax/modals/server.php` modal title.

The two inline-JS sinks in `views/js/event.js.php` are `require_once`'d inside a `<script nonce>` block, so a `</script>` in `Event.Name` or `Notes` broke out of the element and the nonce did not help. `Notes` was also interpolated into a template literal, making backtick and `${}` live. Both now emit `json_encode(..., JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP)`, which supplies its own double quotes.

Follow-ups the advisory lists separately (not in this PR): `Monitor.Name`/`Storage.Name` output escaping, and server-side input validation for the `getFormChanges` save paths.

Refs GHSA-72c3-g86w-f587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
