### PR TITLE
Fix: Continued fixing of race conditions when switching monitors

### DIFF
--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -547,13 +547,13 @@ function MonitorStream(monitorData) {
     }
     this.handlerEventListener['playStream'] = manageEventListener.addEventListener(stream, 'play',
         (e) => {
-          if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+          if (!this.sessionActive(playbackSessionId)) return;
           this.writeTextInfoBlock("");
           this.createVolumeSlider();
 
           this.handlerEventListener['zm:tracksReceived'] = manageEventListener.addEventListener(this.getElement(), 'zm:tracksReceived',
               (e) => {
-                if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+                if (!this.sessionActive(playbackSessionId)) return;
                 if (e.detail.monitorId !== this.id) return;
 
                 if (this.started) {
@@ -598,7 +598,7 @@ function MonitorStream(monitorData) {
     );
     this.handlerEventListener['pauseStream'] = manageEventListener.addEventListener(stream, 'pause',
         (e) => {
-          if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+          if (!this.sessionActive(playbackSessionId)) return;
           this.writeTextInfoBlock("Paused", {showImg: false});
           manageEventListener.removeEventListener(this.handlerEventListener['volumechange']);
           if (typeof pauseAudioMotion === 'function') {
@@ -609,7 +609,7 @@ function MonitorStream(monitorData) {
     this.handlerEventListener['errorStream'] = manageEventListener.addEventListener(stream, 'error',
         (e) => {
           clearTimeout(this.mseWaitingErrorReset);
-          if (!isCurrentPlaybackSession(this, playbackSessionId) || !this.isActive) return;
+          if (!this.sessionActive(playbackSessionId)) return;
           const mediaErrorMsg = e?.target?.error?.message || e?.srcElement?.error?.message || 'Unknown media error';
           console.warn(`Stream playback error for monitor ID=${this.id}.`, `ERROR: ${mediaErrorMsg}`, e);
           this.writeTextInfoBlock("Error");
@@ -984,8 +984,7 @@ function MonitorStream(monitorData) {
     if (countErrors < this.limitCountErrors) {
       const playbackSessionId = this.playbackSessionId;
       setTimeout(function(self) {// During the downtime, the monitor may have already started to work.
-        if (!isCurrentPlaybackSession(self, playbackSessionId)) return;
-        if (!self.isActive) return;
+        if (!self.sessionActive(playbackSessionId)) return;
         if (!self.started && !self.starting) self.start(channelStream);
       }, delay, this);
     } else {
@@ -2014,12 +2013,12 @@ function MonitorStream(monitorData) {
           */
 
           this.hls.on(Hls.Events.MEDIA_ATTACHING, function(event, data) {
-            if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+            if (!this.sessionActive(playbackSessionId)) return;
             console.debug(`HLS Event = MEDIA_ATTACHING for monitor ID=${this.id}`);
           }, this);
           this.hls.on(Hls.Events.BUFFER_CODECS, function(event, data) {
             // Triggers if there is an audio track.
-            if (!isCurrentPlaybackSession(this, playbackSessionId)) {
+            if (!this.sessionActive(playbackSessionId)) {
               //hlsDestroy(this);
               return;
             }
@@ -2034,11 +2033,11 @@ function MonitorStream(monitorData) {
             }
           }, this);
           this.hls.on(Hls.Events.MEDIA_ATTACHED, function(event, data) {
-            if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+            if (!this.sessionActive(playbackSessionId)) return;
             console.log(`Video and hls.js are now bound together for monitor ID=${this.id}`);
           }, this);
           this.hls.on(Hls.Events.ERROR, function(event, data) {
-            if (!isCurrentPlaybackSession(this, playbackSessionId)) {
+            if (!this.sessionActive(playbackSessionId)) {
               //hlsDestroy(this);
               return;
             }
@@ -2135,7 +2134,7 @@ function MonitorStream(monitorData) {
     if (!stream) return;
 
     this.destroyVolumeSlider();
-    if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+    if (!this.sessionActive(playbackSessionId)) return;
 
     this.streamCmdTimer = clearInterval(this.streamCmdTimer);
     // Step 1 make sure we are streaming instead of a static image
@@ -2146,11 +2145,11 @@ function MonitorStream(monitorData) {
     const onLoad = this.img_onload.bind(this);
 
     stream.onerror = (e) => {
-      if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+      if (!this.sessionActive(playbackSessionId)) return;
       onError(e);
     };
     stream.onload = (e) => {
-      if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+      if (!this.sessionActive(playbackSessionId)) return;
       this.resetCountStreamErrors(this.activePlayer);
       onLoad(e);
     };
@@ -2199,14 +2198,14 @@ function MonitorStream(monitorData) {
       }
       if (stream.src != src) {
         //console.log("Setting src.src", stream.src, src);
-        if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+        if (!this.sessionActive(playbackSessionId)) return;
         stream.src = '';
         stream.src = src;
         // This isn't a duplicate of the code above. It's intentional. However, upon closer testing, the similar line above may prove unnecessary.
-        if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+        if (!this.sessionActive(playbackSessionId)) return;
       }
     } // end if paused or not
-    if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+    if (!this.sessionActive(playbackSessionId)) return;
     if (!this.isActive) {
       this.kill();
       return;
@@ -2328,6 +2327,11 @@ function MonitorStream(monitorData) {
       }
     }
   };
+
+  this.sessionActive = function(playbackSessionId) {
+    return (isCurrentPlaybackSession(this, playbackSessionId) && this.isActive);
+  }
+
 } // end class MonitorStream
 
 /* +++ Janus */
@@ -2529,26 +2533,26 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onnegotiationneeded = async function handleNegotiationNeeded() {
-    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+    if (!stream.sessionActive(playbackSessionId)) return;
 
     const offer = await stream.webrtc.createOffer({
       //iceRestart:true,
       offerToReceiveAudio: true,
       offerToReceiveVideo: true
     });
-    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+    if (!stream.sessionActive(playbackSessionId)) return;
     if (stream.webrtc.sctp && stream.webrtc.sctp.state != 'open') return;
 
     await stream.webrtc.setLocalDescription(offer);
     //console.log(stream.webrtc.localDescription.sdp);
-    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+    if (!stream.sessionActive(playbackSessionId)) return;
 
     $j.ajax({
       url: url,
       method: 'POST',
       data: {data: btoa(stream.webrtc.localDescription.sdp)},
       success: function(response) {
-        if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+        if (!stream.sessionActive(playbackSessionId)) return;
         if ((stream.webrtc && 'sctp' in stream.webrtc && stream.webrtc.sctp) && stream.webrtc.sctp.state != 'stable') {
           try {
             stream.webrtc.setRemoteDescription(new RTCSessionDescription({
@@ -2561,7 +2565,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
         }
       },
       error: function(xhr, status, error) {
-        if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+        if (!stream.sessionActive(playbackSessionId)) return;
         console.warn('RTSP2Web_webrtc Error request localDescription:', error, xhr.responseText);
         stream.updateStreamInfo('', 'Error'); //WEBRTC
         stream.streamErrorRegistration();
@@ -2574,7 +2578,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onsignalingstatechange = async function signalingstatechange() {
-    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+    if (!stream.sessionActive(playbackSessionId)) return;
 
     switch (stream.webrtc.signalingState) {
       case 'have-local-offer':
@@ -2599,7 +2603,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.ontrack = function ontrack(event) {
-    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+    if (!stream.sessionActive(playbackSessionId)) return;
 
     console.log(event.track.kind + ' track is delivered');
     mediaStream.addTrack(event.track);
@@ -2637,16 +2641,16 @@ function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE.binaryType = 'arraybuffer';
 
   context.wsMSE.onopen = function(event) {
-    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
+    if (!context.sessionActive(playbackSessionId)) return;
     console.log(`Connect to WebSocket MSE for a video object ID=${context.id}`);
   };
   context.wsMSE.onclose = (event) => {
-    if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
+    if (!context.sessionActive(playbackSessionId)) return;
     context.clearWebSocket();
     console.log(`${dateTimeToISOLocal(new Date())} WebSocket MSE CLOSED for a video object ID=${context.id}.`);
   };
   context.wsMSE.onerror = function(event) {
-    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
+    if (!context.sessionActive(playbackSessionId)) return;
     // Firefox will display error 1006 when closing the socket. There's likely a problem with RTSP2Web.
     console.warn(`${dateTimeToISOLocal(new Date())} WebSocket MSE ERROR for a video object ID=${context.id} [stream status: ${(context.started) ? "started" : "stopped"}]:`, event);
     if (context.started) {
@@ -2655,7 +2659,7 @@ function mseListenerSourceopen(context, videoEl, url) {
     }
   };
   context.wsMSE.onmessage = function(event) {
-    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
+    if (!context.sessionActive(playbackSessionId)) return;
     if (!context.mse || (context.mse && context.mse.readyState !== "open")) return;
     const data = new Uint8Array(event.data);
     if (data[0] === 9) {
@@ -2712,19 +2716,19 @@ function startMsePlay(context, videoEl, url) {
     clearTimeout(context.waitingStart);
   } else {
     context.waitingStart = setTimeout(function(_context) {
-      if (!isCurrentPlaybackSession(_context, playbackSessionId) || !_context.isActive) return;
-      if (context.started) startMsePlay(context, videoEl, url);
+      if (!_context.sessionActive(playbackSessionId)) return;
+      if (_context.started) startMsePlay(_context, videoEl, url);
     }, 100, context);
     return;
   }
 
   context.mse = new MediaSource();
   videoEl.onplay = (event) => {
-    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
+    if (!context.sessionActive(playbackSessionId)) return;
     context.mseWaitingErrorReset = setTimeout(function(self) {
       // If the video is in H.265, the browser may start playing (even if it doesn't support H.265) and an error may immediately appear.
       // You need to wait a bit before resetting the error. This will allow for more accurate error counting.
-      if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
+      if (!context.sessionActive(playbackSessionId)) return;
       self.updateStreamInfo('', ''); //MSE
       self.resetCountStreamErrors(context.activePlayer);
     }, 500, context);
@@ -2765,7 +2769,7 @@ function startMsePlay(context, videoEl, url) {
     console.debug("RTSP2Web type MSE started playing the video stream successfully.");
   })
       .catch((er) => {
-        if (!isCurrentPlaybackSession(self, playbackSessionId) || !self.isActive) return;
+        if (!self.sessionActive(playbackSessionId)) return;;
         if (er.name === 'NotAllowedError' && !videoEl.muted) {
           videoEl.muted = true;
           videoEl.play().then(() => {

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -2327,10 +2327,6 @@ function MonitorStream(monitorData) {
       }
     }
   };
-
-  this.sessionActive = function(playbackSessionId) {
-    return (isCurrentPlaybackSession(this, playbackSessionId) && this.isActive);
-  };
 } // end class MonitorStream
 
 /* +++ Janus */

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -609,7 +609,7 @@ function MonitorStream(monitorData) {
     this.handlerEventListener['errorStream'] = manageEventListener.addEventListener(stream, 'error',
         (e) => {
           clearTimeout(this.mseWaitingErrorReset);
-          if (!isCurrentPlaybackSession(this, playbackSessionId)) return;
+          if (!isCurrentPlaybackSession(this, playbackSessionId) || !this.isActive) return;
           const mediaErrorMsg = e?.target?.error?.message || e?.srcElement?.error?.message || 'Unknown media error';
           console.warn(`Stream playback error for monitor ID=${this.id}.`, `ERROR: ${mediaErrorMsg}`, e);
           this.writeTextInfoBlock("Error");
@@ -2501,6 +2501,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
     stream.RTSP2WebType = null; // Avoid repeated restarts.
     return;
   }
+  const playbackSessionId = stream.playbackSessionId;
   stream.updateStreamInfo('', 'loading');
 
   if (stream.webrtc) {
@@ -2528,20 +2529,26 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onnegotiationneeded = async function handleNegotiationNeeded() {
+    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+
     const offer = await stream.webrtc.createOffer({
       //iceRestart:true,
       offerToReceiveAudio: true,
       offerToReceiveVideo: true
     });
+    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
     if (stream.webrtc.sctp && stream.webrtc.sctp.state != 'open') return;
+
     await stream.webrtc.setLocalDescription(offer);
     //console.log(stream.webrtc.localDescription.sdp);
+    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
 
     $j.ajax({
       url: url,
       method: 'POST',
       data: {data: btoa(stream.webrtc.localDescription.sdp)},
       success: function(response) {
+        if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
         if ((stream.webrtc && 'sctp' in stream.webrtc && stream.webrtc.sctp) && stream.webrtc.sctp.state != 'stable') {
           try {
             stream.webrtc.setRemoteDescription(new RTCSessionDescription({
@@ -2554,6 +2561,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
         }
       },
       error: function(xhr, status, error) {
+        if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
         console.warn('RTSP2Web_webrtc Error request localDescription:', error, xhr.responseText);
         stream.updateStreamInfo('', 'Error'); //WEBRTC
         stream.streamErrorRegistration();
@@ -2566,6 +2574,8 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onsignalingstatechange = async function signalingstatechange() {
+    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+
     switch (stream.webrtc.signalingState) {
       case 'have-local-offer':
         //console.log("webrtc.onsignalingstatechange (connectionState): ", stream.webrtc.connectionState);
@@ -2589,6 +2599,8 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.ontrack = function ontrack(event) {
+    if (!isCurrentPlaybackSession(stream, playbackSessionId) || !stream.isActive) return;
+
     console.log(event.track.kind + ' track is delivered');
     mediaStream.addTrack(event.track);
   };
@@ -2625,7 +2637,7 @@ function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE.binaryType = 'arraybuffer';
 
   context.wsMSE.onopen = function(event) {
-    if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
+    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
     console.log(`Connect to WebSocket MSE for a video object ID=${context.id}`);
   };
   context.wsMSE.onclose = (event) => {
@@ -2634,7 +2646,7 @@ function mseListenerSourceopen(context, videoEl, url) {
     console.log(`${dateTimeToISOLocal(new Date())} WebSocket MSE CLOSED for a video object ID=${context.id}.`);
   };
   context.wsMSE.onerror = function(event) {
-    if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
+    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
     // Firefox will display error 1006 when closing the socket. There's likely a problem with RTSP2Web.
     console.warn(`${dateTimeToISOLocal(new Date())} WebSocket MSE ERROR for a video object ID=${context.id} [stream status: ${(context.started) ? "started" : "stopped"}]:`, event);
     if (context.started) {
@@ -2643,8 +2655,8 @@ function mseListenerSourceopen(context, videoEl, url) {
     }
   };
   context.wsMSE.onmessage = function(event) {
+    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
     if (!context.mse || (context.mse && context.mse.readyState !== "open")) return;
-    if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
     const data = new Uint8Array(event.data);
     if (data[0] === 9) {
       let mimeCodec;
@@ -2700,7 +2712,7 @@ function startMsePlay(context, videoEl, url) {
     clearTimeout(context.waitingStart);
   } else {
     context.waitingStart = setTimeout(function(_context) {
-      if (!isCurrentPlaybackSession(_context, playbackSessionId)) return;
+      if (!isCurrentPlaybackSession(_context, playbackSessionId) || !_context.isActive) return;
       if (context.started) startMsePlay(context, videoEl, url);
     }, 100, context);
     return;
@@ -2708,11 +2720,11 @@ function startMsePlay(context, videoEl, url) {
 
   context.mse = new MediaSource();
   videoEl.onplay = (event) => {
-    if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
+    if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
     context.mseWaitingErrorReset = setTimeout(function(self) {
       // If the video is in H.265, the browser may start playing (even if it doesn't support H.265) and an error may immediately appear.
       // You need to wait a bit before resetting the error. This will allow for more accurate error counting.
-      if (!isCurrentPlaybackSession(context, playbackSessionId)) return;
+      if (!isCurrentPlaybackSession(context, playbackSessionId) || !context.isActive) return;
       self.updateStreamInfo('', ''); //MSE
       self.resetCountStreamErrors(context.activePlayer);
     }, 500, context);
@@ -2753,6 +2765,7 @@ function startMsePlay(context, videoEl, url) {
     console.debug("RTSP2Web type MSE started playing the video stream successfully.");
   })
       .catch((er) => {
+        if (!isCurrentPlaybackSession(self, playbackSessionId) || !self.isActive) return;
         if (er.name === 'NotAllowedError' && !videoEl.muted) {
           videoEl.muted = true;
           videoEl.play().then(() => {

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -2330,8 +2330,7 @@ function MonitorStream(monitorData) {
 
   this.sessionActive = function(playbackSessionId) {
     return (isCurrentPlaybackSession(this, playbackSessionId) && this.isActive);
-  }
-
+  };
 } // end class MonitorStream
 
 /* +++ Janus */
@@ -2769,7 +2768,7 @@ function startMsePlay(context, videoEl, url) {
     console.debug("RTSP2Web type MSE started playing the video stream successfully.");
   })
       .catch((er) => {
-        if (!self.sessionActive(playbackSessionId)) return;;
+        if (!self.sessionActive(playbackSessionId)) return;
         if (er.name === 'NotAllowedError' && !videoEl.muted) {
           videoEl.muted = true;
           videoEl.play().then(() => {

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -547,13 +547,13 @@ function MonitorStream(monitorData) {
     }
     this.handlerEventListener['playStream'] = manageEventListener.addEventListener(stream, 'play',
         (e) => {
-          if (!this.sessionActive(playbackSessionId)) return;
+          if (!streamSessionActive(this, playbackSessionId)) return;
           this.writeTextInfoBlock("");
           this.createVolumeSlider();
 
           this.handlerEventListener['zm:tracksReceived'] = manageEventListener.addEventListener(this.getElement(), 'zm:tracksReceived',
               (e) => {
-                if (!this.sessionActive(playbackSessionId)) return;
+                if (!streamSessionActive(this, playbackSessionId)) return;
                 if (e.detail.monitorId !== this.id) return;
 
                 if (this.started) {
@@ -598,7 +598,7 @@ function MonitorStream(monitorData) {
     );
     this.handlerEventListener['pauseStream'] = manageEventListener.addEventListener(stream, 'pause',
         (e) => {
-          if (!this.sessionActive(playbackSessionId)) return;
+          if (!streamSessionActive(this, playbackSessionId)) return;
           this.writeTextInfoBlock("Paused", {showImg: false});
           manageEventListener.removeEventListener(this.handlerEventListener['volumechange']);
           if (typeof pauseAudioMotion === 'function') {
@@ -609,7 +609,7 @@ function MonitorStream(monitorData) {
     this.handlerEventListener['errorStream'] = manageEventListener.addEventListener(stream, 'error',
         (e) => {
           clearTimeout(this.mseWaitingErrorReset);
-          if (!this.sessionActive(playbackSessionId)) return;
+          if (!streamSessionActive(this, playbackSessionId)) return;
           const mediaErrorMsg = e?.target?.error?.message || e?.srcElement?.error?.message || 'Unknown media error';
           console.warn(`Stream playback error for monitor ID=${this.id}.`, `ERROR: ${mediaErrorMsg}`, e);
           this.writeTextInfoBlock("Error");
@@ -984,7 +984,7 @@ function MonitorStream(monitorData) {
     if (countErrors < this.limitCountErrors) {
       const playbackSessionId = this.playbackSessionId;
       setTimeout(function(self) {// During the downtime, the monitor may have already started to work.
-        if (!self.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(self, playbackSessionId)) return;
         if (!self.started && !self.starting) self.start(channelStream);
       }, delay, this);
     } else {
@@ -2013,12 +2013,12 @@ function MonitorStream(monitorData) {
           */
 
           this.hls.on(Hls.Events.MEDIA_ATTACHING, function(event, data) {
-            if (!this.sessionActive(playbackSessionId)) return;
+            if (!streamSessionActive(this, playbackSessionId)) return;
             console.debug(`HLS Event = MEDIA_ATTACHING for monitor ID=${this.id}`);
           }, this);
           this.hls.on(Hls.Events.BUFFER_CODECS, function(event, data) {
             // Triggers if there is an audio track.
-            if (!this.sessionActive(playbackSessionId)) {
+            if (!streamSessionActive(this, playbackSessionId)) {
               //hlsDestroy(this);
               return;
             }
@@ -2033,11 +2033,11 @@ function MonitorStream(monitorData) {
             }
           }, this);
           this.hls.on(Hls.Events.MEDIA_ATTACHED, function(event, data) {
-            if (!this.sessionActive(playbackSessionId)) return;
+            if (!streamSessionActive(this, playbackSessionId)) return;
             console.log(`Video and hls.js are now bound together for monitor ID=${this.id}`);
           }, this);
           this.hls.on(Hls.Events.ERROR, function(event, data) {
-            if (!this.sessionActive(playbackSessionId)) {
+            if (!streamSessionActive(this, playbackSessionId)) {
               //hlsDestroy(this);
               return;
             }
@@ -2134,7 +2134,7 @@ function MonitorStream(monitorData) {
     if (!stream) return;
 
     this.destroyVolumeSlider();
-    if (!this.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(this, playbackSessionId)) return;
 
     this.streamCmdTimer = clearInterval(this.streamCmdTimer);
     // Step 1 make sure we are streaming instead of a static image
@@ -2145,11 +2145,11 @@ function MonitorStream(monitorData) {
     const onLoad = this.img_onload.bind(this);
 
     stream.onerror = (e) => {
-      if (!this.sessionActive(playbackSessionId)) return;
+      if (!streamSessionActive(this, playbackSessionId)) return;
       onError(e);
     };
     stream.onload = (e) => {
-      if (!this.sessionActive(playbackSessionId)) return;
+      if (!streamSessionActive(this, playbackSessionId)) return;
       this.resetCountStreamErrors(this.activePlayer);
       onLoad(e);
     };
@@ -2198,14 +2198,14 @@ function MonitorStream(monitorData) {
       }
       if (stream.src != src) {
         //console.log("Setting src.src", stream.src, src);
-        if (!this.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(this, playbackSessionId)) return;
         stream.src = '';
         stream.src = src;
         // This isn't a duplicate of the code above. It's intentional. However, upon closer testing, the similar line above may prove unnecessary.
-        if (!this.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(this, playbackSessionId)) return;
       }
     } // end if paused or not
-    if (!this.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(this, playbackSessionId)) return;
     if (!this.isActive) {
       this.kill();
       return;
@@ -2532,26 +2532,26 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onnegotiationneeded = async function handleNegotiationNeeded() {
-    if (!stream.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(stream, playbackSessionId)) return;
 
     const offer = await stream.webrtc.createOffer({
       //iceRestart:true,
       offerToReceiveAudio: true,
       offerToReceiveVideo: true
     });
-    if (!stream.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(stream, playbackSessionId)) return;
     if (stream.webrtc.sctp && stream.webrtc.sctp.state != 'open') return;
 
     await stream.webrtc.setLocalDescription(offer);
     //console.log(stream.webrtc.localDescription.sdp);
-    if (!stream.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(stream, playbackSessionId)) return;
 
     $j.ajax({
       url: url,
       method: 'POST',
       data: {data: btoa(stream.webrtc.localDescription.sdp)},
       success: function(response) {
-        if (!stream.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(stream, playbackSessionId)) return;
         if ((stream.webrtc && 'sctp' in stream.webrtc && stream.webrtc.sctp) && stream.webrtc.sctp.state != 'stable') {
           try {
             stream.webrtc.setRemoteDescription(new RTCSessionDescription({
@@ -2564,7 +2564,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
         }
       },
       error: function(xhr, status, error) {
-        if (!stream.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(stream, playbackSessionId)) return;
         console.warn('RTSP2Web_webrtc Error request localDescription:', error, xhr.responseText);
         stream.updateStreamInfo('', 'Error'); //WEBRTC
         stream.streamErrorRegistration();
@@ -2577,7 +2577,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.onsignalingstatechange = async function signalingstatechange() {
-    if (!stream.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(stream, playbackSessionId)) return;
 
     switch (stream.webrtc.signalingState) {
       case 'have-local-offer':
@@ -2602,7 +2602,7 @@ function startRTSP2WebPlay(videoEl, url, stream) {
   };
 
   stream.webrtc.ontrack = function ontrack(event) {
-    if (!stream.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(stream, playbackSessionId)) return;
 
     console.log(event.track.kind + ' track is delivered');
     mediaStream.addTrack(event.track);
@@ -2610,12 +2610,16 @@ function startRTSP2WebPlay(videoEl, url, stream) {
 
   const webrtcSendChannel = stream.webrtc.createDataChannel('rtsptowebSendChannel');
   webrtcSendChannel.onopen = (event) => {
+    if (!streamSessionActive(stream, playbackSessionId)) return;
+
     stream.updateStreamInfo('', ''); //WEBRTC
     //getTracksFromStream(stream); //WEBRTC
     console.log(`${webrtcSendChannel.label} for camera ID=${stream.id} has opened`);
     webrtcSendChannel.send('ping');
   };
   webrtcSendChannel.onclose = (_event) => {
+    if (!streamSessionActive(stream, playbackSessionId)) return;
+
     if (stream.started) {
       console.warn(`UNSCHEDULED CLOSE ${webrtcSendChannel.label} for camera ID=${stream.id}. We execute "stream.restart"`);
       stream.streamErrorRegistration();
@@ -2640,16 +2644,16 @@ function mseListenerSourceopen(context, videoEl, url) {
   context.wsMSE.binaryType = 'arraybuffer';
 
   context.wsMSE.onopen = function(event) {
-    if (!context.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(context, playbackSessionId)) return;
     console.log(`Connect to WebSocket MSE for a video object ID=${context.id}`);
   };
   context.wsMSE.onclose = (event) => {
-    if (!context.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(context, playbackSessionId)) return;
     context.clearWebSocket();
     console.log(`${dateTimeToISOLocal(new Date())} WebSocket MSE CLOSED for a video object ID=${context.id}.`);
   };
   context.wsMSE.onerror = function(event) {
-    if (!context.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(context, playbackSessionId)) return;
     // Firefox will display error 1006 when closing the socket. There's likely a problem with RTSP2Web.
     console.warn(`${dateTimeToISOLocal(new Date())} WebSocket MSE ERROR for a video object ID=${context.id} [stream status: ${(context.started) ? "started" : "stopped"}]:`, event);
     if (context.started) {
@@ -2658,7 +2662,7 @@ function mseListenerSourceopen(context, videoEl, url) {
     }
   };
   context.wsMSE.onmessage = function(event) {
-    if (!context.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(context, playbackSessionId)) return;
     if (!context.mse || (context.mse && context.mse.readyState !== "open")) return;
     const data = new Uint8Array(event.data);
     if (data[0] === 9) {
@@ -2715,7 +2719,7 @@ function startMsePlay(context, videoEl, url) {
     clearTimeout(context.waitingStart);
   } else {
     context.waitingStart = setTimeout(function(_context) {
-      if (!_context.sessionActive(playbackSessionId)) return;
+      if (!streamSessionActive(_context, playbackSessionId)) return;
       if (_context.started) startMsePlay(_context, videoEl, url);
     }, 100, context);
     return;
@@ -2723,11 +2727,11 @@ function startMsePlay(context, videoEl, url) {
 
   context.mse = new MediaSource();
   videoEl.onplay = (event) => {
-    if (!context.sessionActive(playbackSessionId)) return;
+    if (!streamSessionActive(context, playbackSessionId)) return;
     context.mseWaitingErrorReset = setTimeout(function(self) {
       // If the video is in H.265, the browser may start playing (even if it doesn't support H.265) and an error may immediately appear.
       // You need to wait a bit before resetting the error. This will allow for more accurate error counting.
-      if (!context.sessionActive(playbackSessionId)) return;
+      if (!streamSessionActive(context, playbackSessionId)) return;
       self.updateStreamInfo('', ''); //MSE
       self.resetCountStreamErrors(context.activePlayer);
     }, 500, context);
@@ -2768,7 +2772,7 @@ function startMsePlay(context, videoEl, url) {
     console.debug("RTSP2Web type MSE started playing the video stream successfully.");
   })
       .catch((er) => {
-        if (!self.sessionActive(playbackSessionId)) return;
+        if (!streamSessionActive(self, playbackSessionId)) return;
         if (er.name === 'NotAllowedError' && !videoEl.muted) {
           videoEl.muted = true;
           videoEl.play().then(() => {

--- a/web/js/video-stream.js
+++ b/web/js/video-stream.js
@@ -174,7 +174,7 @@ class VideoStream extends VideoRTC {
     errorHandling(currentMode, message = null) {
         const monitorStream = getMonitorStream(stringToNumber(this.id));
         if (monitorStream) {
-            if (!isCurrentPlaybackSession(monitorStream, this.playbackSessionId)) return;
+            if (!monitorStream.sessionActive(this.playbackSessionId)) return;
             monitorStream.player = "go2rtc_" + currentMode;
             monitorStream.streamErrorRegistration();
             monitorStream.restart(monitorStream.currentChannelStream);

--- a/web/js/video-stream.js
+++ b/web/js/video-stream.js
@@ -174,7 +174,7 @@ class VideoStream extends VideoRTC {
     errorHandling(currentMode, message = null) {
         const monitorStream = getMonitorStream(stringToNumber(this.id));
         if (monitorStream) {
-            if (!monitorStream.sessionActive(this.playbackSessionId)) return;
+            if (!streamSessionActive(monitorStream, this.playbackSessionId)) return;
             monitorStream.player = "go2rtc_" + currentMode;
             monitorStream.streamErrorRegistration();
             monitorStream.restart(monitorStream.currentChannelStream);

--- a/web/skins/classic/js/audioMotionAnalyzer.js
+++ b/web/skins/classic/js/audioMotionAnalyzer.js
@@ -335,7 +335,7 @@ export class _AudioMotionAnalyzer extends HTMLElement {
       this.gainNode = null;
     }
 
-    if (!isCurrentPlaybackSession(monitorStream, this.playbackSessionId)) {
+    if (!monitorStream.sessionActive(this.playbackSessionId)) {
       console.debug(`RACE [${this.playbackSessionId}] AudioMotion.connectToMediaStreamSource() for monitor ID=${this.mid} aborted`);
       return;
     }

--- a/web/skins/classic/js/audioMotionAnalyzer.js
+++ b/web/skins/classic/js/audioMotionAnalyzer.js
@@ -335,7 +335,7 @@ export class _AudioMotionAnalyzer extends HTMLElement {
       this.gainNode = null;
     }
 
-    if (!monitorStream.sessionActive(this.playbackSessionId)) {
+    if (!streamSessionActive(monitorStream, this.playbackSessionId)) {
       console.debug(`RACE [${this.playbackSessionId}] AudioMotion.connectToMediaStreamSource() for monitor ID=${this.mid} aborted`);
       return;
     }

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -3386,7 +3386,7 @@ async function getTracksFromStream(videoFeedStream) {
     console.warn(`"captureStream" NOT found in STREAM for monitor ID=${mid} or not supported by the browser.`);
     streamCaptureNotSupported = true; // This will enable the volume control if the browser does not support captureStream (for example, Safari)
   }
-  if (!(("sessionActive" in videoFeedStream) ? videoFeedStream.sessionActive(playbackSessionId) : isCurrentPlaybackSession(videoFeedStream, playbackSessionId))) {
+  if (!streamSessionActive(videoFeedStream, playbackSessionId)) {
     console.debug(`RACE [${playbackSessionId}] getTracksFromStream() aborted`);
     stopMediaStreamTracks(stream);
     dispatchTracksReceived(videoFeedStream, {
@@ -3400,7 +3400,7 @@ async function getTracksFromStream(videoFeedStream) {
     const timeoutStreamActive = 20000;
     const startTime = Date.now();
     const streamActive = await waitUntil(() => (stream.active || videoFeedStream.started === false), timeoutStreamActive); // We are waiting for the stream to become active.
-    if (!(("sessionActive" in videoFeedStream) ? videoFeedStream.sessionActive(playbackSessionId) : isCurrentPlaybackSession(videoFeedStream, playbackSessionId))) {
+    if (!streamSessionActive(videoFeedStream, playbackSessionId)) {
       console.debug(`RACE [${playbackSessionId}] waitUntil() aborted`);
       stopMediaStreamTracks(stream);
       dispatchTracksReceived(videoFeedStream, {
@@ -3955,5 +3955,9 @@ function generateUUID() {
 function isCurrentPlaybackSession(videoFeedStream, playbackSessionId) {
   return playbackSessionId === videoFeedStream.playbackSessionId;
 }
+
+function streamSessionActive(stream, playbackSessionId) {
+  return (isCurrentPlaybackSession(stream, playbackSessionId) && (("sessionActive" in stream) ? stream.isActive : true));
+};
 
 $j( window ).on("load", initPageGeneral);

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -3386,7 +3386,7 @@ async function getTracksFromStream(videoFeedStream) {
     console.warn(`"captureStream" NOT found in STREAM for monitor ID=${mid} or not supported by the browser.`);
     streamCaptureNotSupported = true; // This will enable the volume control if the browser does not support captureStream (for example, Safari)
   }
-  if (!isCurrentPlaybackSession(videoFeedStream, playbackSessionId)) {
+  if (!(("sessionActive" in videoFeedStream) ? videoFeedStream.sessionActive(playbackSessionId) : isCurrentPlaybackSession(videoFeedStream, playbackSessionId))) {
     console.debug(`RACE [${playbackSessionId}] getTracksFromStream() aborted`);
     stopMediaStreamTracks(stream);
     dispatchTracksReceived(videoFeedStream, {
@@ -3400,7 +3400,7 @@ async function getTracksFromStream(videoFeedStream) {
     const timeoutStreamActive = 20000;
     const startTime = Date.now();
     const streamActive = await waitUntil(() => (stream.active || videoFeedStream.started === false), timeoutStreamActive); // We are waiting for the stream to become active.
-    if (!isCurrentPlaybackSession(videoFeedStream, playbackSessionId)) {
+    if (!(("sessionActive" in videoFeedStream) ? videoFeedStream.sessionActive(playbackSessionId) : isCurrentPlaybackSession(videoFeedStream, playbackSessionId))) {
       console.debug(`RACE [${playbackSessionId}] waitUntil() aborted`);
       stopMediaStreamTracks(stream);
       dispatchTracksReceived(videoFeedStream, {


### PR DESCRIPTION
Now we will always check session activity using two parameters using MonitorStream.sessionActive():
1. Using "playbackSessionId" to monitor player changes within a single monitor.
2. Using MonitorStream.isActive to monitor monitor changes.