### PR TITLE
fix: repair CSV monitor import on release-1.38

### DIFF
--- a/web/skins/classic/views/js/add_monitors.js
+++ b/web/skins/classic/views/js/add_monitors.js
@@ -141,21 +141,33 @@ function addMonitor(btn) {
 }
 
 function import_csv() {
-  const form = $j('#contentForm');
-  var formData = new FormData( form );
-  console.log(formData);
+  // The file input and the CSRF input live in the modal's form, which has
+  // id="importModalForm" (its *name* is contentForm, but jQuery '#' matches on
+  // id, so '#contentForm' picked up the page's main form instead, which holds
+  // neither).
+  const form = $j('#importModalForm')[0];
+  const formData = new FormData(form);
 
-  $j.ajax({
-    url: thisUrl+"?request=add_monitors&action=import",
-    type: 'POST',
-    data: formData,
-    processData: false, // tell jQuery not to process the data
-    contentType: false, // tell jQuery not to set contentType
-    done: function(data) {
-      const json = JSON.parse(data);
-      parseStreams(json.Streams);
-    }
-  });
+  // Use fetch, not $j.ajax: csrf-magic.js overrides XMLHttpRequest.send and does
+  // `csrfMagicName + '=' + token + '&' + data`, which stringifies a FormData body
+  // to "[object FormData]" and drops the uploaded file, so the backend sees no
+  // file. fetch is not wrapped by csrf-magic. The __csrf_magic hidden input is
+  // part of the form, so FormData(form) still carries the token as a real
+  // multipart field.
+  fetch(thisUrl+'?request=add_monitors&action=import', {
+    method: 'POST',
+    body: formData,
+  })
+      .then((resp) => resp.json())
+      .then((data) => {
+        if (data.result == 'Error') {
+          alert(data.message);
+          return;
+        }
+        $j('#ImportMonitorsModal').modal('hide');
+        parseStreams(data.Streams ? data.Streams : []);
+      })
+      .catch(logAjaxFail);
 }
 
 function importMonitors() {


### PR DESCRIPTION
Fixes #4962. Targets `release-1.38`, since master already has this fixed and the reporter is on 1.38.3.

CSV import is broken on 1.38 in three separate ways, which is why the symptom is "nothing happens" rather than a single clean error.

**1. `FormData` gets a jQuery object (the reported crash)**

```js
const form = $j('#contentForm');
var formData = new FormData( form );
```

`FormData` needs an `HTMLFormElement`, so this throws `Argument 1 does not implement interface HTMLFormElement` and the function dies on its first statement.

**2. The selector points at the wrong form**

Adding `[0]` is not enough. The file input and the CSRF input both live in the modal's form, which is `<form id="importModalForm" name="contentForm">` in `ajax/modals/add_monitors_import.php`. jQuery `#` matches on id, not name, so `#contentForm` resolves to the page's main form in `views/add_monitors.php`, which contains neither. Uploading from that form would post an empty body.

**3. `done:` is not a jQuery ajax setting**

```js
$j.ajax({ ..., done: function(data) { ... } });
```

`done` is a promise method, not an `$.ajax` option, so jQuery ignores it. Even with 1 and 2 fixed, the response handler never runs and the table never updates.

**4. csrf-magic corrupts a FormData body sent through `$j.ajax`**

`csrf_startup()` in `functions.php` sets `rewrite-js` to `includes/csrf/csrf-magic.js`, and that file replaces `XMLHttpRequest.prototype.send` with one that does `csrfMagicName + '=' + token + '&' + data`. String-concatenating a `FormData` stringifies it to `"[object FormData]"`, so the upload is destroyed before it leaves the browser. This is the same reason master moved this call to `fetch`, which csrf-magic does not wrap. The `__csrf_magic` input is emitted into the modal form by `getCSRFinputHTML()`, so `FormData(form)` still carries the token as a real multipart field.

**The fix**

Mirrors master's version of `import_csv()`, adapted to this branch:

- `#importModalForm` for the form, matching master.
- `fetch` instead of `$j.ajax`, with the same explanatory comment master carries.
- `.then`/`.catch` with `logAjaxFail`, and the `data.result == 'Error'` check that the other ajax calls in this file already use.
- `parseStreams()` for the result, which is this branch's equivalent of master's `decorateStreams` plus `bootstrapTable('load')`.
- Hides the modal on success, so a successful import no longer looks like nothing happened.
- Keeps this branch's `?request=add_monitors&action=import` URL. `index.php` dispatches on `$request` alone, so it routes correctly as-is.
- Drops a leftover `console.log(formData)`.

**Verified**: `npx eslint .` passes clean across the repo with the CI's exact dependency set. The backend contract was checked against `ajax/add_monitors.php`, which returns `ajaxResponse(array('Streams'=>...))` and `ajaxError()`, matching the `{result, message, Streams}` shape the new handler reads. `parseStreams()` and `logAjaxFail()` both exist on this branch.

Note that the ESLint workflow only triggers on pull requests to master, so CI will not lint this branch.
