### PR TITLE
Fix: Changed the handling of key presses for PanZoom

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -104,7 +104,8 @@ var zmPanZoom = {
         _this.setTriggerChangedMonitors(id);
       });
 
-      $j(document).on('keyup.panzoom keydown.panzoom', function(e) {
+      const nameSpace = '.panzoom_' + id;
+      $j(document).on('keyup' + nameSpace + ' keydown' + nameSpace, function(e) {
         _this.shifted = e.shiftKey ? e.shiftKey : e.shift;
         _this.ctrled = e.ctrlKey;
         _this.alted = e.altKey;
@@ -123,7 +124,8 @@ var zmPanZoom = {
         console.log(`PanZoom for monitor "${params['id']}" was not initialized.`);
         return;
       }
-      //Disables for the entire document!//$j(document).off('keyup.panzoom keydown.panzoom');
+      const nameSpace = '.panzoom_' + params['id'];
+      $j(document).off(nameSpace);
       const obj = this.panZoom[params['id']].target;
       // #videoFeed - Event page, #monitorX - Montage & Watch page
       const el = document.getElementById('videoFeed');

--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -105,7 +105,7 @@ var zmPanZoom = {
       });
 
       const nameSpace = '.panzoom_' + id;
-      $j(document).on('keyup' + nameSpace + ' keydown' + nameSpace, function(e) {
+      $j(document).off(nameSpace).on('keyup' + nameSpace + ' keydown' + nameSpace, function(e) {
         _this.shifted = e.shiftKey ? e.shiftKey : e.shift;
         _this.ctrled = e.ctrlKey;
         _this.alted = e.altKey;


### PR DESCRIPTION
We now assign them using the monitor ID rather than simply using the ".panzoom" namespace.
This allows us to correctly remove the listener for a specific monitor.
Previously, the listener wasn't removed, which resulted in unnecessary code execution.