### PR TITLE
fix: bound sprop-parameter-sets copy to prevent SDP stack overflow

### DIFF
--- a/src/zm_sdp.cpp
+++ b/src/zm_sdp.cpp
@@ -367,7 +367,17 @@ AVFormatContext *SessionDescriptor::generateFormatContext() const {
       codec_context->extradata= nullptr;
       char pvalue[1024], *value = pvalue;
 
-      strcpy(pvalue, mediaDesc->getSprops().c_str());
+      // sprop-parameter-sets comes from the (untrusted) camera SDP. A real
+      // H.264 SPS/PPS base64 blob is small; anything approaching the buffer
+      // size is malformed or hostile, so refuse it rather than overflow the
+      // stack with an unbounded strcpy.
+      if (mediaDesc->getSprops().size() >= sizeof(pvalue)) {
+        Warning("Ignoring oversized sprop-parameter-sets (%zu bytes) from SDP",
+                mediaDesc->getSprops().size());
+        pvalue[0] = '\0';
+      } else {
+        strcpy(pvalue, mediaDesc->getSprops().c_str());
+      }
 
       while ( *value ) {
         char base64packet[1024];


### PR DESCRIPTION
`SessionDescriptor::generateFormatContext()` copied the camera-controlled SDP `sprop-parameter-sets` value into a fixed `char pvalue[1024]` stack buffer via unbounded `strcpy()`. A malicious or MitM'd RTSP camera returning an oversized `sprop-parameter-sets` in its DESCRIBE response could overflow the stack (saved frame pointer / return address) → RCE as the capture process user.

A real H.264 SPS/PPS base64 blob is small; this refuses anything that would not fit the buffer rather than copying it. The inner base64 parse loop was already bounded, so only the outer copy was unsafe.

Verified: builds clean (zmc), no new warnings.

Refs GHSA-wg5h-vcgv-74pv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
