### PR TITLE
fix: enforce Storage containment before deleting files

### DIFF
--- a/web/includes/actions/files.php
+++ b/web/includes/actions/files.php
@@ -45,6 +45,15 @@ if ($action == 'delete') {
   }
   $path_parts = pathinfo($path);
 
+  # $is_ok_path was computed above but never consulted, so a path outside every
+  # Storage area still reached unlink(). detaintPathAllowAbsolute() permits
+  # absolute paths, so this is what keeps the delete inside a Storage area.
+  if (!$is_ok_path) {
+    $error_message .= 'Path is not valid. Path must be below a designated Storage area.<br/>';
+    ZM\Warning("Refusing to delete files under '$path': not below a Storage area");
+    return;
+  }
+
   foreach ($_REQUEST['files'] as $file) {
     $full_path = $path.'/'.detaintPath($file);
     if (is_file($full_path)) {


### PR DESCRIPTION
The delete action computed `$is_ok_path` to confirm the requested path sits below a configured Storage area, but never consulted it, so the check was dead code and `unlink()` ran on whatever path was supplied. The path comes from `detaintPathAllowAbsolute($_REQUEST['path'])`, which deliberately permits absolute paths, so nothing else constrained the target.

This returns with an error when the path is not below a Storage area.

Deleting already requires `System Edit`, so this is not reachable by a low privilege user, but the containment check should do what it was written to do.

Note: the adjacent `$path_parts` assignment is also unused. Left in place as it predates this change.

Refs GHSA-g355-3rf6-f38v.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
