### PR TITLE
fix: rate limit the non increasing dts warning

### DIFF
--- a/src/zm_log_throttle.h
+++ b/src/zm_log_throttle.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ZM_LOG_THROTTLE_H
+#define ZM_LOG_THROTTLE_H
+
+#include "zm_define.h"
+#include "zm_time.h"
+
+// Rate limit for a message that can arrive on every packet. Keeps the message
+// rather than dropping its level, emitting at most one per interval and
+// counting the ones it swallowed so the next one through can say how many there
+// were.
+//
+// The caller passes the time in, as a TimePoint, which is steady_clock. That is
+// deliberate and load bearing: measuring an interval off the wall clock lets an
+// NTP step or a manual correction decide whether a message is emitted, muting
+// it until wall time catches up after a backward step and letting an extra
+// through early after a forward one. SystemTimePoint is a distinct type, so
+// handing this a wall clock reading does not compile. Taking the time as an
+// argument also makes the decision testable without waiting on a real clock.
+// refs #4242
+class LogThrottle {
+ public:
+  explicit LogThrottle(Microseconds interval = Seconds(1)) : interval_(interval) {}
+
+  // True when the caller should emit the message, setting suppressed to the
+  // number folded in since the last emission. On false the occurrence is
+  // counted and suppressed is left alone.
+  bool Admit(TimePoint now, uint64 &suppressed) {
+    if (have_last_ and ((now - last_) < interval_)) {
+      suppressed_++;
+      return false;
+    }
+    suppressed = suppressed_;
+    suppressed_ = 0;
+    last_ = now;
+    have_last_ = true;
+    return true;
+  }
+
+  uint64 suppressed() const { return suppressed_; }
+
+ private:
+  Microseconds interval_;
+  TimePoint last_ = {};
+  bool have_last_ = false;
+  uint64 suppressed_ = 0;
+};
+
+#endif  // ZM_LOG_THROTTLE_H

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -1526,9 +1526,26 @@ int VideoStore::write_packet(AVPacket *pkt, AVStream *stream) {
   } else {
     if (last_dts[stream->index] != AV_NOPTS_VALUE) {
       if (pkt->dts < last_dts[stream->index]) {
-        Warning("non increasing dts, fixing. our dts %" PRId64 " stream %d last_dts %" PRId64 " last_duration %" PRId64 " (%.3f seconds back). reorder_queue_size=%zu",
-            pkt->dts, stream->index, last_dts[stream->index], last_duration[stream->index],
-            (last_dts[stream->index] - pkt->dts) * av_q2d(stream->time_base), reorder_queue_size);
+        // Cameras with sloppy timestamps do this on nearly every packet, so at
+        // one message per packet the log fills at frame rate and buries
+        // everything else (#4242). The message is worth keeping, so rate limit
+        // it to one a second per stream and carry the count of the ones folded
+        // into it rather than dropping it to Debug.
+        const SystemTimePoint now = std::chrono::system_clock::now();
+        const int index = stream->index;
+        if (!last_dts_warning.count(index) or (now - last_dts_warning[index] >= Seconds(1))) {
+          Warning("non increasing dts, fixing. our dts %" PRId64 " stream %d last_dts %" PRId64 " last_duration %" PRId64 " (%.3f seconds back). reorder_queue_size=%zu%s",
+              pkt->dts, stream->index, last_dts[stream->index], last_duration[stream->index],
+              (last_dts[stream->index] - pkt->dts) * av_q2d(stream->time_base), reorder_queue_size,
+              suppressed_dts_warnings[index]
+                ? stringtf(" (%" PRIu64 " more since the last of these)",
+                           suppressed_dts_warnings[index]).c_str()
+                : "");
+          last_dts_warning[index] = now;
+          suppressed_dts_warnings[index] = 0;
+        } else {
+          suppressed_dts_warnings[index]++;
+        }
         pkt->dts = last_dts[stream->index]+last_duration[stream->index];
         if (pkt->dts > pkt->pts) pkt->pts = pkt->dts; // Do it here to avoid warning below
       } else if (pkt->dts == last_dts[stream->index]) {

--- a/src/zm_videostore.cpp
+++ b/src/zm_videostore.cpp
@@ -1530,21 +1530,17 @@ int VideoStore::write_packet(AVPacket *pkt, AVStream *stream) {
         // one message per packet the log fills at frame rate and buries
         // everything else (#4242). The message is worth keeping, so rate limit
         // it to one a second per stream and carry the count of the ones folded
-        // into it rather than dropping it to Debug.
-        const SystemTimePoint now = std::chrono::system_clock::now();
-        const int index = stream->index;
-        if (!last_dts_warning.count(index) or (now - last_dts_warning[index] >= Seconds(1))) {
+        // into it rather than dropping it to Debug. steady_clock, so that an
+        // NTP correction cannot decide whether a warning is emitted.
+        const TimePoint now = std::chrono::steady_clock::now();
+        uint64 suppressed = 0;
+        if (dts_warning_throttle[stream->index].Admit(now, suppressed)) {
           Warning("non increasing dts, fixing. our dts %" PRId64 " stream %d last_dts %" PRId64 " last_duration %" PRId64 " (%.3f seconds back). reorder_queue_size=%zu%s",
               pkt->dts, stream->index, last_dts[stream->index], last_duration[stream->index],
               (last_dts[stream->index] - pkt->dts) * av_q2d(stream->time_base), reorder_queue_size,
-              suppressed_dts_warnings[index]
-                ? stringtf(" (%" PRIu64 " more since the last of these)",
-                           suppressed_dts_warnings[index]).c_str()
+              suppressed
+                ? stringtf(" (%" PRIu64 " more since the last of these)", suppressed).c_str()
                 : "");
-          last_dts_warning[index] = now;
-          suppressed_dts_warnings[index] = 0;
-        } else {
-          suppressed_dts_warnings[index]++;
         }
         pkt->dts = last_dts[stream->index]+last_duration[stream->index];
         if (pkt->dts > pkt->pts) pkt->pts = pkt->dts; // Do it here to avoid warning below

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -5,6 +5,7 @@
 #include "zm_define.h"
 #include "zm_ffmpeg.h"
 #include "zm_swscale.h"
+#include "zm_time.h"
 
 #include <list>
 #include <memory>
@@ -89,6 +90,12 @@ class VideoStore {
   int64_t *next_dts;
   std::map<int, int64_t> last_dts;
   std::map<int, int64_t> last_duration;
+  // Cameras with sloppy timestamps hand us a decreasing dts on nearly every
+  // packet, so warning per packet floods the log at frame rate. See #4242.
+  // Kept per stream: when the last one was logged, and how many have been
+  // folded into the next message.
+  std::map<int, SystemTimePoint> last_dts_warning;
+  std::map<int, uint64_t> suppressed_dts_warnings;
   int64_t audio_next_pts;
 
   int max_stream_index;

--- a/src/zm_videostore.h
+++ b/src/zm_videostore.h
@@ -5,6 +5,7 @@
 #include "zm_define.h"
 #include "zm_ffmpeg.h"
 #include "zm_swscale.h"
+#include "zm_log_throttle.h"
 #include "zm_time.h"
 
 #include <list>
@@ -91,11 +92,9 @@ class VideoStore {
   std::map<int, int64_t> last_dts;
   std::map<int, int64_t> last_duration;
   // Cameras with sloppy timestamps hand us a decreasing dts on nearly every
-  // packet, so warning per packet floods the log at frame rate. See #4242.
-  // Kept per stream: when the last one was logged, and how many have been
-  // folded into the next message.
-  std::map<int, SystemTimePoint> last_dts_warning;
-  std::map<int, uint64_t> suppressed_dts_warnings;
+  // packet, so warning per packet floods the log at frame rate. One throttle
+  // per stream. See #4242.
+  std::map<int, LogThrottle> dts_warning_throttle;
   int64_t audio_next_pts;
 
   int max_stream_index;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_SOURCES
   zm_zone.cpp
   zm_zone_stride.cpp
   zm_image_linesize.cpp
+  zm_log_throttle.cpp
   zm_logger_rotate.cpp
   zm_ffmpeg_camera.cpp
   zm_ffmpeg_fallback.cpp)

--- a/tests/zm_log_throttle.cpp
+++ b/tests/zm_log_throttle.cpp
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_log_throttle.h"
+
+#include <type_traits>
+
+namespace {
+// Synthetic steady time, so the decision is exercised without waiting.
+TimePoint at(Microseconds offset) {
+  return TimePoint{} + offset;
+}
+}  // namespace
+
+TEST_CASE("LogThrottle admits one per interval") {
+  LogThrottle throttle(Seconds(1));
+  uint64 suppressed = 0;
+
+  SECTION("the first occurrence always gets through") {
+    REQUIRE(throttle.Admit(at(Seconds(0)), suppressed));
+    REQUIRE(suppressed == 0);
+  }
+
+  SECTION("occurrences inside the interval are counted, not emitted") {
+    REQUIRE(throttle.Admit(at(Seconds(0)), suppressed));
+    for (int i = 1; i <= 20; i++) {
+      REQUIRE_FALSE(throttle.Admit(at(Milliseconds(i * 10)), suppressed));
+    }
+    REQUIRE(throttle.suppressed() == 20);
+  }
+
+  SECTION("the next one through reports how many were folded in") {
+    REQUIRE(throttle.Admit(at(Seconds(0)), suppressed));
+    for (int i = 1; i <= 5; i++) {
+      REQUIRE_FALSE(throttle.Admit(at(Milliseconds(i * 100)), suppressed));
+    }
+    REQUIRE(throttle.Admit(at(Seconds(1)), suppressed));
+    REQUIRE(suppressed == 5);
+    // and the count starts again for the next window
+    REQUIRE(throttle.suppressed() == 0);
+  }
+
+  SECTION("exactly at the interval counts as elapsed") {
+    REQUIRE(throttle.Admit(at(Seconds(0)), suppressed));
+    REQUIRE(throttle.Admit(at(Seconds(1)), suppressed));
+  }
+
+  SECTION("a long quiet gap still only emits once") {
+    REQUIRE(throttle.Admit(at(Seconds(0)), suppressed));
+    REQUIRE(throttle.Admit(at(Seconds(3600)), suppressed));
+    REQUIRE(suppressed == 0);
+  }
+}
+
+TEST_CASE("LogThrottle is not affected by wall clock corrections") {
+  // The reason the interval is measured on steady_clock. Sampling the wall
+  // clock instead let an NTP or manual correction decide whether a message was
+  // emitted: a backward step muted it until wall time caught up, and a forward
+  // step let an extra through before a real second had passed. refs #4242
+  LogThrottle throttle(Seconds(1));
+  uint64 suppressed = 0;
+
+  SECTION("ten real seconds emit ten times however the wall clock moves") {
+    // Real elapsed time advances one second at a time. A wall clock corrected
+    // backwards to zero at this point would have suppressed all of these.
+    REQUIRE(throttle.Admit(at(Seconds(10)), suppressed));
+    int emitted = 0;
+    for (int i = 1; i <= 10; i++) {
+      if (throttle.Admit(at(Seconds(10 + i)), suppressed)) emitted++;
+    }
+    REQUIRE(emitted == 10);
+  }
+
+  SECTION("a forward jump does not let an extra one through") {
+    // Ten milliseconds of real time, which a forward wall clock step of ninety
+    // seconds would have turned into a second emission.
+    REQUIRE(throttle.Admit(at(Seconds(10)), suppressed));
+    REQUIRE_FALSE(throttle.Admit(at(Seconds(10) + Milliseconds(10)), suppressed));
+    REQUIRE(throttle.suppressed() == 1);
+  }
+}
+
+TEST_CASE("LogThrottle cannot be driven by the wall clock") {
+  // The parameter is a steady_clock point and SystemTimePoint is a distinct
+  // type, so passing std::chrono::system_clock::now() here is a compile error
+  // rather than something a reviewer has to catch.
+  REQUIRE_FALSE((std::is_same<TimePoint, SystemTimePoint>::value));
+  REQUIRE((std::is_same<TimePoint, std::chrono::steady_clock::time_point>::value));
+  REQUIRE_FALSE((std::is_convertible<SystemTimePoint, TimePoint>::value));
+}


### PR DESCRIPTION
Fixes #4242.

Rebased onto 8a4ac9146 and changed approach. This originally dropped the decreasing-dts message to Debug, but you added the regression size to it two days later, so you clearly want the warning. @SteveGilvarry's other suggestion on the issue was to rate limit it, which keeps the message and still fixes the flooding the reporter saw at 20+ a second.

One a second per stream, and the suppressed ones are counted into the next message so the volume is still visible.
