### PR TITLE
fix: do not add zmrepo apt source when a PPA already provides ZoneMinder

### DIFF
--- a/distros/ubuntu2004/zoneminder.postinst
+++ b/distros/ubuntu2004/zoneminder.postinst
@@ -160,7 +160,30 @@ else
   echo "Not doing database upgrade due to remote db server ($ZM_DB_HOST)."
 fi
 
-if [ ! -f /etc/apt/sources.list.d/zoneminder.list ] && [ ! -f /etc/apt/sources.list.d/zoneminder.sources ]; then
+# Only add the zmrepo source when nothing already provides ZoneMinder. Looking
+# for our own filenames is not enough: the Launchpad PPA installs its source as
+# iconnor-ubuntu-zoneminder-<codename>.list, so a PPA install fell through this
+# check and got a second, competing source added here. zmrepo's versions sort
+# higher (1.38.3+noble1 beats 1.38.3-noble), so the next upgrade replaced the
+# PPA package. See zoneminder/zoneminder#4945.
+zm_apt_source_exists () {
+  [ -f /etc/apt/sources.list.d/zoneminder.list ] && return 0
+  [ -f /etc/apt/sources.list.d/zoneminder.sources ] && return 0
+  # Match on content rather than filename, so a PPA or a hand-written source
+  # under any name is found, in either one-line or deb822 format. Each path is
+  # checked separately and only if it exists: grep exits 2 when any argument is
+  # missing, even after matching in another, and /etc/apt/sources.list is absent
+  # on releases that have moved to deb822.
+  for zm_apt_src in /etc/apt/sources.list /etc/apt/sources.list.d; do
+    [ -e "$zm_apt_src" ] || continue
+    if grep -rqsE 'zmrepo\.zoneminder\.com|ppa\.launchpad(content)?\.net/iconnor' "$zm_apt_src"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if ! zm_apt_source_exists; then
   wget -O - https://zmrepo.zoneminder.com/debian/archive-keyring.gpg | sudo tee /etc/apt/trusted.gpg.d/zmrepo.asc
 
   # Resolve the apt codename for the zmrepo source line. Derivatives such as


### PR DESCRIPTION
Fixes #4945.

The postinst only checked for zoneminder.list and zoneminder.sources before adding the zmrepo source. A PPA install lands as iconnor-ubuntu-zoneminder-<codename>.list, so it fell through and got a second, competing source. zmrepo then wins on version (1.38.3+noble1 beats 1.38.3-noble) and replaces the PPA package on the next upgrade.

Now it also greps the existing sources for zmrepo.zoneminder.com or a launchpad iconnor PPA, matching on content rather than filename so a hand-written or deb822 source is found too.

One detail worth mentioning: the paths are checked one at a time and only if they exist. grep exits 2 when any argument is missing even after matching in another, and /etc/apt/sources.list is often absent now that Ubuntu has moved to deb822, so a single grep over both paths silently failed on exactly the systems this is meant to help.

Checked against fake apt trees in both layouts, with and without /etc/apt/sources.list: clean system, our own list and sources files, the reported PPA, the older ppa.launchpad.net host, a PPA in deb822 form, zmrepo under a different filename, and an unrelated repo that must not suppress it. Also confirmed the old check does add a competing source in the reported case.

Same bug is on release-1.38, where the source line points at release-1.38 rather than master. Happy to send that separately if you want it.
