### PR TITLE
fix: cast tv_usec for %jd so armhf varargs stay aligned

### DIFF
--- a/src/zm_rtp_source.cpp
+++ b/src/zm_rtp_source.cpp
@@ -203,17 +203,18 @@ void RtpSource::updateRtcpData(
   timeval ntpTime = zm::chrono::duration_cast<timeval>(
                       Seconds(ntpTimeSecs) + Microseconds((Microseconds::period::den * (ntpTimeFrac >> 16)) / (1 << 16)));
 
-  Debug(5, "ntpTime: %jd.%06ld, rtpTime: %x", static_cast<intmax_t>(ntpTime.tv_sec), ntpTime.tv_usec, rtpTime);
+  Debug(5, "ntpTime: %jd.%06jd, rtpTime: %x", static_cast<intmax_t>(ntpTime.tv_sec),
+        static_cast<intmax_t>(ntpTime.tv_usec), rtpTime);
 
   if ( mBaseTimeNtp.tv_sec == 0 ) {
     mBaseTimeReal = std::chrono::system_clock::now();
     mBaseTimeNtp = ntpTime;
     mBaseTimeRtp = rtpTime;
   } else if ( !mRtpClock ) {
-    Debug(5, "lastSrNtpTime: %jd.%06ld, rtpTime: %x"
-          "ntpTime: %jd.%06ld, rtpTime: %x",
-          static_cast<intmax_t>(mLastSrTimeNtp.tv_sec), mLastSrTimeNtp.tv_usec, rtpTime,
-          static_cast<intmax_t>(ntpTime.tv_sec), ntpTime.tv_usec, rtpTime);
+    Debug(5, "lastSrNtpTime: %jd.%06jd, rtpTime: %x"
+          "ntpTime: %jd.%06jd, rtpTime: %x",
+          static_cast<intmax_t>(mLastSrTimeNtp.tv_sec), static_cast<intmax_t>(mLastSrTimeNtp.tv_usec), rtpTime,
+          static_cast<intmax_t>(ntpTime.tv_sec), static_cast<intmax_t>(ntpTime.tv_usec), rtpTime);
 
     FPSeconds diffNtpTime =
       zm::chrono::duration_cast<Microseconds>(ntpTime) - zm::chrono::duration_cast<Microseconds>(mBaseTimeNtp);

--- a/src/zm_utils.cpp
+++ b/src/zm_utils.cpp
@@ -216,7 +216,11 @@ std::string TimevalToString(timeval tv) {
     return "";
   }
 
-  return stringtf("%s.%06ld", tm_buf.data(), tv.tv_usec);
+  // %jd/intmax_t, not %ld: under glibc's 64 bit time ABI (Debian trixie on
+  // armhf, for one) tv_usec is __suseconds64_t while long is still 32 bits, so
+  // %ld reads half the argument and misaligns the rest of the varargs. Harmless
+  // enough on stdout, but this one lands in a buffer that gets used. refs #4580
+  return stringtf("%s.%06jd", tm_buf.data(), static_cast<intmax_t>(tv.tv_usec));
 }
 
 /* Detect special hardware features, such as SIMD instruction sets */

--- a/tests/zm_utils.cpp
+++ b/tests/zm_utils.cpp
@@ -429,3 +429,40 @@ TEST_CASE("zm_strncpy") {
     REQUIRE(buf[0] == '\0');
   }
 }
+
+TEST_CASE("TimevalToString") {
+  // tv_usec used to go to the format string as %ld. Under glibc's 64 bit time
+  // ABI on a 32 bit platform (Debian trixie on armhf) tv_usec is
+  // __suseconds64_t while long is still 32 bits, so %ld consumed half the
+  // argument and every vararg after it was read from the wrong offset. zmc
+  // crashed on armhf because this result is written into a buffer and then
+  // used. See #4580 and Debian bug 1120447.
+  //
+  // amd64 cannot reproduce the mismatch (long is already 64 bits), so what
+  // this pins is the rendering: six zero padded digits of microseconds, which
+  // is what a wrong conversion would disturb.
+  const char *tz = getenv("TZ");
+  std::string saved_tz = tz ? tz : "";
+  setenv("TZ", "UTC", 1);
+  tzset();
+
+  SECTION("pads microseconds to six digits") {
+    REQUIRE(TimevalToString(timeval{0, 0}) == "1970-01-01 00:00:00.000000");
+    REQUIRE(TimevalToString(timeval{0, 1}) == "1970-01-01 00:00:00.000001");
+    REQUIRE(TimevalToString(timeval{0, 999999}) == "1970-01-01 00:00:00.999999");
+  }
+
+  SECTION("does not truncate or reorder the arguments") {
+    // A conversion that mis-reads tv_usec tends to show up either as a wrong
+    // number here or as the seconds field being wrong, since the bad read
+    // shifts everything after it.
+    REQUIRE(TimevalToString(timeval{1700000000, 123456}) == "2023-11-14 22:13:20.123456");
+  }
+
+  if (saved_tz.empty()) {
+    unsetenv("TZ");
+  } else {
+    setenv("TZ", saved_tz.c_str(), 1);
+  }
+  tzset();
+}


### PR DESCRIPTION
refs #4580.

Four `tv_usec` arguments are still on `%ld`, in two files 40d9f95e8 did not cover: `TimevalToString` in zm_utils.cpp, and three in the SR handling in zm_rtp_source.cpp. On armhf under glibc's 64 bit time ABI `tv_usec` is `__suseconds64_t` while `long` is 32 bits (Debian bug 1120447), so the zm_rtp_source ones misread the `rtpTime` argument that follows, and TimevalToString formats a wrong microseconds field. All four now use `%jd`/`intmax_t`, matching the `tv_sec` casts already on those lines. release-1.38 has the same four.

Tests: added `TimevalToString` to tests/zm_utils.cpp.
