### PR TITLE
fix: lock to stop a second zmcontrol server per monitor

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/General.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/General.pm
@@ -35,6 +35,7 @@ our %EXPORT_TAGS = (
       daemonControl
       parseNameEqualsValueToHash
       hash_diff
+      acquireExclusiveLock
       ) ]
     );
 push( @{$EXPORT_TAGS{all}}, @{$EXPORT_TAGS{$_}} ) foreach keys %EXPORT_TAGS;
@@ -56,6 +57,29 @@ use ZoneMinder::Logger qw(:all);
 use ZoneMinder::Database qw(:all);
 
 use POSIX;
+use Fcntl qw(:flock);
+
+# Take an exclusive, non blocking lock on $path, creating it if needed. Returns
+# the open filehandle on success and undef if someone else already holds it or
+# the file cannot be opened. The lock lives for as long as the caller keeps the
+# returned handle, so store it somewhere that outlives the work it guards. It is
+# released when the handle goes out of scope or the process exits, including on
+# a crash, which a lock built out of a pid file or the presence of a socket
+# cannot manage.
+sub acquireExclusiveLock {
+  my $path = shift;
+
+  my $fh;
+  if (!open($fh, '>', $path)) {
+    Error("Can't open lock file $path: $!");
+    return undef;
+  }
+  if (!flock($fh, LOCK_EX|LOCK_NB)) {
+    close($fh);
+    return undef;
+  }
+  return $fh;
+}
 
 # For running general shell commands
 sub executeShellCommand {
@@ -707,6 +731,7 @@ of the ZoneMinder scripts
       systemStatus
       parseNameEqualsValueToHash
       hash_diff
+      acquireExclusiveLock
       ) ]
 
 

--- a/scripts/ZoneMinder/lib/ZoneMinder/General.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/General.pm
@@ -36,6 +36,7 @@ our %EXPORT_TAGS = (
       parseNameEqualsValueToHash
       hash_diff
       acquireExclusiveLock
+      lockHolderPid
       ) ]
     );
 push( @{$EXPORT_TAGS{all}}, @{$EXPORT_TAGS{$_}} ) foreach keys %EXPORT_TAGS;
@@ -57,28 +58,67 @@ use ZoneMinder::Logger qw(:all);
 use ZoneMinder::Database qw(:all);
 
 use POSIX;
-use Fcntl qw(:flock);
+use Fcntl qw(:flock O_WRONLY O_CREAT);
 
-# Take an exclusive, non blocking lock on $path, creating it if needed. Returns
-# the open filehandle on success and undef if someone else already holds it or
-# the file cannot be opened. The lock lives for as long as the caller keeps the
-# returned handle, so store it somewhere that outlives the work it guards. It is
-# released when the handle goes out of scope or the process exits, including on
-# a crash, which a lock built out of a pid file or the presence of a socket
-# cannot manage.
+# The pid recorded in a lock file, or undef when it is empty or unreadable.
+sub lockHolderPid {
+  my ($path) = @_;
+  my $rfh;
+  return undef unless open($rfh, '<', $path);
+  my $line = <$rfh>;
+  close($rfh);
+  return undef unless defined $line;
+  chomp $line;
+  # The capture also untaints it, since callers log it from taint checked scripts.
+  return ($line =~ /^(\d+)$/) ? $1 : undef;
+}
+
+# Take an exclusive, non blocking lock on $path, creating it if needed, and
+# record the holder's pid in it. The lock lives for as long as the caller keeps
+# the returned handle, so store it somewhere that outlives the work it guards.
+# It is released when the handle goes out of scope or the process exits,
+# including on a crash, which a lock built out of a pid file or the presence of
+# a socket cannot manage.
+#
+# Returns ($fh, $status, $pid):
+#   ($fh,   'ok',    $$)   the lock is ours
+#   (undef, 'held',  $pid) someone else has it, and who, when the file says so
+#   (undef, 'error', undef) it could not be opened at all, already logged
+#
+# Callers need those two failures kept apart. A lock file left behind by another
+# user cannot be opened for write at all, and reporting that as a duplicate
+# server sends the operator hunting for a process that does not exist.
 sub acquireExclusiveLock {
-  my $path = shift;
+  my ($path) = @_;
 
+  # O_CREAT without O_TRUNC on purpose. Truncating at open would throw away the
+  # current holder's pid before we know whether we can have the lock, and that
+  # pid is the one useful thing the loser has to report. 0666 because whoever
+  # runs the daemon next has to be able to open it for write: the socket
+  # directory belongs to the web user, but these daemons get run by hand as root
+  # often enough that a root owned 0644 lock file would wedge that monitor for
+  # good.
   my $fh;
-  if (!open($fh, '>', $path)) {
+  if (!sysopen($fh, $path, O_WRONLY|O_CREAT, 0666)) {
     Error("Can't open lock file $path: $!");
-    return undef;
+    return (undef, 'error', undef);
   }
+  # umask takes the group and other write bits back off the mode above, so set
+  # them again. Harmlessly fails when we did not create it.
+  chmod(0666, $path);
+
   if (!flock($fh, LOCK_EX|LOCK_NB)) {
+    my $pid = lockHolderPid($path);
     close($fh);
-    return undef;
+    return (undef, 'held', $pid);
   }
-  return $fh;
+
+  # Ours now, so say who we are and let the next process name us rather than
+  # leaving someone to run fuser over the file.
+  truncate($fh, 0);
+  seek($fh, 0, 0);
+  syswrite($fh, "$$\n");
+  return ($fh, 'ok', $$);
 }
 
 # For running general shell commands
@@ -732,6 +772,7 @@ of the ZoneMinder scripts
       parseNameEqualsValueToHash
       hash_diff
       acquireExclusiveLock
+      lockHolderPid
       ) ]
 
 

--- a/scripts/zmcontrol.pl.in
+++ b/scripts/zmcontrol.pl.in
@@ -168,9 +168,21 @@ if ($options{command}) {
   my $lock_file = $Config{ZM_PATH_SOCKS}.'/zmcontrol-'.$id.'.lock';
   # Held for the lifetime of the process: the lock is released when $lock_fh
   # goes out of scope, and this block runs until the server exits.
-  my $lock_fh = acquireExclusiveLock($lock_file);
+  my ($lock_fh, $lock_status, $lock_pid) = acquireExclusiveLock($lock_file);
   if (!$lock_fh) {
-    Error("Another zmcontrol server is already running for monitor $id, exiting");
+    if ($lock_status eq 'held') {
+      Error("Another zmcontrol server is already running for monitor $id"
+        .(defined($lock_pid) ? " (pid $lock_pid)" : '').', exiting');
+    } else {
+      Error("Can't take the control server lock at $lock_file, so not starting."
+        .' It has to be writable by the user zmcontrol.pl runs as, so check its'
+        .' ownership if it was created by a hand run as another user.');
+    }
+    # zmdc starts us with keepalive, so a non-zero exit here is retried with a
+    # backoff capped at ZM_MAX_RESTART_DELAY rather than staying dead. That is
+    # what we want while a duplicate is still up, since it clears itself once
+    # the other server goes. A lock file we cannot open never clears on its own,
+    # which is why that case says what to look at.
     exit(1);
   }
 

--- a/scripts/zmcontrol.pl.in
+++ b/scripts/zmcontrol.pl.in
@@ -157,6 +157,23 @@ if ($options{command}) {
   # We are the server
   require ZoneMinder::Monitor;
 
+  # Only one control server per monitor. Nothing used to stop a second one, and
+  # it would unlink the live socket further down and bind its own, leaving the
+  # first listening on an unlinked inode that no client can reach while both
+  # still held the camera's control connection open. Take the lock before
+  # anything talks to the camera or the socket.
+  # The lock is a separate file rather than the socket itself so that a socket
+  # left behind by a killed server does not block startup for good.
+  # refs #4423
+  my $lock_file = $Config{ZM_PATH_SOCKS}.'/zmcontrol-'.$id.'.lock';
+  # Held for the lifetime of the process: the lock is released when $lock_fh
+  # goes out of scope, and this block runs until the server exits.
+  my $lock_fh = acquireExclusiveLock($lock_file);
+  if (!$lock_fh) {
+    Error("Another zmcontrol server is already running for monitor $id, exiting");
+    exit(1);
+  }
+
   my $monitor = ZoneMinder::Monitor->find_one(Id=>$id);
   Fatal("Unable to load control data for monitor $id") if !$monitor;
 

--- a/tests/perl/test_exclusive_lock.pl
+++ b/tests/perl/test_exclusive_lock.pl
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+#
+# Tests ZoneMinder::General::acquireExclusiveLock, which zmcontrol.pl uses to
+# keep a second control server from starting for a monitor that already has one.
+# The old code had no lock at all: the second server unlinked the live socket and
+# bound its own, so the first was left listening on an unlinked inode while both
+# still held the camera's control connection open.  Issue #4423.
+#
+# The interesting property is the one a pid file or "does the socket exist"
+# check cannot give you: the lock has to be gone after the holder is killed, or a
+# crashed server would block its own restart for good.
+#
+# Run as: perl tests/perl/test_exclusive_lock.pl
+#
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../scripts/ZoneMinder/lib";
+
+BEGIN { $ENV{LOG_FILE} = "/tmp/zm_test_lock_$$.log"; }
+
+use File::Temp qw(tempdir);
+use POSIX qw(:sys_wait_h);
+use ZoneMinder::General qw(acquireExclusiveLock);
+
+my $failures = 0;
+my $passes = 0;
+
+sub check {
+  my ($name, $ok) = @_;
+  if ($ok) {
+    $passes++;
+    print "ok - $name\n";
+  } else {
+    $failures++;
+    print "NOT OK - $name\n";
+  }
+}
+
+my $dir = tempdir(CLEANUP => 1);
+my $lock = "$dir/zmcontrol-1.lock";
+
+# A fresh path: nobody holds it, so we get a handle and the file now exists.
+my $first = acquireExclusiveLock($lock);
+check('acquires a lock on a path that does not exist yet', defined $first);
+check('creates the lock file', -e $lock);
+
+# flock() tracks the open file description, not the process, so a second open of
+# the same path is refused even from here.  This is what stops a second server.
+my $second = acquireExclusiveLock($lock);
+check('refuses a second lock while the first is held', !defined $second);
+
+# Dropping the handle releases it, which is also what happens at process exit.
+undef $first;
+my $third = acquireExclusiveLock($lock);
+check('the lock is available again once the holder lets go', defined $third);
+undef $third;
+
+# Now the case that matters: a holder that dies without cleaning up.
+my ($rd, $wr);
+pipe($rd, $wr) or die "pipe: $!";
+my $pid = fork();
+die "fork: $!" if !defined $pid;
+if (!$pid) {
+  close($rd);
+  my $held = acquireExclusiveLock($lock);
+  syswrite($wr, defined $held ? "y" : "n");
+  sleep(60); # killed by the parent below, so the lock is never released tidily
+  exit(0);
+}
+close($wr);
+my $got = '';
+sysread($rd, $got, 1);
+check('a separate process can take the lock', $got eq 'y');
+
+my $blocked = acquireExclusiveLock($lock);
+check('and holds it against everyone else', !defined $blocked);
+
+# SIGKILL leaves the lock file behind with no chance to tidy up, exactly like a
+# crashed or OOM-killed control server.
+kill('KILL', $pid);
+waitpid($pid, 0);
+check('the lock file survives the kill', -e $lock);
+
+my $after = acquireExclusiveLock($lock);
+check('a killed holder does not block the next server', defined $after);
+undef $after;
+close($rd);
+
+# A path that cannot be opened is a failure to lock, not a lock.
+my $bad = acquireExclusiveLock("$dir/no/such/dir/zmcontrol-1.lock");
+check('returns undef when the lock file cannot be opened', !defined $bad);
+
+print "\n$passes passed, $failures failed\n";
+unlink($ENV{LOG_FILE});
+exit($failures ? 1 : 0);

--- a/tests/perl/test_exclusive_lock.pl
+++ b/tests/perl/test_exclusive_lock.pl
@@ -21,7 +21,7 @@ BEGIN { $ENV{LOG_FILE} = "/tmp/zm_test_lock_$$.log"; }
 
 use File::Temp qw(tempdir);
 use POSIX qw(:sys_wait_h);
-use ZoneMinder::General qw(acquireExclusiveLock);
+use ZoneMinder::General qw(acquireExclusiveLock lockHolderPid);
 
 my $failures = 0;
 my $passes = 0;
@@ -41,18 +41,28 @@ my $dir = tempdir(CLEANUP => 1);
 my $lock = "$dir/zmcontrol-1.lock";
 
 # A fresh path: nobody holds it, so we get a handle and the file now exists.
-my $first = acquireExclusiveLock($lock);
+my ($first, $first_status, $first_pid) = acquireExclusiveLock($lock);
 check('acquires a lock on a path that does not exist yet', defined $first);
 check('creates the lock file', -e $lock);
+check('reports success as ok', ($first_status // '') eq 'ok');
+check('records our own pid in it', ($first_pid // 0) == $$);
+check('and writes that pid where anyone can read it', (lockHolderPid($lock) // 0) == $$);
+check('the lock file is writable by whoever runs the daemon next',
+  ((stat($lock))[2] & 0666) == 0666);
 
 # flock() tracks the open file description, not the process, so a second open of
 # the same path is refused even from here.  This is what stops a second server.
-my $second = acquireExclusiveLock($lock);
+my ($second, $second_status, $second_pid) = acquireExclusiveLock($lock);
 check('refuses a second lock while the first is held', !defined $second);
+# The distinction the caller needs: a lock someone holds is not the same as one
+# it cannot open, and only the first means a duplicate server is running.
+check('a held lock reports held, not an error', ($second_status // '') eq 'held');
+check('and names the process holding it', ($second_pid // 0) == $$);
+check('a failed acquire leaves the holder pid intact', (lockHolderPid($lock) // 0) == $$);
 
 # Dropping the handle releases it, which is also what happens at process exit.
 undef $first;
-my $third = acquireExclusiveLock($lock);
+my ($third) = acquireExclusiveLock($lock);
 check('the lock is available again once the holder lets go', defined $third);
 undef $third;
 
@@ -63,7 +73,7 @@ my $pid = fork();
 die "fork: $!" if !defined $pid;
 if (!$pid) {
   close($rd);
-  my $held = acquireExclusiveLock($lock);
+  my ($held) = acquireExclusiveLock($lock);
   syswrite($wr, defined $held ? "y" : "n");
   sleep(60); # killed by the parent below, so the lock is never released tidily
   exit(0);
@@ -73,8 +83,10 @@ my $got = '';
 sysread($rd, $got, 1);
 check('a separate process can take the lock', $got eq 'y');
 
-my $blocked = acquireExclusiveLock($lock);
+my ($blocked, $blocked_status, $blocked_pid) = acquireExclusiveLock($lock);
 check('and holds it against everyone else', !defined $blocked);
+check('the other process is reported as the holder', ($blocked_status // '') eq 'held');
+check('by pid', defined($blocked_pid) && $blocked_pid == $pid);
 
 # SIGKILL leaves the lock file behind with no chance to tidy up, exactly like a
 # crashed or OOM-killed control server.
@@ -82,14 +94,17 @@ kill('KILL', $pid);
 waitpid($pid, 0);
 check('the lock file survives the kill', -e $lock);
 
-my $after = acquireExclusiveLock($lock);
+my ($after) = acquireExclusiveLock($lock);
 check('a killed holder does not block the next server', defined $after);
 undef $after;
 close($rd);
 
 # A path that cannot be opened is a failure to lock, not a lock.
-my $bad = acquireExclusiveLock("$dir/no/such/dir/zmcontrol-1.lock");
+my ($bad, $bad_status, $bad_pid) = acquireExclusiveLock("$dir/no/such/dir/zmcontrol-1.lock");
 check('returns undef when the lock file cannot be opened', !defined $bad);
+check('an unopenable path is an error, not a duplicate server',
+  ($bad_status // '') eq 'error');
+check('with no pid to blame it on', !defined $bad_pid);
 
 print "\n$passes passed, $failures failed\n";
 unlink($ENV{LOG_FILE});


### PR DESCRIPTION
Fixes #4423.

The server branch unlinked the socket before binding it, so a second control server for the same monitor took it over, leaving the first listening on an unlinked inode while both still held the camera's control connection. It now flocks `zmcontrol-<id>.lock` before touching the camera or the socket and exits if another server holds it. The lock file carries the holder's pid, and one that cannot be opened is reported separately from one that is held, so a file left behind by a hand run as root does not read as a duplicate server.

This covers the socket server only. `--protocol` direct mode returns before the lock is taken and can still contend with a running server for the camera.

Tests: `perl tests/perl/test_exclusive_lock.pl`, 20 passed.
