### PR TITLE
Fix: Prevent buttons from expanding to the full height of their parent if they have an immediate parent called "#toolbar" (skin.css)

### DIFF
--- a/web/skins/classic/css/base/skin.css
+++ b/web/skins/classic/css/base/skin.css
@@ -146,6 +146,10 @@ button.btn {
   margin-bottom: 3px;
 }
 
+#toolbar>button {
+  align-self: flex-start;
+}
+
 #toolbar .btn-normal,
 #toolbar .btn-danger {
   margin-right: 3px;


### PR DESCRIPTION
`#toolbar` block is rendered as a` flex container`. We prevent the buttons within it from stretching, i.e., when `#toolbar `is their direct parent.
For example, on the Log page it looked like this:
<img width="1258" height="245" alt="before" src="https://github.com/user-attachments/assets/c64e14a2-dcb2-47bb-8eb9-4f98a6e2f8ff" />

It will look like this:
<img width="1265" height="278" alt="after" src="https://github.com/user-attachments/assets/3b8b98a3-dde7-49c8-93f0-92650a4f72de" />
