### PR TITLE
fix: initialise StreamBase::lock_fd to -1

### DIFF
--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -201,7 +201,7 @@ class StreamBase {
     send_objdetect(false),
     connkey(0),
     sd(-1),
-    lock_fd(0),
+    lock_fd(-1),
     paused(false),
     stopped(false),
     step(0),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_SOURCES
   zm_onvif_renewal.cpp
   zm_onvif_wsse.cpp
   zm_pixformat.cpp
+  zm_stream.cpp
   zm_swscale_range.cpp
   zm_poly.cpp
   zm_time.cpp

--- a/tests/zm_stream.cpp
+++ b/tests/zm_stream.cpp
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_stream.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace {
+
+// Minimal concrete StreamBase so the base constructor and destructor can be
+// exercised without a monitor, a database or shared memory.
+class TestStream : public StreamBase {
+ public:
+  void runStream() override {}
+
+ protected:
+  void processCommand(const CmdMsg *) override {}
+};
+
+bool fd_is_open(int fd) {
+  return fcntl(fd, F_GETFD) != -1;
+}
+
+// Destruct a TestStream with the given connkey and report whether fd 0
+// survived. fd 0 is restored either way, so a failure here can't cascade into
+// the rest of the suite.
+bool stdin_survives_destruction(int connkey) {
+  REQUIRE(fd_is_open(STDIN_FILENO));
+  int saved = dup(STDIN_FILENO);
+  REQUIRE(saved != -1);
+
+  {
+    TestStream stream;
+    if (connkey) stream.setStreamQueue(connkey);
+  }
+
+  bool survived = fd_is_open(STDIN_FILENO);
+  if (!survived) REQUIRE(dup2(saved, STDIN_FILENO) != -1);
+  close(saved);
+  return survived;
+}
+
+}  // namespace
+
+TEST_CASE("StreamBase comms teardown") {
+  SECTION("destructing without openComms() leaves stdin alone") {
+    // Regression: lock_fd was initialised to 0 rather than -1, so closeComms()
+    // -- reached from ~StreamBase() -- saw `lock_fd >= 0` and called close(0),
+    // closing stdin. It only needed connkey > 0 and a runStream() that returned
+    // before openComms(). MonitorStream::runStream() does exactly that for
+    // STREAM_SINGLE and when the monitor fails to load, and mode=single URLs
+    // still carry a connkey.
+    REQUIRE(stdin_survives_destruction(123456));
+  }
+
+  SECTION("destructing with no connkey leaves stdin alone") {
+    // closeComms() is a no-op without a connkey, so this held even before the
+    // fix. Here to pin the guard down.
+    REQUIRE(stdin_survives_destruction(0));
+  }
+}


### PR DESCRIPTION
Split out of the investigation in #5029. Independent of #5033 and #5034.

`StreamBase::lock_fd` was initialised to `0`, but every other use in the class treats a negative value as "no lock held" — `openComms()` sets it to `-1` when `open()` or `flock()` fails, and `closeComms()` guards on `lock_fd >= 0` before closing.

The constructor's `0` passes that guard, so a `StreamBase` destructed without `openComms()` having succeeded calls `close(0)` and closes stdin.

Reaching it takes `connkey > 0` plus a `runStream()` that returns before `openComms()`, and `MonitorStream::runStream()` has two such returns: the `STREAM_SINGLE` branch and the `!monitor` branch. `mode=single` URLs still carry a connkey, so both are reachable in normal operation.

**Severity, honestly:** low today. zms exits shortly afterwards and does little in between. But it is closing a descriptor the class doesn't own, and once fd 0 is free the next `open()` in the process silently lands on it — the kind of thing that turns into a confusing bug later rather than now.

Adds a regression test with a minimal concrete `StreamBase` so the base constructor and destructor can run without a monitor, database, or shared memory. It saves and restores fd 0, so if it ever fails it reports one section rather than cascading into unrelated tests in the shared binary.

**Testing:** verified the test fails with `lock_fd(0)` restored and passes with the fix. Full suite: 117 test cases, 1788 assertions, all passing (Debug, `BUILD_TEST_SUITE=ON`). Note `zm_font` needs to run with `tests/` as cwd — it uses relative `data/fonts/` paths — which is a pre-existing quirk, not related to this change.
