### PR TITLE
fix: only write analysis jpegs for alarm frames

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -608,7 +608,10 @@ void Event::AddFrame(const std::shared_ptr<ZMPacket>&packet) {
       }
     } // end if is an alarm frame
 
-    if (save_jpegs & 2) {
+    // Only write analysis jpegs for alarm frames. Since 1.38 every analysed
+    // packet carries an analysis_image (for the live analysis view), so
+    // writing whenever one exists would save every frame of the event.
+    if ((save_jpegs & 2) and (frame_type == ALARM)) {
       if (packet->analysis_image) {
         std::string event_file = stringtf(staticConfig.analyse_file_format.c_str(), path.c_str(), frames);
         Debug(1, "Writing analysis frame %d to %s", frames, event_file.c_str());


### PR DESCRIPTION
Fixes #4996

## Problem

Since the 1.38 analysis pipeline rewrite, `packet->analysis_image` is created for every frame that goes through motion detection (so the live Analysis view shows full colour instead of greyscale). `Event::AddFrame` wrote an analysis jpeg whenever the packet had one — which is now always — so **SaveJPEGs = Analysis images only (if available)** saved every analysed frame of the event instead of only alarmed frames as in 1.36. On a 10fps Always Recording + Always Analysing monitor that is ~6,000 jpegs (~4GB) per 10-minute event vs ~400MB on 1.36.

## Fix

Gate the analysis-jpeg write on `frame_type == ALARM`, restoring 1.36 semantics: analysis jpegs are only written for alarm frames (including scored pre/post-alarm buffer frames). The live analysis view is unaffected.


🤖 Generated with [Claude Code](https://claude.com/claude-code)