### PR TITLE
test: bind comms tests to ephemeral ports and unique socket paths

### DIFF
--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -19,6 +19,31 @@
 
 #include "zm_comms.h"
 #include <array>
+#include <cstdlib>
+#include <unistd.h>
+
+namespace {
+
+int getBoundPort(int sd) {
+  sockaddr_in addr = {};
+  socklen_t addr_len = sizeof(addr);
+  REQUIRE(::getsockname(sd, reinterpret_cast<sockaddr *>(&addr), &addr_len) == 0);
+
+  const int port = ntohs(addr.sin_port);
+  REQUIRE(port > 0);
+  return port;
+}
+
+std::string makeUnixSocketPath() {
+  char path_template[] = "/tmp/zm.unittest.XXXXXX";
+  const int fd = ::mkstemp(path_template);
+  REQUIRE(fd >= 0);
+  REQUIRE(::close(fd) == 0);
+  REQUIRE(::unlink(path_template) == 0);
+  return std::string(path_template) + ".sock";
+}
+
+}  // namespace
 
 TEST_CASE("ZM::Pipe basics") {
   zm::Pipe pipe;
@@ -132,7 +157,7 @@ TEST_CASE("ZM::UdpInetSocket basics") {
   REQUIRE(socket.isDisconnected() == false);
 
   SECTION("bind with host and port") {
-    REQUIRE(socket.bind(nullptr, "1234") == true);
+    REQUIRE(socket.bind(nullptr, "0") == true);
     REQUIRE(socket.isOpen() == true);
     REQUIRE(socket.isDisconnected() == true);
     REQUIRE(socket.isClosed() == false);
@@ -148,15 +173,15 @@ TEST_CASE("ZM::UdpInetSocket basics") {
   }
 
   SECTION("bind with port") {
-    REQUIRE(socket.bind("1234") == true);
+    REQUIRE(socket.bind("0") == true);
   }
 
   SECTION("bind with host and port number") {
-    REQUIRE(socket.bind(nullptr, 1234) == true);
+    REQUIRE(socket.bind(nullptr, 0) == true);
   }
 
   SECTION("bind with port number") {
-    REQUIRE(socket.bind(1234) == true);
+    REQUIRE(socket.bind(0) == true);
   }
 }
 
@@ -173,10 +198,12 @@ TEST_CASE("ZM::UdpInetSocket send/recv") {
   }
 
   SECTION("send/recv") {
-    REQUIRE(srv_socket.bind("127.0.0.1", "1234") == true);
+    REQUIRE(srv_socket.bind("127.0.0.1", "0") == true);
     REQUIRE(srv_socket.isOpen() == true);
+    const int port = getBoundPort(srv_socket.getReadDesc());
+    const std::string port_str = std::to_string(port);
 
-    REQUIRE(client_socket.connect("127.0.0.1", "1234") == true);
+    REQUIRE(client_socket.connect("127.0.0.1", port_str.c_str()) == true);
     REQUIRE(client_socket.isConnected() == true);
 
     REQUIRE(client_socket.send(msg.data(), msg.size()) == msg.size());
@@ -187,8 +214,7 @@ TEST_CASE("ZM::UdpInetSocket send/recv") {
 }
 
 TEST_CASE("ZM::UdpUnixSocket basics") {
-  std::string sock_path = "/tmp/zm.unittest.sock";
-  unlink(sock_path.c_str()); // make sure the socket file does not exist
+  const std::string sock_path = makeUnixSocketPath();
 
   zm::UdpUnixSocket socket;
   REQUIRE(socket.isClosed() == true);
@@ -218,8 +244,7 @@ TEST_CASE("ZM::UdpUnixSocket basics") {
 }
 
 TEST_CASE("ZM::UdpUnixSocket send/recv") {
-  std::string sock_path = "/tmp/zm.unittest.sock";
-  unlink(sock_path.c_str()); // make sure the socket file does not exist
+  const std::string sock_path = makeUnixSocketPath();
 
   zm::UdpUnixSocket srv_socket;
   zm::UdpUnixSocket client_socket;
@@ -286,7 +311,7 @@ TEST_CASE("ZM::TcpInetServer basics", "[notCI]") {
   REQUIRE(server.isConnected() == false);
   REQUIRE(server.isDisconnected() == false);
 
-  REQUIRE(server.bind(1234) == true);
+  REQUIRE(server.bind(0) == true);
   REQUIRE(server.isOpen() == true);
   REQUIRE(server.isClosed() == false);
   REQUIRE(server.isConnected() == false);
@@ -318,11 +343,12 @@ TEST_CASE("ZM::TcpInetClient/Server send/recv", "[notCI]") {
   }
 
   SECTION("send/recv") {
-    REQUIRE(server.bind(1234) == true);
+    REQUIRE(server.bind(0) == true);
     REQUIRE(server.isOpen() == true);
+    const int port = getBoundPort(server.getReadDesc());
     REQUIRE(server.listen() == true);
 
-    REQUIRE(client.connect("127.0.0.1", 1234) == true);
+    REQUIRE(client.connect("127.0.0.1", port) == true);
     REQUIRE(client.isConnected() == true);
 
     REQUIRE(server.accept() == true);

--- a/tests/zm_comms.cpp
+++ b/tests/zm_comms.cpp
@@ -20,27 +20,62 @@
 #include "zm_comms.h"
 #include <array>
 #include <cstdlib>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 namespace {
 
+// InetSocket::bind() resolves with AF_UNSPEC, so the socket that actually got
+// bound may be AF_INET6. sockaddr_storage is the only buffer guaranteed to be
+// big enough for either, and the port sits at a different offset in each.
 int getBoundPort(int sd) {
-  sockaddr_in addr = {};
+  sockaddr_storage addr = {};
   socklen_t addr_len = sizeof(addr);
   REQUIRE(::getsockname(sd, reinterpret_cast<sockaddr *>(&addr), &addr_len) == 0);
 
-  const int port = ntohs(addr.sin_port);
+  int port = 0;
+  if (addr.ss_family == AF_INET) {
+    port = ntohs(reinterpret_cast<const sockaddr_in *>(&addr)->sin_port);
+  } else if (addr.ss_family == AF_INET6) {
+    port = ntohs(reinterpret_cast<const sockaddr_in6 *>(&addr)->sin6_port);
+  } else {
+    FAIL("unexpected address family " << addr.ss_family);
+  }
+
   REQUIRE(port > 0);
   return port;
 }
 
+// mkstemp is what reserves the name, so the template has to be the socket path
+// itself. Reserving zm.unittest.XXXXXX and then appending .sock would hand back
+// a name nothing had claimed, which two concurrent runs could still collide on.
 std::string makeUnixSocketPath() {
-  char path_template[] = "/tmp/zm.unittest.XXXXXX";
-  const int fd = ::mkstemp(path_template);
+  char path_template[] = "/tmp/zm.unittest.XXXXXX.sock";
+  const int fd = ::mkstemps(path_template, 5);
   REQUIRE(fd >= 0);
   REQUIRE(::close(fd) == 0);
+  // bind() needs the path free, and this process holds the only claim on it.
   REQUIRE(::unlink(path_template) == 0);
-  return std::string(path_template) + ".sock";
+  return std::string(path_template);
+}
+
+// A port nothing is listening on. Binding then closing leaves the number
+// unused, which is far safer than hardcoding one and hoping the host agrees.
+int getUnusedPort() {
+  const int sd = ::socket(AF_INET, SOCK_STREAM, 0);
+  REQUIRE(sd >= 0);
+
+  sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  REQUIRE(::bind(sd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0);
+
+  const int port = getBoundPort(sd);
+  REQUIRE(::close(sd) == 0);
+  return port;
 }
 
 }  // namespace
@@ -297,7 +332,7 @@ TEST_CASE("ZM::TcpInetClient basics") {
   REQUIRE(client.isConnected() == false);
   REQUIRE(client.isDisconnected() == false);
 
-  REQUIRE(client.connect("127.0.0.1", 1234) == false);
+  REQUIRE(client.connect("127.0.0.1", getUnusedPort()) == false);
   REQUIRE(client.isClosed() == true);
   REQUIRE(client.isOpen() == false);
   REQUIRE(client.isConnected() == false);


### PR DESCRIPTION
Split out of #4864 at @SteveGilvarry's request, since these test changes are unrelated to that PR's feature and should stand on their own.

The comms tests bind to a hardcoded port `1234` and a fixed unix socket path `/tmp/zm.unittest.sock`. Both make the suite fail if anything else on the machine holds that port, and they make two concurrent test runs collide with each other.

- Inet tests now bind port `0` and read the actual assigned port back via `getsockname()` (`getBoundPort`), so the client connects to whatever the kernel handed out.
- Unix socket tests get a unique path per test via `mkstemp` (`makeUnixSocketPath`) instead of sharing one file.

No production code is touched.

**Testing**: full suite passes locally, 121 test cases and 1849 assertions. The comms tests specifically pass 4x concurrently (`ZM::Udp*`, `ZM::Tcp*`, 129 assertions each run), which fails on master because all four runs try to bind `1234`.

Note: `tests/zm_onvif_wsse.cpp` on master cannot compile without gsoap-generated `soapH.h`, so I excluded it locally to run the suite. That is a pre-existing environment gap, unrelated to this change.
