### PR TITLE
Smoother progress bar ("#progressBox") updates on the Event page when using video.js

### DIFF
--- a/web/skins/classic/css/base/views/event.css
+++ b/web/skins/classic/css/base/views/event.css
@@ -217,7 +217,7 @@ height: 100%;
 }
 
 #progressBar .progressBox {
-  transition: width .1s;
+  transition: width 0.2s linear;
   height: 100%;
   position: absolute;
   top: 0;

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -148,8 +148,6 @@ height: 100%;
 }
 
 #progressBar .progressBox {
-    transition: width .1s;
-    height: 100%;
     background: rgba(170, 170, 170, .7);
     border-radius: 0 0 .3em .3em;
 }

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1415,7 +1415,6 @@ function initPage() {
     vid.on('timeupdate', function() {
       updateProgressBar();
       $j('#progressValue').html(secsToTime(Math.floor(vid.currentTime())));
-      $j('#currentTimeValue').html(clockTime.toLocaleTimeString());
     });
     vid.on('ratechange', function() {
       rate = vid.playbackRate() * 100;

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1413,9 +1413,8 @@ function initPage() {
     if (cookie) vid.volume(cookie);
 
     vid.on('timeupdate', function() {
+      updateProgressBar();
       $j('#progressValue').html(secsToTime(Math.floor(vid.currentTime())));
-      var clockTime = new Date(eventData.StartDateTime);
-      clockTime.setTime(clockTime.getTime() + (vid.currentTime() * 1000));
       $j('#currentTimeValue').html(clockTime.toLocaleTimeString());
     });
     vid.on('ratechange', function() {

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -498,7 +498,9 @@ function getCmdResponse(respObj, respText) {
     fps.innerHTML = streamStatus.fps;
   }
 
-  updateProgressBar();
+  if (!vid) {
+    updateProgressBar();
+  }
 
   if (streamStatus.auth) {
     if (streamStatus.auth != auth_hash) {
@@ -1793,12 +1795,6 @@ function initPage() {
       updateScale = false;
     }
   }, 500);
-
-  if (vid) {
-    setInterval(() => {
-      updateProgressBar();
-    }, streamTimeout);
-  }
 
   const toggleZonesButton = document.getElementById('toggleZonesButton');
   if (toggleZonesButton) toggleZonesButton.addEventListener('click', toggleZones);


### PR DESCRIPTION
The code
```
      var clockTime = new Date(eventData.StartDateTime);
      clockTime.setTime(clockTime.getTime() + (vid.currentTime() * 1000));
      $j('#currentTimeValue').html(clockTime.toLocaleTimeString());
```
was removed because similar code
```
...
    var progressDate = new Date(eventData.StartDateTime);
    progressDate.setTime(progressDate.getTime() + (currentTime * 1000));
...
$j('#currentTimeValue').html(progressDate.toLocaleTimeString());
```
is already used in updateProgressBar().