### PR TITLE
The "rand" parameter change for SRC has been separated into a separate function, and a function for replacing SRC has been added.

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -619,7 +619,7 @@ function MonitorStream(monitorData) {
     if (-1 == src.search('mode=')) {
       src += '&mode=single';
     }
-    setSrc(imgInfoBlock, src);
+    refreshStreamSrc(imgInfoBlock, src);
     return imgInfoBlock;
   };
 
@@ -1467,7 +1467,6 @@ function MonitorStream(monitorData) {
 
       // Try to reload the image stream.
       console.log('Reloading stream: ' + stream.src);
-      let src = (-1 != stream.src.indexOf('rand=')) ? stream.src.replace(/rand=\d+/i, 'rand='+Math.floor((Math.random() * 1000000) )) : stream.src+'&rand='+Math.floor((Math.random() * 1000000));
       /* Make the old zms exit before we stop being able to address it.  Once
        * the connkey is replaced nothing can reach the old process, so if it
        * missed SIGPIPE it would linger and keep streaming forever.
@@ -1475,8 +1474,7 @@ function MonitorStream(monitorData) {
       this.quitConnKey(this.connKey);
       this.streamCmdParms.connkey = this.statusCmdParms.connkey = this.connKey = this.genConnKey();
       src = zmAuth.applyTo(src, this.connKey);
-      stream.src = '';
-      stream.src = src;
+      refreshStreamSrc(stream, src);
     } // end if Ok or not
   }; // this.getStreamCmdResponse
 

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -619,8 +619,7 @@ function MonitorStream(monitorData) {
     if (-1 == src.search('mode=')) {
       src += '&mode=single';
     }
-    imgInfoBlock.src = '';
-    imgInfoBlock.src = src;
+    setSrc(imgInfoBlock, src);
     return imgInfoBlock;
   };
 

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -1466,7 +1466,8 @@ function MonitorStream(monitorData) {
       }
 
       // Try to reload the image stream.
-      console.log('Reloading stream: ' + stream.src);
+      let src = stream.src;
+      console.log('Reloading stream: ' + src);
       /* Make the old zms exit before we stop being able to address it.  Once
        * the connkey is replaced nothing can reach the old process, so if it
        * missed SIGPIPE it would linger and keep streaming forever.

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2048,8 +2048,18 @@ function initThumbAnimation() {
   }
 }
 
-function setSrc(elem, src) {
-  elem.src = src + (src.includes('?') ? '&' : '?') + '_=' + Date.now();
+function addOrUpdateRandParam(src) {
+  const rand = Date.now();
+  if (/[?&]rand=\d+/i.test(src)) {
+    return src.replace(/([?&])rand=\d+/i, '$1rand=' + rand);
+  }
+  return src + (src.includes('?') ? '&' : '?') + 'rand=' + rand;
+}
+
+function refreshStreamSrc(stream, src) {
+  src = addOrUpdateRandParam(src);
+  stream.src = '';
+  stream.src = src;
 }
 
 /* View in fullscreen */

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2048,6 +2048,10 @@ function initThumbAnimation() {
   }
 }
 
+function setSrc(elem, src) {
+  elem.src = src + (src.includes('?') ? '&' : '?') + '_=' + Date.now();
+}
+
 /* View in fullscreen */
 function openFullscreen(elem) {
   if (elem.requestFullscreen) {

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -326,11 +326,7 @@ function getFrame(monId, time, last_Frame) {
 // time is seconds since epoch
 function getImageSource(monId, time) {
   if (liveMode == 1) {
-    const new_url = monitorImageObject[monId].src.replace(
-        /rand=\d+/i,
-        'rand='+Math.floor(Math.random() * 1000000)
-    );
-    return zmAuth.applyTo(new_url);
+    return zmAuth.applyTo(addOrUpdateRandParam(monitorImageObject[monId].src));
   }
   let frame_id;
 

--- a/web/skins/classic/views/js/watch.js
+++ b/web/skins/classic/views/js/watch.js
@@ -482,10 +482,7 @@ function controlCmdImage(x, y) {
 }
 
 function fetchImage(streamImage) {
-  const oldsrc = streamImage.src;
-  const newsrc = oldsrc.replace(/rand=\d+/i, 'rand='+Math.floor((Math.random() * 1000000) ));
-  streamImage.src = '';
-  streamImage.src = newsrc;
+  refreshStreamSrc(streamImage, streamImage.src);
 }
 
 function handleClick(event) {


### PR DESCRIPTION
- We will use `Date.now()` instead of `Math.random()`.
- We also now use `refreshStreamSrc()` when stopping stream playback to avoid retrieving a cached image from the browser.

For example, when viewing a stream on the Watch page for a long time and then clicking `stop`, Firefox uses the cached image, not the current one. For example, we're viewing a stream and the camera switches to black-and-white mode. We click `stop`, and we get a color image cached XX minutes ago. It's ugly.
