### PR TITLE
fix: unlink the zms command socket on exit

### DIFF
--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -413,9 +413,22 @@ void StreamBase::closeComms() {
       close(sd);
       sd = -1;
     }
-    // Can't delete any files because another zms might have come along and opened them and is waiting on the lock.
+    // Remove our command socket while we still hold the lock. Another zms with
+    // the same connkey blocks on flock(LOCK_EX) in openComms() before it
+    // unlinks and binds, so it cannot have created its own socket yet and we
+    // cannot be deleting a file that belongs to it.
+    //
+    // This has to happen: web/ajax/stream.php uses file_exists() on this path
+    // to decide whether zms is listening. A socket left behind by an exited zms
+    // makes that check succeed, so the sendto() fails with ECONNREFUSED instead
+    // of waiting for the new process to bind, and the command is lost.
+    if ( loc_sock_path[0] && (unlink(loc_sock_path) < 0) && (errno != ENOENT) ) {
+      Warning("Failed to unlink '%s': %s", loc_sock_path, strerror(errno));
+    }
+    // Don't unlink sock_path_lock: another zms may already be waiting on it.
     if ( lock_fd >= 0 ) {
       close(lock_fd); //close it rather than unlock it in case it got deleted.
+      lock_fd = -1;
     }
   }
 } // end void StreamBase::closeComms

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -413,16 +413,29 @@ void StreamBase::closeComms() {
       close(sd);
       sd = -1;
     }
-    // Remove our command socket while we still hold the lock. Another zms with
-    // the same connkey blocks on flock(LOCK_EX) in openComms() before it
-    // unlinks and binds, so it cannot have created its own socket yet and we
-    // cannot be deleting a file that belongs to it.
+    // Remove our command socket, but only while we still hold the lock, and only
+    // if we actually got the lock.
     //
-    // This has to happen: web/ajax/stream.php uses file_exists() on this path
-    // to decide whether zms is listening. A socket left behind by an exited zms
-    // makes that check succeed, so the sendto() fails with ECONNREFUSED instead
-    // of waiting for the new process to bind, and the command is lost.
-    if ( loc_sock_path[0] && (unlink(loc_sock_path) < 0) && (errno != ENOENT) ) {
+    // Note this is zms-<connkey>s.sock, not the .lock file. A second zms sharing
+    // this connkey is blocked in flock(LOCK_EX) on the .lock file, and the first
+    // thing it does after winning that lock is unlink this very path itself
+    // ("Unlink before bind" in openComms()). It never reads our socket file, so
+    // removing it here only does early what our successor would do anyway.
+    //
+    // Ordering matters: if we unlinked after releasing the lock we could delete
+    // a socket the successor had already bound, leaving it unreachable.
+    //
+    // The lock_fd guard matters because openComms() carries on and binds even
+    // when it fails to take the lock, so without it a lockless zms could delete
+    // a socket belonging to the zms that does hold the lock. Leaking the file in
+    // that case is no worse than the behaviour before this check existed.
+    //
+    // This is worth doing because web/ajax/stream.php uses file_exists() on this
+    // path to decide whether zms is listening. A socket left behind by an exited
+    // zms makes that check succeed, so the sendto() fails with ECONNREFUSED
+    // instead of waiting for the new process to bind, and the command is lost.
+    if ( (lock_fd >= 0) && loc_sock_path[0]
+         && (unlink(loc_sock_path) < 0) && (errno != ENOENT) ) {
       Warning("Failed to unlink '%s': %s", loc_sock_path, strerror(errno));
     }
     // Don't unlink sock_path_lock: another zms may already be waiting on it.


### PR DESCRIPTION
Split out of the investigation in #5029. Independent of #5033 and of the `mode=single` question in #5029.

`closeComms()` left `$PATH_SOCKS/zms-NNNNNNs.sock` behind on exit. The only thing that ever removed it was the `unlink()` before `bind()` in a later zms that happened to draw the same connkey, so these files accumulate indefinitely.

That matters because `web/ajax/stream.php` uses `file_exists()` on exactly that path to decide whether zms is listening, and waits for it to appear before giving up:

```php
while ( !file_exists($remSockFile) && $max_socket_tries-- ) {
  usleep(1000);
}
```

A file left by an exited zms defeats that wait: the check passes immediately, the subsequent `socket_sendto()` gets ECONNREFUSED, and the command is reported as failed even though a new zms was about to bind. `genConnKey()` draws from six digits, and a page cycling monitors every five seconds burns ~720 connkeys an hour, so a reuse is likely well within an hour of viewing.

This is the mechanism behind the "Socket ... does not exist" / "Timed out waiting for msg" errors in #5029, which in turn trigger the connkey regeneration that orphans the running zms.

**Why unlinking is safe here.** The existing comment says we can't delete the files because another zms may have opened them and be waiting on the lock. That holds for the `.lock` file, which this PR still leaves alone. It doesn't hold for the command socket: a second zms with the same connkey blocks on `flock(LOCK_EX)` in `openComms()` *before* it unlinks and binds, so while we still hold the lock it cannot yet have created its own socket, and we cannot be deleting a file that belongs to it.

**Limitation:** best effort. A zms killed by a signal still leaves the socket behind. In that case the process is usually still running, so the file being present isn't wrong.

Also resets `lock_fd` to -1 after closing it.

**Testing:** builds clean (`cmake --build . --target zms`, Debug). Not verified against a live install — the useful check is watching `$PATH_SOCKS` stop accumulating `*s.sock` files over a long montage session.
