### PR TITLE
Fix: Prevent the old ZoomPan algorithm from executing for players other than ZMS or when clicking outside of LiveStream & more....

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2792,45 +2792,37 @@ function initDatepicker() {
 }
 
 function managePanZoomButton(evt) {
-  var url = null;
+  var url = "";
   if (panZoomEnabled) {
-    const targetId = evt.target.id;
-    var monitorId_ = null; // Resolve variable conflict. ToDo: In general, you need to use objects.
+    const targetId =
+        evt.target.closest('[id^="imageFeed"]')?.id ||
+        evt.target.closest('[id^="videoFeedStream"]')?.id ||
+        "";
+    if (!targetId) {
+      console.log("Unable to get monitor ID for the clicked object", evt.target);
+      return;
+    }
+    const mid = stringToNumber(targetId);
     if (!evt.target.closest('.imageFeed') && !(evt.target.closest('#videoFeed'))) {
       // Click was outside '.imageFeed'
       $j('[id^="button_zoom"]').addClass('hidden');
       return;
     } else {
-      $j('#button_zoom' + stringToNumber(targetId)).removeClass('hidden');
-    }
-    if (!('getAttribute' in evt.currentTarget)) return; // Touchscreen tap on '.imageFeed' does not have 'currentTarget'
-    //evt.preventDefault();
-    // We are looking for an object with an ID, because there may be another element in the button.
-    const obj = targetId ? evt.target : evt.target.parentElement;
-    if (!obj) {
-      console.log("No obj found", targetId, evt.target, evt.target.parentElement);
-      return;
+      $j('#button_zoom' + mid).removeClass('hidden');
     }
 
-    if (currentView == 'watch') {
-      monitorId_ = monitorId;
-    } else if (currentView == 'montage') {
-      // On Montage page with mode==EDITING it is forbidden to use PanZoom
-      if (mode == EDITING) return;
-      monitorId_ = evt.currentTarget.getAttribute("data-monitor-id");
-    } else if (currentView == 'event') {
-      monitorId_ = eventData.MonitorId;
-    }
-
-    if (obj.className.includes('btn-view-watch')) {
-      url = '?view=watch&mid='+monitorId_;
-    } else if (obj.className.includes('btn-edit-monitor')) {
-      url = '?view=monitor&mid='+monitorId_;
-    } else if (obj.className.includes('btn-fullscreen')) {
+    const buttonClicked = evt.target.closest('button') || evt.target.closest('.btn');
+    if (buttonClicked) {
+      if (buttonClicked.className.includes('btn-view-watch')) {
+        url = '?view=watch&mid='+mid;
+      } else if (buttonClicked.className.includes('btn-edit-monitor')) {
+        url = '?view=monitor&mid='+mid;
+      } else if (buttonClicked.className.includes('btn-fullscreen')) {
       if (document.fullscreenElement) {
         closeFullscreen();
       } else {
-        openFullscreen(document.getElementById('monitor'+evt.currentTarget.getAttribute("data-monitor-id")));
+          openFullscreen(document.getElementById('monitor'+mid));
+        }
       }
     }
     if (url) {
@@ -2841,8 +2833,8 @@ function managePanZoomButton(evt) {
       }
     }
     // Zoom by mouse click
-    if (thisClickOnStreamObject(obj)) {
-      zmPanZoom.click(monitorId_);
+    if (thisClickOnStreamObject(evt.target)) {
+      zmPanZoom.click(mid);
     }
   }
 }

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2818,9 +2818,9 @@ function managePanZoomButton(evt) {
       } else if (buttonClicked.className.includes('btn-edit-monitor')) {
         url = '?view=monitor&mid='+mid;
       } else if (buttonClicked.className.includes('btn-fullscreen')) {
-      if (document.fullscreenElement) {
-        closeFullscreen();
-      } else {
+        if (document.fullscreenElement) {
+          closeFullscreen();
+        } else {
           openFullscreen(document.getElementById('monitor'+mid));
         }
       }

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2793,7 +2793,7 @@ function initDatepicker() {
 
 function managePanZoomButton(evt) {
   var url = "";
-  if (panZoomEnabled) {
+  if (panZoomEnabled && thisClickOnStreamObject(evt.target)) {
     const targetId =
         evt.target.closest('[id^="imageFeed"]')?.id ||
         evt.target.closest('[id^="videoFeedStream"]')?.id ||
@@ -2833,9 +2833,7 @@ function managePanZoomButton(evt) {
       }
     }
     // Zoom by mouse click
-    if (thisClickOnStreamObject(evt.target)) {
-      zmPanZoom.click(mid);
-    }
+    zmPanZoom.click(mid);
   }
 }
 

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2793,25 +2793,17 @@ function initDatepicker() {
 
 function managePanZoomButton(evt) {
   var url = "";
-  if (panZoomEnabled && thisClickOnStreamObject(evt.target)) {
-    const targetId =
-        evt.target.closest('[id^="imageFeed"]')?.id ||
-        evt.target.closest('[id^="videoFeedStream"]')?.id ||
-        "";
-    if (!targetId) {
-      console.log("Unable to get monitor ID for the clicked object", evt.target);
-      return;
-    }
-    const mid = stringToNumber(targetId);
-    if (!evt.target.closest('.imageFeed') && !(evt.target.closest('#videoFeed'))) {
-      // Click was outside '.imageFeed'
+  if (panZoomEnabled) {
+    const target = evt.target.closest('[id^="imageFeed"], [id^="videoFeedStream"]');
+    if (!target) {
+      // Click was outside imageFeed & videoFeedStream
       $j('[id^="button_zoom"]').addClass('hidden');
       return;
-    } else {
-      $j('#button_zoom' + mid).removeClass('hidden');
     }
+    const mid = stringToNumber(target.id);
+    const buttonClicked = evt.target.closest('button, .btn');
+    $j('#button_zoom' + mid).removeClass('hidden');
 
-    const buttonClicked = evt.target.closest('button') || evt.target.closest('.btn');
     if (buttonClicked) {
       if (buttonClicked.className.includes('btn-view-watch')) {
         url = '?view=watch&mid='+mid;
@@ -2832,8 +2824,10 @@ function managePanZoomButton(evt) {
         window.location.assign(url);
       }
     }
-    // Zoom by mouse click
-    zmPanZoom.click(mid);
+    if (thisClickOnStreamObject(evt.target)) {
+      // Zoom by mouse click
+      zmPanZoom.click(mid);
+    }
   }
 }
 

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2832,6 +2832,9 @@ function managePanZoomButton(evt) {
         window.location.assign(url);
       }
     }
+
+    // On Montage page with mode==EDITING it is forbidden to use PanZoom
+    if (currentView == 'montage' && mode == EDITING) return;
     if (thisClickOnStreamObject(evt.target)) {
       // Zoom by mouse click
       zmPanZoom.click(mid);

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2794,13 +2794,21 @@ function initDatepicker() {
 function managePanZoomButton(evt) {
   var url = "";
   if (panZoomEnabled) {
-    const target = evt.target.closest('[id^="imageFeed"], [id^="videoFeedStream"]');
+    const target = evt.target.closest('[id^="imageFeed"], [id^="videoFeedStream"], [id^="videoFeed"]');
     if (!target) {
       // Click was outside imageFeed & videoFeedStream
       $j('[id^="button_zoom"]').addClass('hidden');
       return;
     }
-    const mid = stringToNumber(target.id);
+    let mid = stringToNumber(target.id);
+    if (Number.isNaN(mid)) {
+      // For example, MJPEG on Event page
+      mid = stringToNumber(target.querySelector('[id^="imageFeed"], [id^="videoFeedStream"]')?.id);
+    }
+    if (Number.isNaN(mid)) {
+      console.log("Unable to get monitor ID for the clicked object", evt.target);
+      return;
+    }
     const buttonClicked = evt.target.closest('button, .btn');
     $j('#button_zoom' + mid).removeClass('hidden');
 

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -505,6 +505,7 @@ function handleClick(event) {
     managePanZoomButton(event);
   } else {
     // +++ Old ZoomPan algorithm.
+    if (targetId.indexOf("liveStream") === -1 || monitorStream.activePlayer.indexOf('zms') == -1 ) return;
     if (!(event.ctrlKey && (event.shift || event.shiftKey))) {
     // target should be the img tag
       const target = $j(event.target);
@@ -869,7 +870,7 @@ function streamStart(monitor = null) {
       if (img) fetchImage(img);
     });
   } else {
-    monitorStream.setup_onclick(handleClick);
+    //monitorStream.setup_onclick(handleClick);
     monitorStream.setup_onmove(handleMove);
   }
   monitorStream.setup_onpause(onPause);

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -505,7 +505,7 @@ function handleClick(event) {
     managePanZoomButton(event);
   } else {
     // +++ Old ZoomPan algorithm.
-    if (targetId.indexOf("liveStream") === -1 || monitorStream.activePlayer.indexOf('zms') == -1 ) return;
+    if (targetId.indexOf("liveStream") === -1 || !monitorStream || monitorStream.activePlayer.indexOf('zms') === -1) return;
     if (!(event.ctrlKey && (event.shift || event.shiftKey))) {
     // target should be the img tag
       const target = $j(event.target);
@@ -870,7 +870,6 @@ function streamStart(monitor = null) {
       if (img) fetchImage(img);
     });
   } else {
-    //monitorStream.setup_onclick(handleClick);
     monitorStream.setup_onmove(handleMove);
   }
   monitorStream.setup_onpause(onPause);


### PR DESCRIPTION
Also:
- Don't execute `monitorStream.setup_onclick(handleClick)` since we have a global listener for `handleClick`.
```
document.addEventListener('click', function(event) { 
  handleClick(event);
});
```
This avoids duplicate `"handleClick"` calls on the Watch page.

- Completely redesigned and optimized the `managePanZoomButton(evt)` function to take into account that the listener can be globally assigned to the document. We now use only `evt.target`, rather than `evt.currentTarget`.

This PR replaces the unsuccessful #5003.