### PR TITLE
fix: loop the :// strip in detaintPath so it cannot be re-formed

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -1823,8 +1823,12 @@ function generateConnKey() {
 }
 
 function detaintPathAllowAbsolute($path) {
-  // Strip out :// because php:// is a way to inject code apparently
-  $path = str_replace('://', '', $path);
+  // Strip out :// because php:// is a way to inject code apparently.
+  // This must loop: a single pass lets the removal re-form the sequence it
+  // just removed, so '::////' collapses back into '://'.
+  do {
+    $path = str_replace('://', '', $path, $count);
+  } while($count);
   // Remove any absolute paths, or relative ones that want to go up
   do {
     $path = str_replace('../', '', $path, $count);
@@ -1834,8 +1838,12 @@ function detaintPathAllowAbsolute($path) {
 
 function detaintPath($path) {
 
-  // Strip out :// because php:// is a way to inject code apparently
-  $path = str_replace('://', '', $path);
+  // Strip out :// because php:// is a way to inject code apparently.
+  // This must loop: a single pass lets the removal re-form the sequence it
+  // just removed, so '::////' collapses back into '://'.
+  do {
+    $path = str_replace('://', '', $path, $count);
+  } while($count);
   // Remove any absolute paths, or relative ones that want to go up
   do {
     $path = str_replace('../', '', $path, $count);


### PR DESCRIPTION
`detaintPath()` and `detaintPathAllowAbsolute()` removed `://` with a single `str_replace()` while the `../` removal below them already looped.

One pass is not enough, because removing a match can join its neighbours into a fresh match: `::////` collapses to `://`. So

```
php::////filter/read=string.rot13/resource=/etc/passwd
```

came back out of the filter as

```
php://filter/read=string.rot13/resource=/etc/passwd
```

reinstating exactly the wrapper the strip exists to remove.

This loops the `://` removal the same way the `../` removal is looped. These functions guard `$view`, `$request`, `$action`, the modal name and skin file paths.

Refs GHSA-wgqf-6fjf-7gxw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
