### PR TITLE
fix: snapshot stream command params before queueing ajax

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1644,7 +1644,11 @@ function MonitorStream(monitorData) {
         this.ajaxQueue = jQuery.ajaxQueue({
           url: this.url + (auth_relay?'?'+auth_relay:''),
           xhrFields: {withCredentials: true},
-          data: streamCmdParms,
+          // Snapshot: ajaxQueue defers $.ajax (and therefore data serialization)
+          // until earlier queued requests finish. Callers that pass this.streamCmdParms
+          // directly would otherwise have their command clobbered by the
+          // streamCmdQuery timer setting command=CMD_QUERY before the request fires.
+          data: Object.assign({}, streamCmdParms),
           dataType: 'json'
         })
             .done(this.getStreamCmdResponse.bind(this))


### PR DESCRIPTION
Fixes #5031

### Problem

The Show Analysis button in the live watch view does nothing. `analysis=1` on the `nph-zms` URL works, so zms is fine — the command never reaches it.

### Cause

`$.ajaxQueue` doesn't call `$.ajax()` immediately. It queues a closure and runs it after earlier requests finish (`web/js/ajaxQueue.js:14-22`), and jQuery serialises `data` at that later point.

`streamCmdReq()` passed `data` by reference, and `show_analyse_frames()` hands it the shared `this.streamCmdParms`:

```js
this.streamCmdParms.command = this.analyse_frames ? CMD_ANALYZE_ON : CMD_ANALYZE_OFF;
this.streamCmdReq(this.streamCmdParms);
```

The `streamCmdTimer` then fires `streamCmdQuery()`, which sets `this.streamCmdParms.command = CMD_QUERY` on that same object. If a request was already in flight when the button was clicked — common, since `ajax/stream.php` waits on zms for up to `ZM_WEB_AJAX_TIMEOUT/2` — the queued request goes out as `command=99` instead of `19`. zms gets a status query, never enters `FRAME_ANALYSIS`.

`streamCommand()` and `alarmCommand()` already copy with `Object.assign` before queueing. `show_analyse_frames()` was the only caller passing the shared object.

### Fix

Copy the params inside `streamCmdReq()`, so all callers are covered rather than just the one.

### Testing

Manual, on a live zms MJPEG stream with `Analysing = Always`. Before the fix, clicking the button changed only the button colour. After, the analysis frames arrive, confirmed from the monitor's shared memory:

```
last_analysis_viewed   0s ago         zms is in FRAME_ANALYSIS
analysis_image_count   999 -> 1059    zmc publishing analysis images
last_analysis_index    2              == (count-1) % ImageBufferCount
```

`last_analysis_viewed_time` is written only from `zm_monitorstream.cpp:678`, which runs only when `frame_type == FRAME_ANALYSIS`, so this confirms the command landed.

`npx eslint web/js/MonitorStream.js` is clean. No C++ changes, no rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
