### PR TITLE
fix: backport findVideoEventFile to release-1.38

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2569,4 +2569,29 @@ function to_string($thing) {
   if (is_array($thing)) return implode(', ', $thing);
   return strval($thing);
 }
+
+function findVideoEventFile ($Event, $ext="*") {
+  $dir = $Event->Path();
+  $eventDefaultVideo = to_string($Event->DefaultVideo());
+  $path = '';
+  if ($eventDefaultVideo !== '' &&
+    !str_ends_with($eventDefaultVideo, '.m3u8') &&
+    ($ext === "*" || str_ends_with(strtolower($eventDefaultVideo), '.' . $ext))) {
+      $path = $dir.'/'.$eventDefaultVideo;
+  }
+  if (!is_file($path)) $path = ''; # So we don't return a reference to a non-existent file.
+
+  if ($path === '') {
+    # By default, we search for files with any extension, such as mp4, mkv, or webm.
+    # Look for the final renamed first, then incomplete.
+    # Incomplete files may exist as either incomplete.<container> or incomplete.<codec>.<container>.
+    $candidates = glob($dir.'/'.$Event->Id().'-video.*.'.$ext);
+    if (!$candidates) $candidates = glob($dir.'/incomplete.'.$ext);
+    if (!$candidates) $candidates = glob($dir.'/incomplete.*.'.$ext);
+    if ($candidates) {
+      $path = $candidates[0];
+    }
+  }
+  return $path;
+}
 ?>

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2576,7 +2576,7 @@ function findVideoEventFile ($Event, $ext="*") {
   $path = '';
   if ($eventDefaultVideo !== '' &&
     !str_ends_with($eventDefaultVideo, '.m3u8') &&
-    ($ext === "*" || str_ends_with(strtolower($eventDefaultVideo), '.' . $ext))) {
+    ($ext === "*" || str_ends_with(strtolower($eventDefaultVideo), '.' . strtolower($ext)))) {
       $path = $dir.'/'.$eventDefaultVideo;
   }
   if (!is_file($path)) $path = ''; # So we don't return a reference to a non-existent file.


### PR DESCRIPTION
Fixes #4898. Backport to `release-1.38`, so this targets that branch rather than master.

@SteveGilvarry diagnosed this already: `download_functions.php` calls `findVideoEventFile()` on both branches, but the definition only ever landed on master. On `release-1.38` the call site sits at `download_functions.php:118` with nothing defining it, so exporting an event as video, zip or tar fatals with `Call to undefined function findVideoEventFile()` for everyone on the 1.38 apt packages. He asked for a cherry-pick of `a7c8fbe1a`; this is that, opened as a PR so it is ready to merge.

**What I brought across**

Rather than `a7c8fbe1a` alone, this backports the *current* master version of the function, which is `a7c8fbe1a` plus the review fixes from `905399824`. It is byte-identical to what is on master today. The later version is strictly better and still satisfies the one 1-arg call site on this branch, because `$ext` defaults to `"*"`:

- `is_file()` check so it never returns a path to a file that is not there, which is the failure the original version would still have hit on the export path.
- Handles any container (mp4, mkv, webm) instead of hardcoding mp4.
- Matches `incomplete.<container>` as well as `incomplete.<codec>.<container>`.
- `to_string()` on `DefaultVideo()` so a null does not trip `str_ends_with()`.

**Dependencies checked on this branch**

- `to_string()` is already defined in `functions.php` on `release-1.38`.
- `str_ends_with()` is already used twice in the same file, so the PHP 8 baseline is fine.
- Insertion point is the same as on master, directly after `to_string()`.
- `findVideoEventFile` has exactly one call site on this branch, `download_functions.php:118`, which passes one argument.

**Verified**: the added function is byte-identical to the version running on master, the file parses with balanced braces and parens, and the function is defined exactly once.
