### PR TITLE
perf: scale during colour conversion in zms playback

### DIFF
--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -939,6 +939,9 @@ bool EventStream::sendFrame(Microseconds delta_us) {
       }
     } else {
       Image *image = nullptr;
+      // Non zero once the frame has been decoded straight to the size we are
+      // going to send, so prepareImage knows not to scale it a second time.
+      int pre_scaled_by = 0;
       // Owns the image only on the ffmpeg (mp4) path; the JPEG path decodes into
       // the reused member, so nothing is freed there. unique_ptr replaces the
       // old new/delete pair and frees automatically at scope exit.
@@ -958,7 +961,23 @@ bool EventStream::sendFrame(Microseconds delta_us) {
                            ffmpeg_input->get_video_stream_id(),
                            FPSeconds(frame_data->offset).count());
         if (frame) {
-          owned_image = std::make_unique<Image>(frame, monitor->Width(), monitor->Height());
+          // Decode straight to the size being sent. sws_scale colour converts
+          // and resizes in the same pass, so converting at full size and then
+          // scaling cost an extra full frame conversion plus a full frame copy
+          // for every frame streamed. Only safe with no zoom active: zoom crops
+          // before scaling and needs the full resolution to crop out of.
+          // refs #3681
+          int convert_width = monitor->Width();
+          int convert_height = monitor->Height();
+          const int cur_scale = scale.load();
+          if ((zoom.load() == ZM_SCALE_BASE) and (cur_scale != ZM_SCALE_BASE)) {
+            convert_width = (monitor->Width() * cur_scale) / ZM_SCALE_BASE;
+            convert_height = (monitor->Height() * cur_scale) / ZM_SCALE_BASE;
+            pre_scaled_by = cur_scale;
+            Debug(3, "Converting straight to %dx%d for scale %d",
+                convert_width, convert_height, cur_scale);
+          }
+          owned_image = std::make_unique<Image>(frame, convert_width, convert_height);
           image = owned_image.get();
         } else {
           Error("Failed getting a frame.");
@@ -999,7 +1018,7 @@ bool EventStream::sendFrame(Microseconds delta_us) {
         return true;
       }
 
-      Image *send_image = prepareImage(image);
+      Image *send_image = prepareImage(image, pre_scaled_by);
       reserveTempImgBuffer(send_image->Size());
       size_t img_buffer_size = 0;
       uint8_t *img_buffer = temp_img_buffer;

--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -964,19 +964,11 @@ bool EventStream::sendFrame(Microseconds delta_us) {
           // Decode straight to the size being sent. sws_scale colour converts
           // and resizes in the same pass, so converting at full size and then
           // scaling cost an extra full frame conversion plus a full frame copy
-          // for every frame streamed. Only safe with no zoom active: zoom crops
-          // before scaling and needs the full resolution to crop out of.
-          // refs #3681
+          // for every frame streamed. refs #3681
           int convert_width = monitor->Width();
           int convert_height = monitor->Height();
-          const int cur_scale = scale.load();
-          if ((zoom.load() == ZM_SCALE_BASE) and (cur_scale != ZM_SCALE_BASE)) {
-            convert_width = (monitor->Width() * cur_scale) / ZM_SCALE_BASE;
-            convert_height = (monitor->Height() * cur_scale) / ZM_SCALE_BASE;
-            pre_scaled_by = cur_scale;
-            Debug(3, "Converting straight to %dx%d for scale %d",
-                convert_width, convert_height, cur_scale);
-          }
+          pre_scaled_by = preScaleDimensions(monitor->Width(), monitor->Height(),
+                                             convert_width, convert_height);
           owned_image = std::make_unique<Image>(frame, convert_width, convert_height);
           image = owned_image.get();
         } else {

--- a/src/zm_eventstream.cpp
+++ b/src/zm_eventstream.cpp
@@ -961,10 +961,11 @@ bool EventStream::sendFrame(Microseconds delta_us) {
                            ffmpeg_input->get_video_stream_id(),
                            FPSeconds(frame_data->offset).count());
         if (frame) {
-          // Decode straight to the size being sent. sws_scale colour converts
-          // and resizes in the same pass, so converting at full size and then
-          // scaling cost an extra full frame conversion plus a full frame copy
-          // for every frame streamed. refs #3681
+          // Convert straight to the size being sent. The decode is unchanged,
+          // but the RGBA conversion sws_scale was doing anyway can resize in
+          // the same pass, so converting at full size and then scaling cost an
+          // extra full frame conversion plus a full frame copy for every frame
+          // streamed. refs #3681
           int convert_width = monitor->Width();
           int convert_height = monitor->Height();
           pre_scaled_by = preScaleDimensions(monitor->Width(), monitor->Height(),

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -150,7 +150,7 @@ void StreamBase::checkCommandQueue() {
   } // end while !zm_terminate
 }  // end void StreamBase::checkCommandQueue()
 
-Image *StreamBase::prepareImage(Image *image) {
+Image *StreamBase::prepareImage(Image *image, int pre_scaled_by) {
   /* zooming should happen before scaling to preserve quality
    * scale is relative to base dimensions, and represents the rough ratio between desired view size and base dimensions
    */
@@ -165,6 +165,10 @@ Image *StreamBase::prepareImage(Image *image) {
   const unsigned short cur_x = x.load();
   const unsigned short cur_y = y.load();
 
+  // A caller that pre-scaled did so having seen no zoom. If zoom was turned on
+  // in between, this frame crops a downscaled image and so looks softer than it
+  // should; the next frame is produced at full size because the caller sees the
+  // zoom by then. Not worth decoding the frame twice to avoid.
   if (cur_zoom != 100) {
     int base_image_width = image->Width(),
         base_image_height = image->Height(),
@@ -248,12 +252,20 @@ Image *StreamBase::prepareImage(Image *image) {
     image->Crop(last_crop);
     image->Scale(disp_image_width, disp_image_height);
   } else if (cur_scale != ZM_SCALE_BASE) {
-    Debug(3, "scaling by %d from %dx%d", cur_scale, image->Width(), image->Height());
-    static Image copy_image;
-    copy_image.Assign(*image);
-    image = &copy_image;
-    image_copied = true;
-    image->Scale(cur_scale);
+    if (pre_scaled_by == cur_scale) {
+      // Already at the right size: the caller folded the scale into a colour
+      // conversion it had to do anyway, which saves a second full frame
+      // sws_scale and the full frame copy below. Nothing to do, and nothing to
+      // copy either, since we are not about to modify it.
+      Debug(3, "already scaled by %d to %dx%d", cur_scale, image->Width(), image->Height());
+    } else {
+      Debug(3, "scaling by %d from %dx%d", cur_scale, image->Width(), image->Height());
+      static Image copy_image;
+      copy_image.Assign(*image);
+      image = &copy_image;
+      image_copied = true;
+      image->Scale(cur_scale);
+    }
   }
   Debug(3, "Sending %dx%d", image->Width(), image->Height());
 
@@ -265,7 +277,7 @@ Image *StreamBase::prepareImage(Image *image) {
   last_y = cur_y;
 
   return image;
-}  // end Image *StreamBase::prepareImage(Image *image)
+}  // end Image *StreamBase::prepareImage(Image *image, int pre_scaled_by)
 
 bool StreamBase::sendTextFrame(const char *frame_text) {
   int width = 640;

--- a/src/zm_stream.cpp
+++ b/src/zm_stream.cpp
@@ -150,7 +150,44 @@ void StreamBase::checkCommandQueue() {
   } // end while !zm_terminate
 }  // end void StreamBase::checkCommandQueue()
 
+int StreamBase::preScaleDimensions(int base_width, int base_height, int &width, int &height) const {
+  // Any zoom crops before scaling and needs the full resolution to crop out of.
+  if (zoom.load() != ZM_SCALE_BASE) return 0;
+
+  const int cur_scale = scale.load();
+  if (cur_scale == ZM_SCALE_BASE) return 0;
+
+  const int scaled_width = (base_width * cur_scale) / ZM_SCALE_BASE;
+  const int scaled_height = (base_height * cur_scale) / ZM_SCALE_BASE;
+  // CMD_SCALE stores whatever the client sent, so 0 gets here. Image::Scale
+  // refuses a zero factor, but converting straight to 0x0 would instead put a
+  // negative av_image_get_buffer_size result into an unsigned size and allocate
+  // on it, so leave anything degenerate to the path that already rejects it.
+  if ((scaled_width <= 0) or (scaled_height <= 0)) return 0;
+
+  width = scaled_width;
+  height = scaled_height;
+  return cur_scale;
+}
+
 Image *StreamBase::prepareImage(Image *image, int pre_scaled_by) {
+  if (pre_scaled_by) {
+    // The caller produced the image at exactly the size to send, folding the
+    // scale into a colour conversion it had to do anyway. Send it untouched.
+    //
+    // The command thread can change scale or zoom between the caller reading
+    // them and this call, in which case this one frame goes out at the scale it
+    // was built for and without any new zoom, and the next frame is built from
+    // the new values. Scaling here instead would apply the scale a second time
+    // (a 50% frame of a 640px source would go out at 160px, not 320px), and
+    // cropping here would do it in the reduced image's coordinates and leave
+    // last_crop in the wrong units for every later frame. refs #3681
+    Debug(3, "Sending pre-scaled %dx%d, scale %d", image->Width(), image->Height(), pre_scaled_by);
+    last_scale = pre_scaled_by;
+    last_zoom = ZM_SCALE_BASE;
+    return image;
+  }
+
   /* zooming should happen before scaling to preserve quality
    * scale is relative to base dimensions, and represents the rough ratio between desired view size and base dimensions
    */
@@ -165,10 +202,6 @@ Image *StreamBase::prepareImage(Image *image, int pre_scaled_by) {
   const unsigned short cur_x = x.load();
   const unsigned short cur_y = y.load();
 
-  // A caller that pre-scaled did so having seen no zoom. If zoom was turned on
-  // in between, this frame crops a downscaled image and so looks softer than it
-  // should; the next frame is produced at full size because the caller sees the
-  // zoom by then. Not worth decoding the frame twice to avoid.
   if (cur_zoom != 100) {
     int base_image_width = image->Width(),
         base_image_height = image->Height(),
@@ -252,20 +285,12 @@ Image *StreamBase::prepareImage(Image *image, int pre_scaled_by) {
     image->Crop(last_crop);
     image->Scale(disp_image_width, disp_image_height);
   } else if (cur_scale != ZM_SCALE_BASE) {
-    if (pre_scaled_by == cur_scale) {
-      // Already at the right size: the caller folded the scale into a colour
-      // conversion it had to do anyway, which saves a second full frame
-      // sws_scale and the full frame copy below. Nothing to do, and nothing to
-      // copy either, since we are not about to modify it.
-      Debug(3, "already scaled by %d to %dx%d", cur_scale, image->Width(), image->Height());
-    } else {
-      Debug(3, "scaling by %d from %dx%d", cur_scale, image->Width(), image->Height());
-      static Image copy_image;
-      copy_image.Assign(*image);
-      image = &copy_image;
-      image_copied = true;
-      image->Scale(cur_scale);
-    }
+    Debug(3, "scaling by %d from %dx%d", cur_scale, image->Width(), image->Height());
+    static Image copy_image;
+    copy_image.Assign(*image);
+    image = &copy_image;
+    image_copied = true;
+    image->Scale(cur_scale);
   }
   Debug(3, "Sending %dx%d", image->Width(), image->Height());
 

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -179,7 +179,10 @@ class StreamBase {
   bool loadMonitor(int monitor_id);
   bool checkInitialised();
   void updateFrameRate(double fps);
-  Image *prepareImage(Image *image);
+  // pre_scaled_by is the scale the caller already produced the image at, for
+  // callers that have to colour convert anyway and can therefore scale in the
+  // same swscale pass. 0 means the image is at full size. See #3681.
+  Image *prepareImage(Image *image, int pre_scaled_by = 0);
   void checkCommandQueue();
   virtual void processCommand(const CmdMsg *msg)=0;
   void reserveTempImgBuffer(size_t size);

--- a/src/zm_stream.h
+++ b/src/zm_stream.h
@@ -183,6 +183,12 @@ class StreamBase {
   // callers that have to colour convert anyway and can therefore scale in the
   // same swscale pass. 0 means the image is at full size. See #3681.
   Image *prepareImage(Image *image, int pre_scaled_by = 0);
+
+  // Dimensions a caller should produce the source image at so the scale folds
+  // into a colour conversion it has to do anyway. Returns the scale used, which
+  // is what prepareImage wants as pre_scaled_by, or 0 when the fast path does
+  // not apply and the image must be produced at base_width x base_height.
+  int preScaleDimensions(int base_width, int base_height, int &width, int &height) const;
   void checkCommandQueue();
   virtual void processCommand(const CmdMsg *msg)=0;
   void reserveTempImgBuffer(size_t size);

--- a/tests/zm_stream.cpp
+++ b/tests/zm_stream.cpp
@@ -19,6 +19,9 @@
 
 #include "zm_stream.h"
 
+#include "zm_config.h"
+#include "zm_image.h"
+
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -30,9 +33,26 @@ class TestStream : public StreamBase {
  public:
   void runStream() override {}
 
+  // prepareImage and the view state it reads are protected; expose just enough
+  // to drive it from a test.
+  Image *prepare(Image *image, int pre_scaled_by = 0) {
+    return prepareImage(image, pre_scaled_by);
+  }
+  void setView(int p_scale, int p_zoom) {
+    scale = p_scale;
+    zoom = p_zoom;
+  }
+
  protected:
   void processCommand(const CmdMsg *) override {}
 };
+
+// Image::Initialise() dereferences config.font_file_location, which is null in
+// the unit-test harness (no zm.conf loaded). Give it a non-null value so the
+// first Image construction doesn't throw. Same guard as zm_image_linesize.cpp.
+void EnsureImageInit() {
+  if (!config.font_file_location) config.font_file_location = "";
+}
 
 bool fd_is_open(int fd) {
   return fcntl(fd, F_GETFD) != -1;
@@ -76,3 +96,83 @@ TEST_CASE("StreamBase comms teardown") {
     REQUIRE(stdin_survives_destruction(0));
   }
 }
+
+
+TEST_CASE("StreamBase::prepareImage pre-scaled frames") {
+  // zms used to colour convert an mp4 frame to full size RGBA and then scale
+  // that down to the requested size, so every streamed frame paid for two
+  // sws_scale passes and a full frame copy. sws_scale converts and resizes in
+  // one pass, so the decode side now produces the image at the size being sent
+  // and tells prepareImage it has already been scaled. refs #3681
+  EnsureImageInit();
+  const unsigned int kWidth = 640;
+  const unsigned int kHeight = 480;
+
+  SECTION("a pre-scaled image is passed through untouched") {
+    TestStream stream;
+    stream.setView(50, ZM_SCALE_BASE);
+    Image image(kWidth / 2, kHeight / 2, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+
+    Image *sent = stream.prepare(&image, 50);
+
+    // Same object, not a scaled copy: nothing was resized and nothing copied.
+    REQUIRE(sent == &image);
+    REQUIRE(sent->Width() == kWidth / 2);
+    REQUIRE(sent->Height() == kHeight / 2);
+  }
+
+  SECTION("a full size image is still scaled") {
+    TestStream stream;
+    stream.setView(50, ZM_SCALE_BASE);
+    Image image(kWidth, kHeight, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+
+    Image *sent = stream.prepare(&image, 0);
+
+    REQUIRE(sent != &image);  // scaled into the copy, caller's image intact
+    REQUIRE(image.Width() == kWidth);
+    REQUIRE(sent->Width() == kWidth / 2);
+    REQUIRE(sent->Height() == kHeight / 2);
+  }
+
+  SECTION("a scale that does not match what the caller produced is redone") {
+    // The command thread can change scale after the decode side read it. The
+    // frame in hand is then the wrong size and has to be scaled the old way
+    // rather than sent at whatever size it happens to be.
+    TestStream stream;
+    stream.setView(50, ZM_SCALE_BASE);
+    Image image(kWidth, kHeight, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+
+    Image *sent = stream.prepare(&image, 25);
+
+    REQUIRE(sent != &image);
+    REQUIRE(sent->Width() == kWidth / 2);
+    REQUIRE(sent->Height() == kHeight / 2);
+  }
+
+  SECTION("unscaled streaming is unaffected") {
+    TestStream stream;
+    stream.setView(ZM_SCALE_BASE, ZM_SCALE_BASE);
+    Image image(kWidth, kHeight, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+
+    Image *sent = stream.prepare(&image, 0);
+
+    REQUIRE(sent == &image);
+    REQUIRE(sent->Width() == kWidth);
+  }
+
+  SECTION("converting at the target size lands on the size Scale would have") {
+    // The whole optimisation rests on these agreeing: the decode side computes
+    // the target as (dimension * scale) / ZM_SCALE_BASE, which has to match what
+    // Image::Scale(scale) produces, or pre-scaled frames would go out at a
+    // different size than they used to.
+    for (unsigned int scale : {25u, 33u, 50u, 75u, 150u}) {
+      Image scaled(kWidth, kHeight, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+      scaled.Scale(scale);
+
+      CAPTURE(scale);
+      REQUIRE(scaled.Width() == (kWidth * scale) / ZM_SCALE_BASE);
+      REQUIRE(scaled.Height() == (kHeight * scale) / ZM_SCALE_BASE);
+    }
+  }
+}
+

--- a/tests/zm_stream.cpp
+++ b/tests/zm_stream.cpp
@@ -38,6 +38,9 @@ class TestStream : public StreamBase {
   Image *prepare(Image *image, int pre_scaled_by = 0) {
     return prepareImage(image, pre_scaled_by);
   }
+  int preScale(int base_width, int base_height, int &width, int &height) {
+    return preScaleDimensions(base_width, base_height, width, height);
+  }
   void setView(int p_scale, int p_zoom) {
     scale = p_scale;
     zoom = p_zoom;
@@ -134,17 +137,35 @@ TEST_CASE("StreamBase::prepareImage pre-scaled frames") {
     REQUIRE(sent->Height() == kHeight / 2);
   }
 
-  SECTION("a scale that does not match what the caller produced is redone") {
+  SECTION("a scale changed since the decode is not applied a second time") {
     // The command thread can change scale after the decode side read it. The
-    // frame in hand is then the wrong size and has to be scaled the old way
-    // rather than sent at whatever size it happens to be.
+    // image in hand is a real 25% frame; scaling it again by the new 50% would
+    // send 80x60 rather than either the 160x120 it is or the 320x240 now
+    // wanted. It goes out as built and the next frame uses the new scale.
     TestStream stream;
     stream.setView(50, ZM_SCALE_BASE);
-    Image image(kWidth, kHeight, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+    Image image((kWidth * 25) / 100, (kHeight * 25) / 100,
+                ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
 
     Image *sent = stream.prepare(&image, 25);
 
-    REQUIRE(sent != &image);
+    REQUIRE(sent == &image);
+    REQUIRE(sent->Width() == (kWidth * 25) / 100);
+    REQUIRE(sent->Height() == (kHeight * 25) / 100);
+  }
+
+  SECTION("a zoom turned on since the decode does not crop the reduced image") {
+    // Same race, the other field. The zoom branch derives its base geometry and
+    // its crop from the image's own dimensions, so handing it a half sized frame
+    // would both halve the output again and record last_crop in the wrong
+    // coordinate space, which would then be wrong for every later frame.
+    TestStream stream;
+    stream.setView(50, 150);
+    Image image(kWidth / 2, kHeight / 2, ZM_COLOUR_RGB32, ZM_SUBPIX_ORDER_RGBA);
+
+    Image *sent = stream.prepare(&image, 50);
+
+    REQUIRE(sent == &image);
     REQUIRE(sent->Width() == kWidth / 2);
     REQUIRE(sent->Height() == kHeight / 2);
   }
@@ -161,8 +182,8 @@ TEST_CASE("StreamBase::prepareImage pre-scaled frames") {
   }
 
   SECTION("converting at the target size lands on the size Scale would have") {
-    // The whole optimisation rests on these agreeing: the decode side computes
-    // the target as (dimension * scale) / ZM_SCALE_BASE, which has to match what
+    // The whole optimisation rests on these agreeing: preScaleDimensions
+    // computes (dimension * scale) / ZM_SCALE_BASE, which has to match what
     // Image::Scale(scale) produces, or pre-scaled frames would go out at a
     // different size than they used to.
     for (unsigned int scale : {25u, 33u, 50u, 75u, 150u}) {
@@ -176,3 +197,58 @@ TEST_CASE("StreamBase::prepareImage pre-scaled frames") {
   }
 }
 
+TEST_CASE("StreamBase::preScaleDimensions") {
+  const int kWidth = 640;
+  const int kHeight = 480;
+  int width = -1, height = -1;
+
+  SECTION("reports the scaled size when only a scale is set") {
+    TestStream stream;
+    stream.setView(50, ZM_SCALE_BASE);
+
+    REQUIRE(stream.preScale(kWidth, kHeight, width, height) == 50);
+    REQUIRE(width == 320);
+    REQUIRE(height == 240);
+  }
+
+  SECTION("declines while a zoom is active") {
+    // Zoom crops before scaling and needs the full resolution to crop out of.
+    TestStream stream;
+    stream.setView(50, 150);
+
+    REQUIRE(stream.preScale(kWidth, kHeight, width, height) == 0);
+  }
+
+  SECTION("declines at the base scale, where there is nothing to fold in") {
+    TestStream stream;
+    stream.setView(ZM_SCALE_BASE, ZM_SCALE_BASE);
+
+    REQUIRE(stream.preScale(kWidth, kHeight, width, height) == 0);
+  }
+
+  SECTION("declines a scale that would produce a zero dimension") {
+    // CMD_SCALE stores the two bytes the client sent without validating them,
+    // so 0 reaches here. Image::Scale(0) refuses the factor; asking swscale for
+    // a 0x0 frame would instead take a negative buffer size into an unsigned
+    // field and allocate on it.
+    TestStream stream;
+    stream.setView(0, ZM_SCALE_BASE);
+
+    REQUIRE(stream.preScale(kWidth, kHeight, width, height) == 0);
+
+    // Also when the scale is nonzero but too small to survive the division.
+    stream.setView(1, ZM_SCALE_BASE);
+    REQUIRE(stream.preScale(4, 4, width, height) == 0);
+  }
+
+  SECTION("leaves the out params alone when it declines") {
+    TestStream stream;
+    stream.setView(0, ZM_SCALE_BASE);
+    width = kWidth;
+    height = kHeight;
+
+    REQUIRE(stream.preScale(kWidth, kHeight, width, height) == 0);
+    REQUIRE(width == kWidth);
+    REQUIRE(height == kHeight);
+  }
+}


### PR DESCRIPTION
Fixes #3681.

mp4 playback converted each frame to full size RGBA then scaled a copy down, two sws_scale passes and a full frame copy per streamed frame. `Image::Assign(const AVFrame *)` already passes both sets of dimensions to `sws_getCachedContext`, so the conversion now targets the size being sent and the resize comes with it. The decode itself is unchanged.

`StreamBase::preScaleDimensions` declines while zoom is active, and on a zero dimension since `CMD_SCALE` takes the client's bytes unvalidated. A pre-scaled frame is sent as built, so a scale or zoom change mid-frame cannot rescale or crop it.

Tests: `tests/zm_stream.cpp`, 35 assertions in two new cases covering both races and `preScaleDimensions`.
