### PR TITLE
fix: stop fps log spam before the first report interval

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -274,6 +274,7 @@ Monitor::Monitor() :
   event_count(0),
   //image_count(0),
   last_capture_image_count(0),
+  fps_reported(false),
   analysis_image_count(0),
   decoding_image_count(0),
   motion_frame_count(0),
@@ -1308,6 +1309,7 @@ bool Monitor::connect() {
   last_fps_time = std::chrono::system_clock::now();
   last_analysis_fps_time = std::chrono::system_clock::now();
   last_capture_image_count = 0;
+  fps_reported = false;
 
   Debug(3, "Success connecting");
   return true;
@@ -2049,13 +2051,17 @@ void Monitor::UpdateFPS() {
         new_capture_fps,
         new_analysis_fps);
 
+    // Report on the configured interval, plus once at startup so a fresh
+    // process shows an fps promptly instead of staying silent for a whole
+    // interval. This used to report every 10 frames for the whole of the first
+    // interval, and since the block above runs at most once a second that came
+    // out as a line a second: a 10fps camera with an interval of 36000 logged
+    // roughly 3600 times before quieting down. See
+    // https://github.com/ZoneMinder/zoneminder/issues/3269
     if ( fps_report_interval and
-        (
-         !(shared_data->image_count%fps_report_interval)
-         or
-         ( (shared_data->image_count < fps_report_interval) and !(shared_data->image_count%10) )
-        )
+        ( !fps_reported or !(shared_data->image_count%fps_report_interval) )
        ) {
+      fps_reported = true;
       Info("%s: %d - Capturing at %.2lf fps, capturing bandwidth %ubytes/sec Analysing at %.2lf fps",
           name.c_str(), shared_data->image_count, new_capture_fps, new_capture_bandwidth, new_analysis_fps);
 

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -658,6 +658,9 @@ class Monitor : public std::enable_shared_from_this<Monitor> {
 
   int        event_count;
   int        last_capture_image_count; // last value of image_count when calculating capture fps
+  // Whether an fps line has been logged yet. A fresh process reports once
+  // promptly rather than staying silent for a whole fps_report_interval.
+  bool       fps_reported;
   int        analysis_image_count;    // How many frames have been processed by analysis thread.
   int        decoding_image_count;    // How many frames have been processed by analysis thread.
   int        motion_frame_count;      // How many frames have had motion detection performed on them.


### PR DESCRIPTION
Fixes #3269.

UpdateFPS reported whenever image_count hit fps_report_interval, or, while image_count was still below the interval, every 10 frames. The enclosing block already runs at most once a second, so that second clause works out as one line per second for the whole of the first interval. The reporter's 10fps camera with an interval of 36000 logged about 3600 times in its first hour before quieting down.

Now it reports once at startup and then on the interval. That keeps what the early clause was presumably for, not staying silent for a whole interval on a fresh process, without the spam.

Modelled both predicates over a simulated run with the one-per-second gate: the reported case goes from 3600 lines in the first hour to 2, and over 24 hours from 3623 to 25, which is the startup line plus one per hour. Small intervals are barely affected, 30fps with interval 100 goes from 63 to 61 over ten minutes. Suite passes, 143 cases, and zmc builds warning free.
