### PR TITLE
fix: surface API authorization failures instead of leaving the page looking loaded

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -1118,10 +1118,41 @@ function escapeHTML(text) {
       .replace(/'/g, '&#39;');
 }
 
+// A 401 or 403 from the API used to reach the console and nowhere else, so a
+// view like montagereview looked like it had loaded and was simply empty. Shown
+// once per page load: a view that fetches per monitor would otherwise stack up
+// one dialog per request.
+let apiAuthFailureReported = false;
+function reportApiAuthFailure(jqxhr) {
+  if (apiAuthFailureReported) return;
+  apiAuthFailureReported = true;
+
+  let detail = '';
+  try {
+    const parsed = JSON.parse(jqxhr.responseText);
+    if (parsed && parsed.message) detail = parsed.message;
+  } catch {
+    // Not JSON, so fall back to the generic message below.
+  }
+
+  // The usual one is "API disabled for: <user>", where what to do about it is
+  // not obvious from the message, so point at the setting.
+  alert(
+      (detail ? detail + '\n\n' : '') +
+      'This page could not load its data because the API rejected the request. ' +
+      'If the API is disabled for your account, an administrator can enable it ' +
+      'under Options, Users.');
+}
+
 function logAjaxFail(jqxhr, textStatus, error) {
   if (jqxhr.statusText == 'abort') {
     console.log('request aborted');
     return;
+  }
+  // Before the responseText check below, because an auth failure with an empty
+  // body still needs to reach the user.
+  if ((jqxhr.status === 401) || (jqxhr.status === 403)) {
+    reportApiAuthFailure(jqxhr);
   }
   if (!jqxhr.responseText) {
     console.log("Ajax request failed.  No responseText.  jqxhr follows:\n", jqxhr);

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -1260,7 +1260,7 @@ function loadEventData(e) {
         success: receive_events,
         error: function(jqXHR) {
           ajax = null;
-          console.log("error", jqXHR);
+          logAjaxFail(jqXHR);
         }
       });
     } // end foreach monitor
@@ -1274,7 +1274,7 @@ function loadEventData(e) {
       success: receive_events,
       error: function(jqXHR) {
         ajax = null;
-        console.log("error", jqXHR);
+        logAjaxFail(jqXHR);
       }
     });
   }


### PR DESCRIPTION
Fixes #4908. Targets release-1.38, per your note on the issue that 1.38 should pop up a useful error.

A 401 from the API only ever reached the console, so montagereview looked like it had loaded and was simply empty. Its two error handlers did not even call logAjaxFail, they just console.log'd.

logAjaxFail now shows a 401 or 403 to the user, quoting the API's own message ("API disabled for: admin") and saying an administrator can enable it under Options, Users, since that is not obvious from the message alone. Everything else still goes to the console as before. It fires once per page load because montagereview requests one URL per monitor and would otherwise stack up a dialog for each. The check sits before the responseText early return so an auth failure with an empty body still gets through.

That covers the other 96 logAjaxFail call sites too, not just this page.

The 1.39 half of your note, removing the ability to disable the API, is a separate change and not in here.

Checked by driving logAjaxFail directly: the reported 401 alerts once and quotes the message, ten repeats stay at one dialog, an abort stays silent, a 401 with an empty body still alerts, a non-JSON body does not throw, and a 500 does not alert. eslint clean.
