### PR TITLE
fix(decoder): make the software-decoding fallback visible, and retryable

### DIFF
--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -749,7 +749,19 @@ int FfmpegCamera::OpenFfmpeg() {
       }  // end foreach candidate type
 
       if (hw_pix_fmt == AV_PIX_FMT_NONE) {
-        Debug(1, "No usable hardware decoder found; falling back to software decoding.");
+        // "auto" asks us to probe, so finding nothing is unremarkable. But if
+        // the admin named hwaccels explicitly and none of them worked, this
+        // monitor now decodes on the CPU and nothing else will ever say so:
+        // a default install does not log Debug, and we only get here once, at
+        // capture start. That silence hides a dead GPU for as long as nobody
+        // wonders why the load average doubled.
+        if (auto_detect) {
+          Debug(1, "No usable hardware decoder found; falling back to software decoding.");
+        } else {
+          Warning("None of the requested hwaccels (%s) are usable for %s; "
+              "falling back to software decoding.",
+              hwaccel_name.c_str(), mVideoCodec->name);
+        }
         use_hwaccel = false;
       }
 #else

--- a/src/zm_ffmpeg_camera.cpp
+++ b/src/zm_ffmpeg_camera.cpp
@@ -897,6 +897,14 @@ int FfmpegCamera::Close() {
   }
 #endif
 
+  // Re-arm hardware decoding for the next PrimeCapture(). Without this a
+  // single transient failure - a GPU still resetting, a driver that finished
+  // initialising after zmc started, a render node not yet permissioned -
+  // pins the monitor to software decoding for the whole life of the process,
+  // long after the hardware is healthy again. Reconnects are the natural
+  // retry point, so let them retry.
+  use_hwaccel = true;
+
   if ( mFormatContext ) {
     avformat_close_input(&mFormatContext);
     mFormatContext = nullptr;


### PR DESCRIPTION
Two follow-ups to #4984, both found the hard way: my iGPU hung on a HEVC fence and ZoneMinder spent a week decoding on the CPU without ever telling me.

### 1. A failed hwaccel no longer says anything

Before #4984 the failure path was `Error("Failed to create hwaccel device...")`. The rework moved the per-candidate failure to `Warning` — correct, since with a candidate list one miss is not a fault — but the *final* "nothing worked" case ended up at `Debug(1)`, which a default install never writes.

The result is a monitor that looks identical whether it is decoding in hardware or not. Recording keeps working (camera passthrough writes the stream without decoding it), so the only symptom is a load average that quietly doubled. On my box that was `%user` 28 → 48 and roughly one extra core per stream; I only went looking because the fans got loud.

This restores the old visibility, but keeps `auto` quiet: probing and finding nothing is the expected outcome there, whereas naming `vaapi` explicitly and silently not getting it is worth a line in the log.

### 2. `use_hwaccel` latched off for the life of the process

`use_hwaccel` was set to `false` on first failure and never restored, so the decision outlived the condition that caused it. `Close()` frees `hw_device_ctx` and is on the path of every `PrimeCapture()`, but the flag stayed off — meaning a reconnect never retried hardware decoding.

That turns any transient failure into a permanent one:

- the host reboots and `zmc` wins the race against the graphics driver
- the GPU is mid-reset when a camera reconnects
- the render node is not permissioned yet at boot

In each case the monitor is pinned to software decoding until someone restarts the process, long after the hardware is fine. Resetting the flag in `Close()` makes reconnects the natural retry point. Hardware that is genuinely gone simply fails again — and now, with the first commit, says so.

### Testing

Built against master in a clean Ubuntu 24.04 container (`cmake -DCMAKE_BUILD_TYPE=Release`); `zm_ffmpeg_camera.cpp` compiles with no new warnings. Verified on a live 1.38 install with two Hikvision cameras on a Jasper Lake iGPU, in both states — VAAPI working, and VAAPI dead after a GuC reset failure (`i915 ... Failed to reset GuC, ret = -110`), which is what prompted this.

No unit tests: this is logging behaviour and a flag reset inside `FfmpegCamera`, which needs a real capture device to exercise.
