### PR TITLE
fix: do not treat EPERM as missing hard link support on FreeBSD

### DIFF
--- a/src/zm_event.cpp
+++ b/src/zm_event.cpp
@@ -238,9 +238,12 @@ Event::~Event() {
       // hard links there is no way to have the file under both names at once,
       // and a brief window beats every event on the system being named as
       // though it never finished recording.
+      const int link_errno = errno;
       if (rename(video_incomplete_path.c_str(), video_path.c_str()) == 0) {
-        Debug(1, "Filesystem does not support hard links, renamed %s to %s",
-              video_incomplete_path.c_str(), video_path.c_str());
+        // Reports the errno rather than asserting the cause: on Linux EPERM
+        // usually means something other than a filesystem without hard links.
+        Debug(1, "Renamed %s to %s, link was refused: %s",
+              video_incomplete_path.c_str(), video_path.c_str(), strerror(link_errno));
       } else {
         Error("Failed renaming %s to %s, reason: %s",
               video_incomplete_path.c_str(), video_path.c_str(), strerror(errno));

--- a/src/zm_event.h
+++ b/src/zm_event.h
@@ -48,23 +48,28 @@ class VideoStore;
 class ZMPacket;
 class Zone;
 
-// True when a failed link(2) means the filesystem has no hard links at all,
-// rather than something being wrong with this particular call.
+// True when a failed link(2) means renaming instead is worth trying, rather
+// than something being wrong that a rename would hit too. EXDEV is deliberately
+// excluded: a cross-device link is one rename(2) cannot do either.
 //
-// link(2) documents EPERM for "the filesystem containing oldpath and newpath
-// does not support the creation of hard links", which is what exFAT, FAT and
-// most FUSE-mounted network filesystems report. EXDEV is deliberately excluded:
-// that is a cross-device link, where rename(2) would fail the same way.
+// EOPNOTSUPP (and its alias ENOTSUP) and ENOSYS mean the filesystem has no hard
+// links at all, on both platforms.
+//
+// EPERM only means that on Linux, where the VFS returns it for a filesystem
+// with no link operation, which is the exFAT and FAT case. Linux overloads it
+// with fs.protected_hardlinks, immutable sources and idmapped mounts, so this
+// is a broader "try the rename" than the errno alone proves; rename is the
+// right attempt in all of those, and where it genuinely cannot proceed it fails
+// and gets reported. FreeBSD is excluded because there EPERM only ever means a
+// directory source, an immutable source or an immutable target directory, all
+// real errors, and absent link support arrives as EOPNOTSUPP above.
 // See https://github.com/ZoneMinder/zoneminder/issues/5048
 inline bool ErrnoMeansNoHardLinkSupport(int err) {
-  return (err == EPERM)
-#ifdef EOPNOTSUPP
-      || (err == EOPNOTSUPP)
+  if ((err == EOPNOTSUPP) || (err == ENOTSUP) || (err == ENOSYS)) return true;
+#ifndef __FreeBSD__
+  if (err == EPERM) return true;
 #endif
-#ifdef ENOTSUP
-      || (err == ENOTSUP)
-#endif
-      || (err == ENOSYS);
+  return false;
 }
 
 // Maximum number of prealarm frames that can be stored

--- a/tests/zm_event_hardlink.cpp
+++ b/tests/zm_event_hardlink.cpp
@@ -27,10 +27,21 @@
 
 TEST_CASE("ErrnoMeansNoHardLinkSupport") {
   SECTION("errnos that mean the filesystem has no hard links") {
-    // What exFAT/FAT report; see zoneminder/zoneminder#5048.
-    REQUIRE(ErrnoMeansNoHardLinkSupport(EPERM));
     REQUIRE(ErrnoMeansNoHardLinkSupport(ENOSYS));
     REQUIRE(ErrnoMeansNoHardLinkSupport(EOPNOTSUPP));
+    REQUIRE(ErrnoMeansNoHardLinkSupport(ENOTSUP));
+  }
+
+  SECTION("EPERM is Linux only") {
+#ifndef __FreeBSD__
+    // What exFAT and FAT report; see zoneminder/zoneminder#5048.
+    REQUIRE(ErrnoMeansNoHardLinkSupport(EPERM));
+#else
+    // FreeBSD reports absent link support as EOPNOTSUPP and uses EPERM only for
+    // a directory source, an immutable or append-only source, and an immutable
+    // target directory. Renaming on those would paper over a real error.
+    REQUIRE_FALSE(ErrnoMeansNoHardLinkSupport(EPERM));
+#endif
   }
 
   SECTION("errnos that mean something else went wrong") {


### PR DESCRIPTION
#5056 treats EPERM as "filesystem has no hard links". That's right on Linux (exFAT, FAT) but wrong on FreeBSD, where link(2) reports missing link support as EOPNOTSUPP and uses EPERM only for a directory source, an immutable source, or an immutable target dir. All real errors, so right now FreeBSD silently renames on them and drops the log from Error to Debug. FreeBSD is in CI.

So: skip EPERM on FreeBSD, Linux unchanged.

Also stopped the rename path logging "Filesystem does not support hard links", since on Linux EPERM is usually protected_hardlinks or an immutable source. Logs the errno instead.
