### PR TITLE
Fix: If a codec for Rtsp2Web type MSE playback is missing, always log the error as a fatal error, not just when players are automatically selected.

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -2662,11 +2662,11 @@ function mseListenerSourceopen(context, videoEl, url) {
         console.warn(msg);
         context.showText(msg);
         context.RTSP2WebType = null; // Avoid repeated restarts
+        context.streamErrorRegistration(true);
         if (context.selectedPlayer) {
           context.stop();
         } else {
           // Restart for select next player only for "Auto" mode
-          context.streamErrorRegistration(true);
           context.restart(context.currentChannelStream);
         }
         return;


### PR DESCRIPTION
This will ensure more correct code execution. This is especially true for switching to the next monitor in PR https://github.com/ZoneMinder/zoneminder/pull/4980