### PR TITLE
Fix: PanZoom. When scale = 1 and Ctrl, Alt, or Shift is pressed, prevent the player from responding to image clicks. on Event page (panzoom.js)

### DIFF
--- a/web/js/panzoom.js
+++ b/web/js/panzoom.js
@@ -261,7 +261,13 @@ var zmPanZoom = {
       if (videoJs) videoJs.style.pointerEvents = 'none';
     } else {
       this.panZoom[id].setOptions({handleStartEvent: (event) => {}});
-      if (videoJs) videoJs.style.pointerEvents = '';
+      if (videoJs) {
+        if (this.shifted || this.ctrled || this.alted) {
+          videoJs.style.pointerEvents = 'none';
+        } else {
+          videoJs.style.pointerEvents = '';
+        }
+      }
     }
   },
 


### PR DESCRIPTION
In addition to #4651
This will allow the image to be zoomed when using the "Shift + Left-Click" combination when scale = 1 without stopping or starting playback.