### PR TITLE
chore: only upload package artifacts on tag builds

### DIFF
--- a/.github/workflows/build-deb-packages-aarch64.yml
+++ b/.github/workflows/build-deb-packages-aarch64.yml
@@ -132,6 +132,9 @@ jobs:
           echo "artifact_name=binary-${sanitized_distro_name}" >> $GITHUB_ENV
 
       - name: Upload .deb artifacts
+        # Only the tag-only `release` job consumes these. On branch pushes the
+        # packages go straight to ZMREPO below, so uploading is pure storage cost.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/deb

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -128,6 +128,9 @@ jobs:
           echo "artifact_name=binary-${sanitized_distro_name}" >> $GITHUB_ENV
 
       - name: Upload .deb artifacts
+        # Only the tag-only `release` job consumes these. On branch pushes the
+        # packages go straight to ZMREPO below, so uploading is pure storage cost.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/deb

--- a/.github/workflows/build-rpm-packages-aarch64.yml
+++ b/.github/workflows/build-rpm-packages-aarch64.yml
@@ -217,6 +217,9 @@ jobs:
           echo "artifact_name=rpm-aarch64-${sanitized_distro_name}" >> $GITHUB_ENV
 
       - name: Upload RPM artifacts
+        # Only the tag-only `release` job consumes these. On branch pushes the
+        # packages go straight to ZMREPO below, so uploading is pure storage cost.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/rpm

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -215,6 +215,9 @@ jobs:
           echo "artifact_name=rpm-${sanitized_distro_name}" >> $GITHUB_ENV
 
       - name: Upload RPM artifacts
+        # Only the tag-only `release` job consumes these. On branch pushes the
+        # packages go straight to ZMREPO below, so uploading is pure storage cost.
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           path: artifacts/rpm


### PR DESCRIPTION
Follow-on to the Actions storage cleanup. The org hit 90% of its storage quota, and the largest live contributor turned out to be this repo's package builds.

## The redundancy

All four package workflows have the same shape:

- `build-*` job: build → `upload-artifact` (`retention-days: 1`) → **rsync to ZMREPO**
- `release` job: `needs: build-*`, `if: startsWith(github.ref, 'refs/tags/')` → `download-artifact` → create release

The `release` job is the only consumer of those artifacts, and it only runs on tags. On branch pushes to `master` / `release-1.38` nothing ever reads them — the packages are already published to ZMREPO by the step immediately after the upload.

So every push to master parked ~1.3 GB against the quota for the full one-day retention. Three pushes on 2026-08-05 held **3.93 GB live at once** (69 artifacts). Retention was already at the 1-day floor, so the volume was the only remaining lever.

## Change

Gate each `upload-artifact` step on the same tag condition the `release` job already uses, so artifacts exist exactly when something consumes them:

```yaml
- name: Upload .deb artifacts
  if: startsWith(github.ref, 'refs/tags/')
```

Branch pushes still publish to ZMREPO unchanged. Tag builds are unaffected — upload and download are now guarded by identical conditions, verified across all four files.

Side benefit: skipping the upload saves transferring ~1.3 GB per push, which is real time on the self-hosted aarch64 runners.

## Trade-off

Per-commit packages are no longer downloadable from the Actions run page on branch pushes — ZMREPO becomes the only channel for those, which is already where they're consumed from. And if an rsync to ZMREPO fails there's no longer an artifact fallback copy; that build would need a re-run.

## Verification

All four workflows parse as valid YAML, and each was checked programmatically to confirm the upload guard matches the consuming job's guard:

```
build-deb-packages.yml         | upload if: startsWith(github.ref, 'refs/tags/')
                               | download in job release | job if: ... && startsWith(github.ref, 'refs/tags/')
build-deb-packages-aarch64.yml | (same)
build-rpm-packages.yml         | (same)
build-rpm-packages-aarch64.yml | (same)
```

Not exercised against a real tag build — worth watching the next tag through the `release` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179XFS73S5t4PM4L8zomZHX