### PR TITLE
fix: honour ZM_WEB_SHOW_PROGRESS in the event view

### DIFF
--- a/tests/php/test_web_option_wiring.php
+++ b/tests/php/test_web_option_wiring.php
@@ -1,0 +1,65 @@
+<?php
+// ZM_WEB_*_SHOW_PROGRESS was configurable, translated into several languages and
+// shown in Options, but nothing ever read it, so the setting did nothing at all
+// (issue #4850). These checks pin the two halves of that: every per-bandwidth
+// web option the classic skin defines has to be consumed somewhere, and the
+// progress display specifically has to stay gated on ZM_WEB_SHOW_PROGRESS.
+// Run: php tests/php/test_web_option_wiring.php   (from the repo root)
+
+$root = __DIR__.'/../..';
+$skin_config = $root.'/web/skins/classic/includes/config.php';
+
+$failures = 0;
+function check($label, $ok, $detail = '') {
+  global $failures;
+  if (!$ok) $failures++;
+  printf("[%s] %s%s\n", $ok ? 'PASS' : 'FAIL', $label, ($ok || $detail === '') ? '' : "\n        $detail");
+}
+
+// Every file the skin could read an option from.
+function skin_sources($root, $exclude) {
+  $found = array();
+  $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root.'/web'));
+  foreach ($it as $file) {
+    $path = $file->getPathname();
+    if (!preg_match('/\.(php|js)$/', $path)) continue;
+    if (realpath($path) === realpath($exclude)) continue;
+    if (strpos($path, '/node_modules/') !== false) continue;
+    $found[] = $path;
+  }
+  return $found;
+}
+
+$config_src = file_get_contents($skin_config);
+preg_match_all("/define\(\s*'(ZM_WEB_[A-Z_]+)'/", $config_src, $m);
+$options = array_values(array_unique($m[1]));
+check('the skin defines per-bandwidth web options', count($options) > 0);
+
+$sources = skin_sources($root, $skin_config);
+$haystack = '';
+foreach ($sources as $path) $haystack .= file_get_contents($path)."\n";
+
+$dead = array();
+foreach ($options as $opt) {
+  if (strpos($haystack, $opt) === false) $dead[] = $opt;
+}
+check('every per-bandwidth web option is read somewhere', count($dead) === 0,
+  'defined but never used: '.implode(', ', $dead));
+
+// The specific wiring #4850 was about. The bar itself must stay, since the
+// option's help text keeps the navigation and only drops the progress display.
+$event_src = file_get_contents($root.'/web/skins/classic/views/event.php');
+
+check('the replay position fill is gated on ZM_WEB_SHOW_PROGRESS',
+  (bool)preg_match('/id="progressBox".*ZM_WEB_SHOW_PROGRESS/s', substr($event_src,
+    strpos($event_src, 'id="progressBox"') - 400, 800)));
+
+check('the progress readout is gated on ZM_WEB_SHOW_PROGRESS',
+  (bool)preg_match('/<span id="progress"[^>]*ZM_WEB_SHOW_PROGRESS/', $event_src));
+
+check('the progress bar itself is not gated, so jumping still works',
+  (bool)preg_match('/<div id="progressBar" style="width: 100%;">/', $event_src),
+  'the help text keeps the navigation aspect when the progress display is off');
+
+print $failures ? "\n$failures failed\n" : "\nall passed\n";
+exit($failures ? 1 : 0);

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -463,7 +463,10 @@ if ($video_tag) {
                   </div><!--"#videoFeedStream"-->
                   <div id="progressBar" style="width: 100%;">
                     <div id="alarmCues" style="width: 100%;"></div>
-                    <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
+                    <?php # progressBox is the replay position fill. ZM_WEB_SHOW_PROGRESS turns
+                          # the progress display off while keeping the bar itself, which is what
+                          # you click to jump around the event. See #4850. ?>
+                    <div class="progressBox" id="progressBox" title="" style="width: 0%;<?php echo ZM_WEB_SHOW_PROGRESS ? '' : 'display:none;' ?>"></div>
                     <div id="indicator" style="display: none;"></div>
                   </div><!--progressBar-->
                   <svg class="zones" id="zones<?php echo $monitor->Id() ?>" style="display:<?php echo $showZones ? 'block' : 'none'; ?>" viewBox="0 0 100 100" preserveAspectRatio="none">
@@ -531,7 +534,7 @@ if (defined('AUDIO_MOTION_ENABLED') && AUDIO_MOTION_ENABLED) echo '
   #rates are defined in skins/classic/includes/config.php
   echo htmlSelect('rate', $rates, intval($rate), array('id'=>'rateValue'));
 ?>
-                  <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
+                  <span id="progress"<?php echo ZM_WEB_SHOW_PROGRESS ? '' : ' style="display:none;"' ?>><?php echo translate('Progress') ?>: <span id="progressValue">0</span>s</span>
                   <span id="currentTime"><?php echo translate('Time') ?>: <span id="currentTimeValue"></span></span>
                   <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue">1</span>x</span>
 <?php if (!$video_tag) { ?>


### PR DESCRIPTION
Fixes #4850.

`ZM_WEB_SHOW_PROGRESS` was defined per bandwidth tier in the skin config, translated into several languages and shown in Options, but nothing ever read it, so the setting did nothing.

@IgorA100 asked whether it should hide the whole panel. I read the option's own help text as no: it says it turns off the progress display "whilst still keeping the navigation aspect", so this hides the position fill and the Progress readout and leaves the bar clickable for jumping. Say the word if you meant the whole panel.

Tests: `php tests/php/test_web_option_wiring.php`, which also asserts no other per-tier web option is left unread. Fails on current master.
