### PR TITLE
fix: fall back to rename when the filesystem has no hard links

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -226,6 +226,26 @@ Event::~Event() {
     // the rename.
     if (link(video_incomplete_path.c_str(), video_path.c_str()) == 0) {
       video_file_linked = true;
+    } else if (ErrnoMeansNoHardLinkSupport(errno)) {
+      // exFAT and friends are perfectly writable but have no hard links at all,
+      // so fall back to a plain rename. The event then gets its normal final
+      // name instead of keeping incomplete.* forever, and this is a supported
+      // configuration rather than an error worth logging as one.
+      //
+      // The cost is the dual-name window described above: between this rename
+      // and the DefaultVideo update below, a reader of the still-stale row
+      // looks for incomplete.* and will not find it. On a filesystem without
+      // hard links there is no way to have the file under both names at once,
+      // and a brief window beats every event on the system being named as
+      // though it never finished recording.
+      if (rename(video_incomplete_path.c_str(), video_path.c_str()) == 0) {
+        Debug(1, "Filesystem does not support hard links, renamed %s to %s",
+              video_incomplete_path.c_str(), video_path.c_str());
+      } else {
+        Error("Failed renaming %s to %s, reason: %s",
+              video_incomplete_path.c_str(), video_path.c_str(), strerror(errno));
+        video_file = video_incomplete_file;
+      }
     } else {
       Error("Failed linking %s to %s, reason: %s", video_incomplete_path.c_str(), video_path.c_str(), strerror(errno));
       video_file = video_incomplete_file;

--- a/src/zm_event.h
+++ b/src/zm_event.h
@@ -48,6 +48,25 @@ class VideoStore;
 class ZMPacket;
 class Zone;
 
+// True when a failed link(2) means the filesystem has no hard links at all,
+// rather than something being wrong with this particular call.
+//
+// link(2) documents EPERM for "the filesystem containing oldpath and newpath
+// does not support the creation of hard links", which is what exFAT, FAT and
+// most FUSE-mounted network filesystems report. EXDEV is deliberately excluded:
+// that is a cross-device link, where rename(2) would fail the same way.
+// See https://github.com/ZoneMinder/zoneminder/issues/5048
+inline bool ErrnoMeansNoHardLinkSupport(int err) {
+  return (err == EPERM)
+#ifdef EOPNOTSUPP
+      || (err == EOPNOTSUPP)
+#endif
+#ifdef ENOTSUP
+      || (err == ENOTSUP)
+#endif
+      || (err == ENOSYS);
+}
+
 // Maximum number of prealarm frames that can be stored
 #define MAX_PRE_ALARM_FRAMES  16
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
   zm_box.cpp
   zm_comms.cpp
   zm_crypt.cpp
+  zm_event_hardlink.cpp
   zm_font.cpp
   zm_image.cpp
   zm_monitorstream.cpp

--- a/tests/zm_event_hardlink.cpp
+++ b/tests/zm_event_hardlink.cpp
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_event.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+TEST_CASE("ErrnoMeansNoHardLinkSupport") {
+  SECTION("errnos that mean the filesystem has no hard links") {
+    // What exFAT/FAT report; see zoneminder/zoneminder#5048.
+    REQUIRE(ErrnoMeansNoHardLinkSupport(EPERM));
+    REQUIRE(ErrnoMeansNoHardLinkSupport(ENOSYS));
+    REQUIRE(ErrnoMeansNoHardLinkSupport(EOPNOTSUPP));
+  }
+
+  SECTION("errnos that mean something else went wrong") {
+    // A cross-device link must stay an error: rename() cannot do it either,
+    // so falling back would just fail a second time.
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EXDEV));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(ENOENT));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EACCES));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EEXIST));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(ENOSPC));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EMLINK));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EROFS));
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(0));
+  }
+}
+
+TEST_CASE("Event video finalization fallback") {
+  // Mirrors what ~Event does with the incomplete.* file, so the rename path
+  // that filesystems without hard links take is exercised end to end.
+  char dir_template[] = "/tmp/zm.event.XXXXXX";
+  const char *dir = mkdtemp(dir_template);
+  REQUIRE(dir != nullptr);
+
+  const std::string incomplete = std::string(dir) + "/incomplete.h264.mp4";
+  const std::string final_name = std::string(dir) + "/1-video.h264.mp4";
+
+  FILE *fp = fopen(incomplete.c_str(), "w");
+  REQUIRE(fp != nullptr);
+  fputs("video", fp);
+  fclose(fp);
+
+  SECTION("rename leaves only the final name in place") {
+    REQUIRE(rename(incomplete.c_str(), final_name.c_str()) == 0);
+
+    struct stat st;
+    REQUIRE(stat(final_name.c_str(), &st) == 0);
+    // Nothing left to unlink afterwards, which is why video_file_linked stays
+    // false on this path.
+    REQUIRE(stat(incomplete.c_str(), &st) != 0);
+
+    REQUIRE(unlink(final_name.c_str()) == 0);
+  }
+
+  SECTION("link leaves both names pointing at one inode") {
+    // The normal path on a filesystem that does support hard links.
+    REQUIRE(link(incomplete.c_str(), final_name.c_str()) == 0);
+
+    struct stat incomplete_stat, final_stat;
+    REQUIRE(stat(incomplete.c_str(), &incomplete_stat) == 0);
+    REQUIRE(stat(final_name.c_str(), &final_stat) == 0);
+    REQUIRE(incomplete_stat.st_ino == final_stat.st_ino);
+    // ~Event counts distinct inodes so the video is not double counted
+    // toward DiskSpace while both names exist.
+    REQUIRE(final_stat.st_nlink == 2);
+
+    REQUIRE(unlink(incomplete.c_str()) == 0);
+    REQUIRE(stat(final_name.c_str(), &final_stat) == 0);
+    REQUIRE(final_stat.st_nlink == 1);
+
+    REQUIRE(unlink(final_name.c_str()) == 0);
+  }
+
+  rmdir(dir);
+}


### PR DESCRIPTION
Fixes #5048.

`~Event` hard-links `incomplete.h264.mp4` to `<Id>-video.h264.mp4` when finalizing. exFAT is writable but supports no hard links at all, so `link(2)` returns `EPERM` and every completed event logs an ERR and keeps the `incomplete.*` name permanently.

**Change**

When `link()` fails specifically because the filesystem has no hard links, fall back to `rename()`. The event then gets its normal final name, and the fallback logs at Debug rather than Error, since this is a supported configuration and not a failure. Genuine link failures still log as errors.

`ErrnoMeansNoHardLinkSupport()` covers `EPERM` (what `link(2)` documents for "the filesystem does not support the creation of hard links", and what exFAT and FAT return), plus `ENOSYS` and `EOPNOTSUPP`/`ENOTSUP` for FUSE and network mounts. `EXDEV` is deliberately not in that set: a cross-device link means `rename()` would fail the same way, so that stays an error.

**The tradeoff**

The hard link is not an implementation detail, it is load-bearing. The comment above it explains that the file has to be reachable under *both* names for the whole window in which the database still advertises `DefaultVideo=incomplete.*`, so a reader of the briefly-stale row always finds a file. `rename()` cannot provide that.

So on a filesystem without hard links there is a window between the rename and the `DefaultVideo` update where a reader of the stale row looks for `incomplete.*` and does not find it. That window is short: the update is written synchronously a few statements later in the same thread, and `EventEndCommand` is only forked after it returns.

I took the view that a brief window on filesystems that cannot do better beats every event on such a system being permanently named as though it never finished recording, which is the current behaviour. It is a real regression in that narrow case though, so if you would rather keep the `incomplete.*` fallback and only downgrade the log level, that is a one-line change from here and I am happy to do it instead.

The rest of the surrounding logic already handles this path. `video_file` keeps the final name, so the m3u8 rewrite fires correctly (it is guarded on `video_file != video_incomplete_file`). `video_file_linked` stays false, so nothing tries to unlink a path that no longer exists. And the inode-deduplicating `DiskSpace` count is unaffected, since after a rename there is only one name.

**Testing**: new `tests/zm_event_hardlink.cpp`, 28 assertions in 2 cases. It covers the errno classification in both directions, and exercises both finalization paths against a real temp directory: that `rename` leaves only the final name with nothing left to unlink, and that `link` leaves both names on one inode with `st_nlink == 2`, dropping to 1 after the incomplete name is removed. Full suite passes, 123 test cases and 1858 assertions. `zmc` builds warning-free.
