### PR TITLE
Fix: Avoid duplicate "handleClick" calls on Watch page

### DIFF
--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -866,7 +866,6 @@ function streamStart(monitor = null) {
   if (streamMode == 'single') {
     monitorStream.setup_onclick(fetchImage);
   } else {
-    monitorStream.setup_onclick(handleClick);
     monitorStream.setup_onmove(handleMove);
   }
   monitorStream.setup_onpause(onPause);

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -864,7 +864,7 @@ function streamStart(monitor = null) {
   //monitorsSetScale(monitorId);
   streamCmdPlay(true);
   if (streamMode == 'single') {
-    monitorStream.setup_onclick(fetchImage);
+    monitorStream.setup_onclick((evt) => { const img = evt && evt.target && evt.target.closest ? evt.target.closest('img') : null; if (img) fetchImage(img); });
   } else {
     monitorStream.setup_onmove(handleMove);
   }


### PR DESCRIPTION
We don't need to additionally assign a listener via `setup_onclick` in `monitorStream`, since we have a global listener:
```
document.addEventListener('click', function(event) { 
  handleClick(event);
});
```