### PR TITLE
fix: make MonitorStream playback state shared with the command thread atomic

### DIFF
--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -497,10 +497,10 @@ void EventStream::processCommand(const CmdMsg *msg) {
     paused = false;
     replay_rate = (((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2])-VARPLAY_RATE_OFFSET;
     if (replay_rate > 50 * ZM_RATE_BASE) {
-      Warning("requested replay rate (%d) is too high. We only support up to 50x", replay_rate);
+      Warning("requested replay rate (%d) is too high. We only support up to 50x", replay_rate.load());
       replay_rate = 50 * ZM_RATE_BASE;
-    } else if (replay_rate < -50*ZM_RATE_BASE) {
-      Warning("requested replay rate (%d) is too low. We only support up to -50x", replay_rate);
+    } else if (replay_rate.load() < -50*ZM_RATE_BASE) {
+      Warning("requested replay rate (%d) is too low. We only support up to -50x", replay_rate.load());
       replay_rate = -50 * ZM_RATE_BASE;
     }
     break;
@@ -532,7 +532,7 @@ void EventStream::processCommand(const CmdMsg *msg) {
       replay_rate = 50 * ZM_RATE_BASE;
       break;
     default :
-      Debug(1,"Defaulting replay_rate to 2*ZM_RATE_BASE because it is %d", replay_rate);
+      Debug(1,"Defaulting replay_rate to 2*ZM_RATE_BASE because it is %d", replay_rate.load());
       replay_rate = 2 * ZM_RATE_BASE;
       break;
     }
@@ -587,10 +587,10 @@ void EventStream::processCommand(const CmdMsg *msg) {
   case CMD_ZOOMIN :
     x = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
     y = ((unsigned char)msg->msg_data[3]<<8)|(unsigned char)msg->msg_data[4];
-    Debug(1, "Got ZOOM IN command, to %d,%d", x, y);
+    Debug(1, "Got ZOOM IN command, to %d,%d", x.load(), y.load());
     zoom += 10;
     send_frame = true;
-    if (paused) {
+    if (paused.load()) {
       step = 1;
       send_twice = true;
     }
@@ -617,18 +617,18 @@ void EventStream::processCommand(const CmdMsg *msg) {
   case CMD_PAN :
     x = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
     y = ((unsigned char)msg->msg_data[3]<<8)|(unsigned char)msg->msg_data[4];
-    Debug(1, "Got PAN command, to %d,%d", x, y);
+    Debug(1, "Got PAN command, to %d,%d", x.load(), y.load());
     send_frame = true;
-    if (paused) {
+    if (paused.load()) {
       step = 1;
       send_twice = true;
     }
     break;
   case CMD_SCALE :
     scale = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
-    Debug(1, "Got SCALE command, to %d", scale);
+    Debug(1, "Got SCALE command, to %d", scale.load());
     send_frame = true;
-    if (paused) {
+    if (paused.load()) {
       step = 1;
       send_twice = true;
     }
@@ -739,7 +739,7 @@ void EventStream::processCommand(const CmdMsg *msg) {
     if (elapsed.count() > 0) {
       actual_fps = (actual_fps + (frame_count - last_frame_count) / elapsed.count())/2;
       Debug(1, "actual_fps %f = old + frame_count %d - last %d / elapsed %.2f from %.2f - %.2f scale %d", actual_fps, frame_count, last_frame_count,
-          elapsed.count(), FPSeconds(now.time_since_epoch()).count(), FPSeconds(last_fps_update.time_since_epoch()).count(), scale);
+          elapsed.count(), FPSeconds(now.time_since_epoch()).count(), FPSeconds(last_fps_update.time_since_epoch()).count(), scale.load());
       last_frame_count = frame_count;
       last_fps_update = now;
     }
@@ -1112,7 +1112,7 @@ void EventStream::runStream() {
         send_frame = true;
         //}
       } else if (step != 0) {
-        Debug(2, "Paused with step %d", step);
+        Debug(2, "Paused with step %d", step.load());
         // We are paused and are just stepping forward or backward one frame
         step = 0;
         send_frame = true;
@@ -1286,7 +1286,7 @@ void EventStream::runStream() {
           // This doesn't make sense unless we have hit the end of the event.
           time_to_event = event_data->frames[0].timestamp - curr_stream_time;
           Debug(1, "replay rate (%d) time_to_event (%f s) = frame timestamp (%f s) - curr_stream_time (%f s)",
-                replay_rate,
+                replay_rate.load(),
                 FPSeconds(time_to_event).count(),
                 FPSeconds(event_data->frames[0].timestamp.time_since_epoch()).count(),
                 FPSeconds(curr_stream_time.time_since_epoch()).count());
@@ -1294,7 +1294,7 @@ void EventStream::runStream() {
         } else if (replay_rate < 0) {
           time_to_event = curr_stream_time - event_data->frames[event_data->frames.size()-1].timestamp;
           Debug(1, "replay rate (%d), time_to_event(%f s) = curr_stream_time (%f s) - frame timestamp (%f s)",
-                replay_rate,
+                replay_rate.load(),
                 FPSeconds(time_to_event).count(),
                 FPSeconds(curr_stream_time.time_since_epoch()).count(),
                 FPSeconds(event_data->frames[event_data->frames.size() - 1].timestamp.time_since_epoch()).count());

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -158,7 +158,7 @@ void MonitorStream::processCommand(const CmdMsg *msg) {
 
     maxfps = (int_part + dec_part / 1000000.0);
 
-    Debug(1, "Got MAXFPS %f", maxfps);
+    Debug(1, "Got MAXFPS %f", maxfps.load());
     break;
   }
   case CMD_SLOWFWD :
@@ -208,25 +208,25 @@ void MonitorStream::processCommand(const CmdMsg *msg) {
     x = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
     y = ((unsigned char)msg->msg_data[3]<<8)|(unsigned char)msg->msg_data[4];
     zoom += 10;
-    Debug(1, "Got ZOOM IN command, to %d,%d zoom value %d%%", x, y, zoom);
+    Debug(1, "Got ZOOM IN command, to %d,%d zoom value %d%%", x.load(), y.load(), zoom.load());
     break;
   case CMD_ZOOMOUT :
     zoom -= 10;
-    if (zoom < 100) zoom = 100;
-    Debug(1, "Got ZOOM OUT command resulting zoom %d%%", zoom);
+    if (zoom.load() < 100) zoom = 100;
+    Debug(1, "Got ZOOM OUT command resulting zoom %d%%", zoom.load());
     break;
   case CMD_ZOOMSTOP :
     zoom = 100;
-    Debug(1, "Got ZOOM OUT FULL command resulting zoom %d%%", zoom);
+    Debug(1, "Got ZOOM OUT FULL command resulting zoom %d%%", zoom.load());
     break;
   case CMD_PAN :
     x = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
     y = ((unsigned char)msg->msg_data[3]<<8)|(unsigned char)msg->msg_data[4];
-    Debug(1, "Got PAN command, to %d,%d", x, y);
+    Debug(1, "Got PAN command, to %d,%d", x.load(), y.load());
     break;
   case CMD_SCALE :
     scale = ((unsigned char)msg->msg_data[1]<<8)|(unsigned char)msg->msg_data[2];
-    Debug(1, "Got SCALE command, to %d", scale);
+    Debug(1, "Got SCALE command, to %d", scale.load());
     break;
   case CMD_QUIT :
     Info("User initiated exit - CMD_QUIT");
@@ -391,7 +391,7 @@ bool MonitorStream::sendFrame(const std::string &filepath, SystemTimePoint times
       if (frame_send_time > Milliseconds(lround(Milliseconds::period::den / maxfps))) {
         Debug(1, "Frame send time %" PRIi64 " ms too slow, throttling maxfps to %.2f",
              static_cast<int64>(std::chrono::duration_cast<Milliseconds>(frame_send_time).count()),
-             maxfps);
+             maxfps.load());
       }
     }
 
@@ -489,7 +489,7 @@ bool MonitorStream::sendFrame(Image *image, SystemTimePoint timestamp) {
       Debug(1, "Frame send time %" PRIi64 " msec too slow (> %" PRIi64 ", %.3f",
             static_cast<int64>(std::chrono::duration_cast<Milliseconds>(frame_send_time).count()),
             static_cast<int64>(std::chrono::duration_cast<Milliseconds>(maxfps_milliseconds).count()),
-            maxfps);
+            maxfps.load());
     }
   }
   return true;
@@ -552,8 +552,8 @@ void MonitorStream::runStream() {
   const Seconds mem_report_interval = Seconds(30);
 
   temp_image_buffer_count = playback_buffer;
-  temp_read_index = temp_image_buffer_count;
-  temp_write_index = temp_image_buffer_count;
+  temp_read_index = temp_image_buffer_count.load();
+  temp_write_index = temp_image_buffer_count.load();
 
   std::string swap_path;
   bool buffered_playback = false;
@@ -628,8 +628,8 @@ void MonitorStream::runStream() {
       last_mem_report = now;
       Debug(1, "mem trace m%d: rss=%zuKB frame_count=%d buffer_level=%d temp_count=%d paused=%d delayed=%d",
            monitor_id, zm_get_rss_kb(), frame_count,
-           MonitorStreamBufferLevel(temp_write_index, temp_read_index, temp_image_buffer_count),
-           temp_image_buffer_count, paused, delayed);
+           MonitorStreamBufferLevel(temp_write_index.load(), temp_read_index.load(), temp_image_buffer_count.load()),
+           temp_image_buffer_count.load(), paused.load(), delayed.load());
     }
 
     bool was_paused = paused;
@@ -706,7 +706,7 @@ void MonitorStream::runStream() {
             delayed = true;
             temp_read_index = MOD_ADD(temp_read_index, (replay_rate>=0?-1:1), temp_image_buffer_count);
           } else {
-            FPSeconds expected_delta_time = ((FPSeconds(swap_image->timestamp - last_frame_timestamp)) * ZM_RATE_BASE) / replay_rate;
+            FPSeconds expected_delta_time = ((FPSeconds(swap_image->timestamp - last_frame_timestamp)) * ZM_RATE_BASE) / replay_rate.load();
             TimePoint::duration actual_delta_time = now - last_frame_sent;
 
             // If the next frame is due
@@ -778,7 +778,7 @@ void MonitorStream::runStream() {
       if ( now >= when_to_send_next_frame ) {
         if (!paused && !delayed) {
           Debug(2, "Sending frame index: %d(%d%%%d): frame_mod: %d frame count: %d last image count %d image count %d paused %d delayed %d",
-                index, last_write_index, monitor->image_buffer_count, frame_mod, frame_count, last_image_count, monitor->shared_data->image_count, paused, delayed);
+                index, last_write_index, monitor->image_buffer_count, frame_mod, frame_count, last_image_count, monitor->shared_data->image_count, paused.load(), delayed.load());
           last_read_index = last_write_index;
           last_image_count = monitor->shared_data->image_count;
           // Send the next frame
@@ -818,14 +818,14 @@ void MonitorStream::runStream() {
             }
           }
 
-          temp_read_index = temp_write_index;
+          temp_read_index = temp_write_index.load();
         } else {
-          if (delayed && !buffered_playback) {
+          if (delayed.load() && !buffered_playback) {
             Debug(2, "Can't delay when not buffering.");
             delayed = false;
           }
           if (last_zoom != zoom) {
-            Debug(2, "Sending 2 frames because change in zoom %d ?= %d", last_zoom, zoom);
+            Debug(2, "Sending 2 frames because change in zoom %d ?= %d", last_zoom, zoom.load());
             if (!sendFrame(paused_image, paused_timestamp))
               zm_terminate = true;
             if (!sendFrame(paused_image, paused_timestamp))
@@ -909,11 +909,16 @@ void MonitorStream::runStream() {
     if (now >= when_to_send_next_frame) {
       // sent a frame, so update
 
+      // Snapshot both once: the command thread can change them at any point,
+      // and re-reading mid-expression could mix an old value with a new one.
+      const double max_fps = maxfps.load();
+      const int rate = replay_rate.load();
+
       double capture_fps = monitor->GetFPS();
-      double fps = ((maxfps > 0.0) && (capture_fps > maxfps)) ? maxfps : capture_fps;
+      double fps = ((max_fps > 0.0) && (capture_fps > max_fps)) ? max_fps : capture_fps;
       double sleep_time_seconds = (1 / ((fps ? fps : 1)))    // 1 second / fps
-                                  * (replay_rate ? abs(replay_rate)/ZM_RATE_BASE : 1); // replay_rate is 100 for 1x
-      Debug(3, "Using %f for maxfps.  capture_fps: %f maxfps %f * replay_rate: %d = %f", fps, capture_fps, maxfps, replay_rate, sleep_time_seconds);
+                                  * (rate ? abs(rate)/ZM_RATE_BASE : 1); // replay_rate is 100 for 1x
+      Debug(3, "Using %f for maxfps.  capture_fps: %f maxfps %f * replay_rate: %d = %f", fps, capture_fps, max_fps, rate, sleep_time_seconds);
 
       sleep_time = FPSeconds(sleep_time_seconds);
       if (when_to_send_next_frame > now) {

--- a/src/zm_monitorstream.h
+++ b/src/zm_monitorstream.h
@@ -22,6 +22,8 @@
 
 #include "zm_stream.h"
 
+#include <atomic>
+
 // Returns the playback buffer fill level as a percentage (0-100).
 // Guards against buffer_count <= 0, which would otherwise raise SIGFPE via
 // modulo/division by zero. processCommand() can run on the command thread
@@ -44,14 +46,19 @@ class MonitorStream : public StreamBase {
 
  private:
   SwapImage *temp_image_buffer;
-  int temp_image_buffer_count;
-  int temp_read_index;
-  int temp_write_index;
+  // runStream() owns every write to these; processCommand() reads them on the
+  // command thread to report the buffer level. Atomic so those reads are
+  // defined. Each stays within [0, count) on its own, so a read of the three
+  // that straddles an update still yields an in-range percentage.
+  // See https://github.com/ZoneMinder/zoneminder/issues/4939
+  std::atomic<int> temp_image_buffer_count;
+  std::atomic<int> temp_read_index;
+  std::atomic<int> temp_write_index;
 
  protected:
   Microseconds ttl;
   int playback_buffer;
-  bool delayed;
+  std::atomic<bool> delayed;
 
  protected:
   bool checkSwapPath(const char *path, bool create_path);

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -99,19 +99,23 @@ void StreamBase::updateFrameRate(double fps) {
     return;
   }
 
+  // Snapshot once so the loop below cannot see maxfps change underneath it.
+  const double max_fps = maxfps.load();
+  const int rate = replay_rate.load();
+
   base_fps = fps;
-  effective_fps = (base_fps*abs(replay_rate))/ZM_RATE_BASE;
+  effective_fps = (base_fps*abs(rate))/ZM_RATE_BASE;
   frame_mod = 1;
   Debug(3, "FPS:%.2f, MaxFPS:%.2f, BaseFPS:%.2f, EffectiveFPS:%.2f, FrameMod:%d, replay_rate(%d)",
-        fps, maxfps, base_fps, effective_fps, frame_mod, replay_rate);
-  if (maxfps > 0.0) {
+        fps, max_fps, base_fps, effective_fps, frame_mod, rate);
+  if (max_fps > 0.0) {
     // Min frame repeat?
     // We want to keep the frame skip easy... problem is ... if effective = 31 and max = 30 then we end up with 15.5 fps.
-    while ( (int)effective_fps > (int)maxfps ) {
+    while ( (int)effective_fps > (int)max_fps ) {
       effective_fps /= 2.0;
       frame_mod *= 2;
       Debug(3, "Changing fps to be < max %.2f EffectiveFPS:%.2f, FrameMod:%d",
-            maxfps, effective_fps, frame_mod);
+            max_fps, effective_fps, frame_mod);
     }
   }
 } // void StreamBase::updateFrameRate(double fps)
@@ -152,11 +156,20 @@ Image *StreamBase::prepareImage(Image *image) {
    */
   bool image_copied = false;
 
-  if (zoom != 100) {
+  // Snapshot the pan/zoom/scale state once. The command thread can change any
+  // of these at any point, and the crop below is derived from all three
+  // together, so re-reading them mid-calculation could mix a new zoom with an
+  // old click position and produce a crop that matches neither.
+  const int cur_zoom = zoom.load();
+  const int cur_scale = scale.load();
+  const unsigned short cur_x = x.load();
+  const unsigned short cur_y = y.load();
+
+  if (cur_zoom != 100) {
     int base_image_width = image->Width(),
         base_image_height = image->Height(),
-        disp_image_width = image->Width() * scale/ZM_SCALE_BASE,
-        disp_image_height = image->Height() * scale / ZM_SCALE_BASE;
+        disp_image_width = image->Width() * cur_scale/ZM_SCALE_BASE,
+        disp_image_height = image->Height() * cur_scale / ZM_SCALE_BASE;
     /* x and y are scaled by web UI to base dimensions units.
      * When zooming, we blow up the image by the amount 150 for first zoom, right? 150%, then cut out a base sized chunk
      * However if we have zoomed before, then we are zooming into the previous cutout
@@ -164,20 +177,20 @@ Image *StreamBase::prepareImage(Image *image) {
      */
     if (!last_crop.Hi().x_ && !last_crop.Hi().y_) last_crop = Box({0, 0}, {base_image_width, base_image_height});
 
-    double x_percent = static_cast<double>(x * ZM_SCALE_BASE) / base_image_width;
-    double y_percent = static_cast<double>(y * ZM_SCALE_BASE) / base_image_height;
-    Debug(2, "click percent %dx%d => %.2fx%.2f", x, y, x_percent, y_percent);
+    double x_percent = static_cast<double>(cur_x * ZM_SCALE_BASE) / base_image_width;
+    double y_percent = static_cast<double>(cur_y * ZM_SCALE_BASE) / base_image_height;
+    Debug(2, "click percent %dx%d => %.2fx%.2f", cur_x, cur_y, x_percent, y_percent);
 
     // If we were previously zoomed in, then the coordinate percentages are into the crop, so calculate the click coordinates in base image
     int crop_x = last_crop.Lo().x_ + (x_percent * last_crop.Width() / ZM_SCALE_BASE);
     int crop_y = last_crop.Lo().y_ + (y_percent * last_crop.Height() / ZM_SCALE_BASE);
-    Debug(2, "crop click %dx%d => %dx%d out of %dx%d", x, y, crop_x, crop_y, last_crop.Width(), last_crop.Height());
+    Debug(2, "crop click %dx%d => %dx%d out of %dx%d", cur_x, cur_y, crop_x, crop_y, last_crop.Width(), last_crop.Height());
 
-    int zoom_image_width = base_image_width * zoom / ZM_SCALE_BASE,
-        zoom_image_height = base_image_height * zoom / ZM_SCALE_BASE,
-        click_x = crop_x * zoom / ZM_SCALE_BASE,
-        click_y = crop_y * zoom / ZM_SCALE_BASE;
-    Debug(2, "adjusted click %dx%d * %d zoom => %dx%d out of %dx%d", x, y, zoom, click_x, click_y, zoom_image_width, zoom_image_height);
+    int zoom_image_width = base_image_width * cur_zoom / ZM_SCALE_BASE,
+        zoom_image_height = base_image_height * cur_zoom / ZM_SCALE_BASE,
+        click_x = crop_x * cur_zoom / ZM_SCALE_BASE,
+        click_y = crop_y * cur_zoom / ZM_SCALE_BASE;
+    Debug(2, "adjusted click %dx%d * %d zoom => %dx%d out of %dx%d", cur_x, cur_y, cur_zoom, click_x, click_y, zoom_image_width, zoom_image_height);
 
     // These can go out of image. Resulting size will be less than base image. That's ok.
     // We don't want to center it, we want to keep the relative offset from center where the click is.
@@ -234,20 +247,22 @@ Image *StreamBase::prepareImage(Image *image) {
     }
     image->Crop(last_crop);
     image->Scale(disp_image_width, disp_image_height);
-  } else if (scale != ZM_SCALE_BASE) {
-    Debug(3, "scaling by %d from %dx%d", scale, image->Width(), image->Height());
+  } else if (cur_scale != ZM_SCALE_BASE) {
+    Debug(3, "scaling by %d from %dx%d", cur_scale, image->Width(), image->Height());
     static Image copy_image;
     copy_image.Assign(*image);
     image = &copy_image;
     image_copied = true;
-    image->Scale(scale);
+    image->Scale(cur_scale);
   }
   Debug(3, "Sending %dx%d", image->Width(), image->Height());
 
-  last_scale = scale;
-  last_zoom = zoom;
-  last_x = x;
-  last_y = y;
+  // Record what was actually rendered, not whatever the command thread may
+  // have set since.
+  last_scale = cur_scale;
+  last_zoom = cur_zoom;
+  last_x = cur_x;
+  last_y = cur_y;
 
   return image;
 }  // end Image *StreamBase::prepareImage(Image *image)
@@ -267,7 +282,7 @@ bool StreamBase::sendTextFrame(const char *frame_text) {
     labelsize = monitor->LabelSize();
   }
   Debug(2, "Sending %dx%dx%dx%d * %d scale text frame '%s'",
-        width, height, colours, subpixelorder, scale, frame_text);
+        width, height, colours, subpixelorder, scale.load(), frame_text);
 
   Image image(width, height, colours, subpixelorder);
   image.Clear();

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -24,6 +24,7 @@
 #include "zm_logger.h"
 #include "zm_mpeg.h"
 #include "zm_time.h"
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <sys/un.h>
@@ -117,17 +118,20 @@ class StreamBase {
   std::shared_ptr<Monitor> monitor;
 
   StreamType type;
-  FrameType   frame_type;
+  std::atomic<FrameType> frame_type;
   const char *format;
-  int replay_rate;
-  int scale;
+  // Written by the command thread (processCommand), read by the streaming
+  // loop every iteration. Atomic so the accesses are defined rather than a
+  // data race; see https://github.com/ZoneMinder/zoneminder/issues/4939
+  std::atomic<int> replay_rate;
+  std::atomic<int> scale;
   int last_scale;
-  int zoom;
+  std::atomic<int> zoom;
   int last_zoom;
   Box last_crop;
   int bitrate;
   unsigned short last_x, last_y;
-  unsigned short x, y;
+  std::atomic<unsigned short> x, y;
   bool send_analysis;
   bool send_objdetect;
   int connkey;
@@ -138,15 +142,15 @@ class StreamBase {
   struct sockaddr_un rem_addr;
   char sock_path_lock[108];
   int lock_fd;
-  bool paused;
-  bool stopped;
-  int step;
-  bool send_twice;        // flag to send the same frame twice
+  std::atomic<bool> paused;
+  std::atomic<bool> stopped;
+  std::atomic<int> step;
+  std::atomic<bool> send_twice;  // flag to send the same frame twice
 
   TimePoint now;
   TimePoint last_comm_update;
 
-  double maxfps;
+  std::atomic<double> maxfps;
   double base_fps;        // Should be capturing fps, hence a rough target
   double effective_fps;   // Target fps after taking max_fps into account
   double actual_fps;      // sliding calculated actual streaming fps achieved

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
   zm_onvif_wsse.cpp
   zm_pixformat.cpp
   zm_stream.cpp
+  zm_stream_races.cpp
   zm_swscale_range.cpp
   zm_poly.cpp
   zm_time.cpp

--- a/tests/zm_monitorstream.cpp
+++ b/tests/zm_monitorstream.cpp
@@ -50,4 +50,20 @@ TEST_CASE("MonitorStreamBufferLevel") {
     // write_index - read_index is negative; modular arithmetic keeps it in range
     REQUIRE(MonitorStreamBufferLevel(2, 7, 10) == 50);
   }
+
+  SECTION("a read that straddles an update still reports in range") {
+    // zoneminder/zoneminder#4939: the command thread reads the three values as
+    // separate atomics, so it can pick up a write index from one moment and a
+    // read index from another. That stays harmless for this percentage as long
+    // as each index is individually within [0, count): the +count before the
+    // modulo covers the whole (-count, count) span the difference can take.
+    const int count = 64;
+    for (int write_index = 0; write_index < count; write_index++) {
+      for (int read_index = 0; read_index < count; read_index++) {
+        const int level = MonitorStreamBufferLevel(write_index, read_index, count);
+        REQUIRE(level >= 0);
+        REQUIRE(level <= 100);
+      }
+    }
+  }
 }

--- a/tests/zm_stream_races.cpp
+++ b/tests/zm_stream_races.cpp
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_stream.h"
+
+#include <atomic>
+#include <thread>
+
+// zms runs two threads over one StreamBase: the command thread
+// (checkCommandQueue -> processCommand) writes the playback state, and the
+// streaming loop (runStream) reads it every iteration. Nothing synchronises
+// them, so before zoneminder/zoneminder#4939 every one of these fields was a
+// data race, which is undefined behaviour regardless of what it does on x86.
+//
+// This exercises those exact members from two threads. It passes trivially in a
+// normal build; its value is under ThreadSanitizer:
+//
+//   cmake -DTSAN=ON -DBUILD_TEST_SUITE=ON .. && cmake --build .
+//   ./tests/tests "[races]"
+//
+// With the fields plain, TSan reports a write/read race on each. With them
+// atomic it is clean.
+
+namespace {
+
+class PlaybackStateProbe : public StreamBase {
+ public:
+  // The writes MonitorStream::processCommand performs on the command thread.
+  void applyCommands(int iterations) {
+    for (int i = 0; i < iterations; i++) {
+      stopped = false;
+      paused = true;
+      replay_rate = ZM_RATE_BASE * ((i % 5) + 1);
+      scale = 100 + (i % 100);
+      zoom = 100 + (i % 50);
+      x = static_cast<unsigned short>(i % 1000);
+      y = static_cast<unsigned short>(i % 800);
+      step = (i % 3) - 1;
+      send_twice = (i % 2) == 0;
+      maxfps = 1.0 + (i % 30);
+      frame_type = (i % 2) ? FRAME_ANALYSIS : FRAME_NORMAL;
+      paused = false;
+    }
+  }
+
+  // The reads runStream() performs on the streaming thread. The accumulator
+  // exists so none of this is optimised away.
+  int64 readPlaybackState(int iterations) {
+    int64 sink = 0;
+    for (int i = 0; i < iterations; i++) {
+      sink += paused ? 1 : 0;
+      sink += stopped ? 1 : 0;
+      sink += replay_rate;
+      sink += scale;
+      sink += zoom;
+      sink += x;
+      sink += y;
+      sink += step;
+      sink += send_twice ? 1 : 0;
+      sink += static_cast<int64>(maxfps);
+      sink += (frame_type == FRAME_ANALYSIS) ? 1 : 0;
+    }
+    return sink;
+  }
+
+ protected:
+  void processCommand(const CmdMsg *) override {}
+  void runStream() override {}
+};
+
+}  // namespace
+
+TEST_CASE("StreamBase playback state is shared safely between the command and stream threads", "[races]") {
+  // connkey defaults to 0, so ~StreamBase does no socket teardown here.
+  PlaybackStateProbe probe;
+
+  constexpr int kIterations = 20000;
+  std::atomic<int64> observed{0};
+
+  std::thread command_thread([&probe]() { probe.applyCommands(kIterations); });
+  std::thread stream_thread([&probe, &observed]() {
+    observed = probe.readPlaybackState(kIterations);
+  });
+
+  command_thread.join();
+  stream_thread.join();
+
+  // The exact total is timing dependent and deliberately not asserted. What
+  // matters is that both threads completed and that, under TSan, the run
+  // produced no race report.
+  REQUIRE(observed.load() >= 0);
+}


### PR DESCRIPTION
Fixes #4939.

`processCommand()` runs on the command thread and mutates playback state that `runStream()` reads every iteration, with nothing between them. That is a data race and therefore undefined behaviour, regardless of whether it currently appears to work on x86.

**Fields made atomic**

In `StreamBase`: `replay_rate`, `scale`, `zoom`, `x`, `y`, `paused`, `stopped`, `step`, `send_twice`, `maxfps`, `frame_type`. In `MonitorStream`: `delayed`, `temp_read_index`, `temp_write_index`, `temp_image_buffer_count`.

The `last_*` companions (`last_scale`, `last_zoom`, `last_x`, `last_y`, `last_crop`) stay plain. Only the streaming loop touches those.

**Verified under ThreadSanitizer**

The issue asked for this to be run under TSan, so it was. `tests/zm_stream_races.cpp` drives a minimal `StreamBase` subclass from two threads, one writing the fields the way `processCommand()` does and one reading them the way `runStream()` does. It needs no database, shared memory or capture daemon, so it runs anywhere the test suite builds.

```
cmake -DTSAN=ON -DBUILD_TEST_SUITE=ON .. && cmake --build .
./tests/tests "[races]"
```

Against master, TSan reports 7 data races, on `paused`, `replay_rate`, `zoom`, `x`, `send_twice`, `maxfps` and `frame_type`:

```
WARNING: ThreadSanitizer: data race (pid=2354883)
  Read of size 1 by thread T18:
    #0 readPlaybackState tests/zm_stream_races.cpp:67
  Previous write of size 1 by thread T17:
    #0 applyCommands tests/zm_stream_races.cpp:58
```

With this change, 0. The full suite under TSan is also clean: 122 test cases, 10023 assertions, no reports.

One environment note for anyone reproducing: TSan aborts with `unexpected memory mapping` under the default ASLR settings on recent kernels, so the binary needs `setarch $(uname -m) -R ./tests`.

**Why atomics rather than the mutex for the buffer indices**

The issue suggested guarding the index triple under the existing mutex. I did not, and it is worth saying why. `runStream()` owns every write to those three, and they are read across threads in exactly one place: `processCommand()` computing a buffer-level percentage for the status reply. The indices are otherwise read and written throughout the streaming hot loop, so taking a lock around them would put a mutex acquisition in the per-frame path to protect a status number.

Atomics remove the undefined behaviour, which is the actual defect. The remaining looseness is that the three can be read from slightly different moments. That is harmless here: each index individually stays within `[0, count)`, so their difference stays within `(-count, count)`, and the `+ count` before the modulo in `MonitorStreamBufferLevel()` covers that whole span. The result is always a sane 0-100. There is a test section that exhaustively checks every index pairing for a 64-slot buffer to pin that down.

If you would rather have the strict version, say so and I will move it under `monitor_mutex`, but it costs a lock per frame.

**Consistency snapshots**

Making these atomic exposed a subtler problem: several expressions read the same field two or three times, so they could mix an old value with a new one. Those now snapshot once into a local:

- `prepareImage()` derives a crop rectangle from `zoom`, `x`, `y` and `scale` together. Re-reading mid-calculation could pair a new zoom with an old click position and produce a crop matching neither. It also now records `last_scale`/`last_zoom`/`last_x`/`last_y` from the snapshot, so they describe what was actually rendered rather than whatever arrived since.
- `updateFrameRate()` re-read `maxfps` on every iteration of its halving loop.
- The sleep-time calculation in `runStream()` read `maxfps` three times and `replay_rate` twice in one expression.

**Not addressed**

`now`, `last_frame_sent` and `last_fps_update` are `TimePoint`s that also cross the two threads. Making them atomic means explicit loads at every arithmetic site, which is a much larger and more invasive diff than this one, so I left it out rather than bundle it in. The new harness does not cover them either, since it exercises the fields directly rather than the timing logic. Worth a follow-up issue if you agree.

**Testing**: full suite passes, 122 test cases and 10023 assertions, in both a normal build and a TSan build. `zms`, `zmc` and `zmu` all build warning-free.
