### PR TITLE
feat: add ZM_WEB_LOGIN_MESSAGE to show a notice on the login page

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -3046,6 +3046,26 @@ our @options = (
     category    => 'web',
   },
   {
+    name        => 'ZM_WEB_LOGIN_MESSAGE',
+    default     => '',
+    description => 'Message to display above the login form.',
+    help        => q`
+      Text shown on the login page, between the title and the username
+      and password fields. Useful for a site notice, an acceptable use
+      or legal warning, or a note identifying which installation this
+      is when you run more than one.
+
+      Leave empty to show nothing, which is the default.
+
+      The text is displayed exactly as entered: HTML is escaped rather
+      than interpreted, because the login page is served before anyone
+      has authenticated. Line breaks are preserved, so a multi-line
+      message renders as multiple lines.
+      `,
+    type        => $types{text},
+    category    => 'web',
+  },
+  {
     name        => 'ZM_WEB_SHOW_NAV_BUTTONS',
     default     => 'yes',
     description => 'Show Back and Refresh buttons at the top of views.',

--- a/tests/php/test_login_message.php
+++ b/tests/php/test_login_message.php
@@ -1,0 +1,107 @@
+<?php
+// Tests for the ZM_WEB_LOGIN_MESSAGE notice on the login view.
+//
+// The login page is served before anyone has authenticated, so the message is
+// escaped rather than interpreted. Escaping has to happen BEFORE nl2br, so the
+// only tags that reach the browser are the <br /> we add ourselves. Reversing
+// that order would turn the setting into stored XSS on an unauthenticated page.
+//
+// Run as: php tests/php/test_login_message.php
+
+$failures = 0;
+$passes = 0;
+
+function check($name, $got, $want) {
+  global $failures, $passes;
+  if ($got === $want) {
+    $passes++;
+    echo "  ok $name\n";
+  } else {
+    $failures++;
+    echo "  FAIL $name\n";
+    echo "    got:  " . var_export($got, true) . "\n";
+    echo "    want: " . var_export($want, true) . "\n";
+  }
+}
+
+// Same as web/includes/functions.php.
+function validHtmlStr($input) {
+  if (is_null($input)) return '';
+  return htmlspecialchars($input, ENT_QUOTES);
+}
+
+// The rendering decision and expression used by the login view. Kept in step
+// with web/skins/classic/views/login.php.
+function renderLoginMessage($message) {
+  if (trim($message) === '') return null;
+  return '<div id="loginMessage">'.nl2br(validHtmlStr(trim($message))).'</div>';
+}
+
+echo "when the message is shown\n";
+check('empty message renders nothing', renderLoginMessage(''), null);
+check('whitespace-only message renders nothing', renderLoginMessage("  \n\t "), null);
+check('a message renders a block',
+  renderLoginMessage('Authorized users only.'),
+  '<div id="loginMessage">Authorized users only.</div>');
+check('surrounding whitespace is trimmed',
+  renderLoginMessage("  Authorized users only.  "),
+  '<div id="loginMessage">Authorized users only.</div>');
+
+echo "\nmulti-line messages\n";
+check('newlines become <br />',
+  renderLoginMessage("Line one\nLine two"),
+  '<div id="loginMessage">Line one<br />'."\n".'Line two</div>');
+
+echo "\nhtml is escaped, not interpreted\n";
+// If escaping and nl2br were the other way round, or escaping were dropped,
+// these would emit live markup on a page shown to unauthenticated visitors.
+check('script tag is inert',
+  renderLoginMessage('<script>alert(1)</script>'),
+  '<div id="loginMessage">&lt;script&gt;alert(1)&lt;/script&gt;</div>');
+check('img onerror is inert',
+  renderLoginMessage('<img src=x onerror=alert(1)>'),
+  '<div id="loginMessage">&lt;img src=x onerror=alert(1)&gt;</div>');
+check('formatting tags are shown literally',
+  renderLoginMessage('Site: <b>HQ</b>'),
+  '<div id="loginMessage">Site: &lt;b&gt;HQ&lt;/b&gt;</div>');
+check('quotes and ampersands are escaped',
+  renderLoginMessage('He said "hi" & \'bye\''),
+  '<div id="loginMessage">He said &quot;hi&quot; &amp; &#039;bye&#039;</div>');
+
+// The only tags in the output must be the <br /> nl2br adds.
+$rendered = renderLoginMessage("<i>a</i>\n<u>b</u>");
+preg_match_all('/<([a-z\/][^>]*)>/i', $rendered, $m);
+$tags = array_values(array_filter($m[1], function($t) {
+  return stripos($t, 'div') === false;
+}));
+check('no tags survive except the br we add', $tags, array('br /'));
+
+echo "\nconfig option definition\n";
+$cfg = file_get_contents(__DIR__.'/../../scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in');
+check('ZM_WEB_LOGIN_MESSAGE is defined',
+  (bool)preg_match("/name\s*=>\s*'ZM_WEB_LOGIN_MESSAGE'/", $cfg), true);
+// An empty default keeps existing installs looking exactly as they do now.
+check("defaults to empty so nothing is shown until configured",
+  (bool)preg_match("/name\s*=>\s*'ZM_WEB_LOGIN_MESSAGE',\s*\n\s*default\s*=>\s*'',/", $cfg), true);
+// text rather than string, so the DB column holds a multi-line notice.
+check('uses the text type for multi-line content',
+  (bool)preg_match("/name\s*=>\s*'ZM_WEB_LOGIN_MESSAGE'.*?type\s*=>\s*\\\$types\{text\}/s", $cfg), true);
+check('is in the web category',
+  (bool)preg_match("/name\s*=>\s*'ZM_WEB_LOGIN_MESSAGE'.*?category\s*=>\s*'web'/s", $cfg), true);
+
+echo "\nlogin view wiring\n";
+$view = file_get_contents(__DIR__.'/../../web/skins/classic/views/login.php');
+// Guarded with defined() so code newer than the database still renders.
+check('guarded by defined() for installs that have not run zmupdate yet',
+  (bool)preg_match('/defined\(\x27ZM_WEB_LOGIN_MESSAGE\x27\)/', $view), true);
+check('escaped before nl2br',
+  (bool)preg_match('/nl2br\(validHtmlStr\(/', $view), true);
+// Placement: after the heading, before the username field.
+$posMsg = strpos($view, 'id="loginMessage"');
+$posUser = strpos($view, 'id="inputUsername"');
+$posH1 = strpos($view, '<h1>');
+check('rendered after the title and before the username field',
+  ($posH1 < $posMsg && $posMsg < $posUser), true);
+
+echo "\n$passes passed, $failures failed\n";
+exit($failures ? 1 : 0);

--- a/web/skins/classic/css/base/views/login.css
+++ b/web/skins/classic/css/base/views/login.css
@@ -32,6 +32,18 @@ form .alarm {
 	border-bottom: 1px solid #e7e7e7;
 }
 
+#loginMessage {
+	margin-bottom: 15px;
+	padding: 10px 12px;
+	border-left: 3px solid #ccc;
+	background-color: #f8f8f8;
+	color: #555;
+	font-size: 90%;
+	/* Admin-supplied text of unknown length, so keep long words from
+	   widening the fixed-width form. */
+	overflow-wrap: break-word;
+}
+
 #loginform {
 	padding: 40px 60px;
 }

--- a/web/skins/classic/css/classic/views/login.css
+++ b/web/skins/classic/css/classic/views/login.css
@@ -32,6 +32,18 @@ form .alarm {
 	border-bottom: 1px solid #e7e7e7;
 }
 
+#loginMessage {
+	margin-bottom: 15px;
+	padding: 10px 12px;
+	border-left: 3px solid #ccc;
+	background-color: #f8f8f8;
+	color: #555;
+	font-size: 90%;
+	/* Admin-supplied text of unknown length, so keep long words from
+	   widening the fixed-width form. */
+	overflow-wrap: break-word;
+}
+
 #loginform {
 	padding: 40px 60px;
 }

--- a/web/skins/classic/css/dark/views/login.css
+++ b/web/skins/classic/css/dark/views/login.css
@@ -30,3 +30,9 @@ border-bottom: 1px solid #303030;
 .form-control::placeholder {
   color: #dddddd;
 }
+
+#loginMessage {
+  border-left-color: #444444;
+  background-color: #2a2a2a;
+  color: #bbbbbb;
+}

--- a/web/skins/classic/views/login.php
+++ b/web/skins/classic/views/login.php
@@ -27,6 +27,17 @@ if ( defined('ZM_OPT_USE_AUTH') and ZM_OPT_USE_AUTH ) {
       <div id="loginform">
 
         <h1><i class="material-icons md-36">account_circle</i> <?php echo validHtmlStr(ZM_WEB_TITLE) . ' ' . translate('Login') ?></h1>
+<?php
+// Optional site notice. Escaped rather than interpreted: this page is served
+// before anyone has authenticated, so it is not a place to emit raw markup.
+// nl2br runs after escaping so that the only tags in the output are the ones
+// we added, and a multi-line message still renders as multiple lines.
+if (defined('ZM_WEB_LOGIN_MESSAGE') and trim(ZM_WEB_LOGIN_MESSAGE) !== '') {
+?>
+        <div id="loginMessage"><?php echo nl2br(validHtmlStr(trim(ZM_WEB_LOGIN_MESSAGE))) ?></div>
+<?php
+}
+?>
         <label for="inputUsername" class="sr-only"><?php echo translate('Username') ?></label>
         <input type="text" id="inputUsername" name="username" class="form-control" autocapitalize="none" placeholder="Username" required autofocus autocomplete="username"/>
 


### PR DESCRIPTION
Adds a `web` config option, `ZM_WEB_LOGIN_MESSAGE`, whose contents are shown on the login page between the title and the username/password fields.

Useful for a site notice, an acceptable-use or legal warning, or a note identifying which installation you're looking at when you run more than one.

Defaults to empty, and nothing is emitted when it's empty or whitespace-only, so existing installs look exactly as they do today.

## The text is escaped, not interpreted

The login page is served before anyone has authenticated, so it isn't somewhere to start emitting admin-supplied markup. No other config value in the skin is output unescaped either — `ZM_WEB_TITLE` on the line above uses `validHtmlStr`, and this follows it.

Escaping runs *before* `nl2br`, so the only tags reaching the browser are the line breaks we add:

```php
<div id="loginMessage"><?php echo nl2br(validHtmlStr(trim(ZM_WEB_LOGIN_MESSAGE))) ?></div>
```

Reversing that order would turn the setting into stored XSS on an unauthenticated page, so it's the thing the tests pin hardest.

Happy to switch to raw HTML if you'd rather — it's a one-line change — but it seemed worth defaulting to the safe reading.

## No schema change needed

- `Config.Value` is already `text`, so a multi-line notice fits.
- The `text` type makes the Options UI render a 5-row textarea (`options.php:328`), so multi-line entry works.
- `web/includes/actions/options.php:91` already normalises CRLF to LF on save, so `nl2br` sees consistent newlines.
- The type's Perl pattern `^(.+)$` would reject newlines, but it is only *stored* in the `Pattern` column and never enforced — nothing in PHP reads it.

Guarded with `defined()` to match the surrounding code, so the view still renders on an install whose database predates the option.

## Styling

Added to `base`, `classic` and `dark`. Text contrast measured at **7.02:1** light and **7.48:1** dark, both comfortably above WCAG AA for body text. The accent border carries near-identical weight in both themes (1.51 vs 1.47), so they read consistently. Long unbroken tokens wrap via `overflow-wrap` rather than widening the fixed-width form.

## Testing

`tests/php/test_login_message.php` — 17 cases covering when it renders, trimming, multi-line handling, escaping of `<script>` / `<img onerror>` / quotes, that no tags survive except the `<br />`, plus the config definition and the view wiring.

Mutation-tested: swapping the escape order fails 2 cases, dropping escaping entirely fails 5, removing the `defined()` guard fails 1.

Also rendered in Chrome across light and dark, with and without a message, and with long wrapping text.

**Not verified against a running install** — I have no ZM instance here, so the real check is setting the option in Options → Web and loading the login page.

Note `tests/php/event_sort_test.php` fails in my tree with or without this change; it needs a generated `web/includes/config.php`. Pre-existing, unrelated.
