### PR TITLE
fix: keep the per-event export dir to the owner and off the flat path

### DIFF
--- a/tests/php/test_export_dir_permissions.php
+++ b/tests/php/test_export_dir_permissions.php
@@ -1,13 +1,23 @@
 <?php
-// Exporting events created the per-event subdirectory with a bare mkdir(), so
-// its mode came from the PHP process umask. A strict umask leaves it with no
-// execute bit, and a directory with no execute bit cannot be traversed even by
-// root, because the search check is the one thing CAP_DAC_OVERRIDE does not
-// bypass. Every copy into it then failed with permission denied and the export
-// came out incomplete with nothing useful in the UI. Issue #5074, reported with
-// this diagnosis by techrockedge.
+// Exports hold event footage, and the export path keeps its directories to the
+// owning user: ZM_DIR_EXPORTS and the per-export directory are both chmod 0700,
+// as are all three directories in download_functions.php. The per-event
+// directory was created with a bare mkdir(), so its mode came from the umask
+// instead, leaving it 0755 under the usual 0022. The footage was world readable
+// and only the 0700 parent above it was keeping anyone out. Issue #5074.
+//
+// Note on the umask: parent permissions do not propagate to a child directory,
+// only a POSIX default ACL would do that and ZM sets none, so the umask alone
+// decides the mode.
+//
+// The source checks below read the file with token_get_all() rather than
+// matching text. Regex versions of these passed on the very regressions they
+// name: one matched any chmod near a mkdir regardless of which directory it
+// applied to, one skipped any mkdir that carried a mode argument, and one never
+// looked at the mode at all, so reverting 0700 to 0755 went unnoticed.
 // Run: php tests/php/test_export_dir_permissions.php   (from the repo root)
 
+$root = __DIR__.'/../..';
 $failures = 0;
 function check($label, $ok, $detail = '') {
   global $failures;
@@ -15,62 +25,156 @@ function check($label, $ok, $detail = '') {
   printf("[%s] %s%s\n", $ok ? 'PASS' : 'FAIL', $label, ($ok || $detail === '') ? '' : "\n        $detail");
 }
 
-$root = __DIR__.'/../..';
+// ---- source model -------------------------------------------------------
+// Significant tokens only, so positions are stable against comments and layout.
+function zm_tokens($src) {
+  $out = array();
+  foreach (token_get_all($src) as $t) {
+    if (is_array($t)) {
+      if ($t[0] === T_WHITESPACE || $t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT) continue;
+      $out[] = array('text' => $t[1], 'line' => $t[2], 'id' => $t[0]);
+    } else {
+      $out[] = array('text' => $t, 'line' => null, 'id' => null);
+    }
+  }
+  // carry the last known line onto punctuation
+  $line = 0;
+  foreach ($out as $i => $t) {
+    if ($t['line'] !== null) $line = $t['line'];
+    else $out[$i]['line'] = $line;
+  }
+  return $out;
+}
+
+// Every call to $name, with its arguments split at top level.
+function zm_calls($tokens, $name) {
+  $calls = array();
+  for ($i = 0; $i < count($tokens); $i++) {
+    if ($tokens[$i]['id'] !== T_STRING || $tokens[$i]['text'] !== $name) continue;
+    if (!isset($tokens[$i + 1]) || $tokens[$i + 1]['text'] !== '(') continue;
+    // a method call is not what we are looking for
+    if ($i > 0 && in_array($tokens[$i - 1]['text'], array('->', '::'), true)) continue;
+    $depth = 0;
+    $args = array();
+    $cur = '';
+    for ($j = $i + 1; $j < count($tokens); $j++) {
+      $tx = $tokens[$j]['text'];
+      if ($tx === '(') {
+        $depth++;
+        if ($depth === 1) continue;
+      } elseif ($tx === ')') {
+        $depth--;
+        if ($depth === 0) { $args[] = trim($cur); break; }
+      } elseif ($tx === ',' && $depth === 1) {
+        $args[] = trim($cur);
+        $cur = '';
+        continue;
+      }
+      $cur .= $tx;
+    }
+    $calls[] = array('line' => $tokens[$i]['line'], 'args' => $args);
+  }
+  return $calls;
+}
+
+// Line range of the block guarded by if ($exportStructure != 'flat').
+function zm_non_flat_block($tokens) {
+  for ($i = 0; $i < count($tokens); $i++) {
+    if ($tokens[$i]['id'] !== T_IF) continue;
+    // scan the condition
+    $depth = 0; $sawVar = false; $sawNe = false; $sawFlat = false; $j = $i + 1;
+    for (; $j < count($tokens); $j++) {
+      $tx = $tokens[$j]['text'];
+      if ($tx === '(') { $depth++; continue; }
+      if ($tx === ')') { $depth--; if ($depth === 0) { $j++; break; } continue; }
+      if ($tokens[$j]['id'] === T_VARIABLE && $tx === '$exportStructure') $sawVar = true;
+      if ($tokens[$j]['id'] === T_IS_NOT_EQUAL || $tokens[$j]['id'] === T_IS_NOT_IDENTICAL) $sawNe = true;
+      if ($tokens[$j]['id'] === T_CONSTANT_ENCAPSED_STRING && trim($tx, "'\"") === 'flat') $sawFlat = true;
+    }
+    if (!($sawVar && $sawNe && $sawFlat)) continue;
+    if (!isset($tokens[$j]) || $tokens[$j]['text'] !== '{') continue;
+    $start = $tokens[$j]['line'];
+    $bd = 0;
+    for ($k = $j; $k < count($tokens); $k++) {
+      if ($tokens[$k]['text'] === '{') $bd++;
+      elseif ($tokens[$k]['text'] === '}') {
+        $bd--;
+        if ($bd === 0) return array($start, $tokens[$k]['line']);
+      }
+    }
+  }
+  return null;
+}
+
+// ---- what a bare mkdir actually leaves behind ---------------------------
 $base = sys_get_temp_dir().'/zm_export_perm_'.getmypid();
 @mkdir($base);
-
-// The reporter's environment: a umask that strips the execute bits.
-$old_umask = umask(0117);
-
-// What the code used to do.
+$old_umask = umask(0022);
 $bare = $base.'/bare';
 @mkdir($bare);
 $bare_mode = fileperms($bare) & 0777;
-check('a bare mkdir under a strict umask loses the execute bits',
-  ($bare_mode & 0111) === 0,
-  sprintf('got mode %04o, so this platform does not reproduce the report', $bare_mode));
-
-// Writing through such a directory is what actually broke.
-$probe = @file_put_contents($bare.'/probe.txt', 'x');
-check('and the directory cannot be written through', $probe === false,
-  'expected the write to fail, so the export failure is reproduced');
-
-// What the code does now.
+check('a bare mkdir under the usual umask is world readable',
+  $bare_mode === 0755, sprintf('got mode %04o, want 0755', $bare_mode));
+// This half exercises PHP's own chmod, not ZoneMinder: exportEvents() needs a
+// database, config constants and exec(), so it cannot be called from here. It
+// documents the intended mode, it is not behavioural coverage of the export.
 $fixed = $base.'/fixed';
 @mkdir($fixed);
 chmod($fixed, 0700);
 $fixed_mode = fileperms($fixed) & 0777;
-check('an explicit chmod gives a predictable mode regardless of umask',
+check('an explicit chmod keeps it to the owner',
   $fixed_mode === 0700, sprintf('got mode %04o, want 0700', $fixed_mode));
-check('and the directory can be written through',
-  @file_put_contents($fixed.'/probe.txt', 'x') !== false);
-
 umask($old_umask);
-@unlink($fixed.'/probe.txt');
-@chmod($bare, 0700);
-@rmdir($bare);
-@rmdir($fixed);
-@rmdir($base);
+@rmdir($bare); @rmdir($fixed); @rmdir($base);
 
-// Guard the source itself: every mkdir in the export path must be followed by an
-// explicit chmod, since this was the one of three that was not.
-$src = file_get_contents($root.'/web/skins/classic/includes/export_functions.php');
-$lines = explode("\n", $src);
-$unchmodded = array();
-foreach ($lines as $i => $line) {
-  if (strpos($line, 'mkdir(') === false) continue;
-  // chmod follows within a few lines, past any error handling and comments.
-  $window = implode("\n", array_slice($lines, $i, 12));
-  if (strpos($window, 'chmod(') === false) $unchmodded[] = $i + 1;
+// ---- source guards ------------------------------------------------------
+$path = $root.'/web/skins/classic/includes/export_functions.php';
+$src = file_get_contents($path);
+$tokens = zm_tokens($src);
+$mkdirs = zm_calls($tokens, 'mkdir');
+$chmods = zm_calls($tokens, 'chmod');
+
+check('the export path still creates directories', count($mkdirs) > 0);
+
+// Pair by the actual first argument, whatever form the mkdir takes. An
+// unreadable argument counts as unpaired rather than being skipped.
+$unpaired = array();
+$wrong_mode = array();
+foreach ($mkdirs as $mk) {
+  $target = isset($mk['args'][0]) ? $mk['args'][0] : '';
+  if ($target === '') { $unpaired[] = $mk['line'].': (unreadable argument)'; continue; }
+  $paired = null;
+  foreach ($chmods as $ch) {
+    if (isset($ch['args'][0]) && $ch['args'][0] === $target) { $paired = $ch; break; }
+  }
+  if ($paired === null) { $unpaired[] = $mk['line'].': '.$target; continue; }
+  $mode = isset($paired['args'][1]) ? $paired['args'][1] : '';
+  if ($mode !== '0700') $wrong_mode[] = $paired['line'].': '.$target.' set to '.($mode === '' ? '(none)' : $mode);
 }
-check('every mkdir in the export path sets its mode explicitly',
-  count($unchmodded) === 0,
-  'mkdir with no following chmod at line(s): '.implode(', ', $unchmodded));
+check('every mkdir in the export path chmods that same directory',
+  count($unpaired) === 0, 'unpaired: '.implode('; ', $unpaired));
+check('and sets it to 0700, not something the world can read',
+  count($wrong_mode) === 0, implode('; ', $wrong_mode));
 
-// And a failed mkdir must skip the event rather than writing into a path that
-// does not exist, which is what made the failure silent.
-check('a failed export mkdir skips that event',
-  (bool)preg_match('/Can\'t mkdir \$event_dir"\);\s*\n\s*continue;/', $src));
+// The per-event directory belongs to the non-flat structure. A flat export
+// copies into $export_dir directly and never touches it, so creating it there,
+// and skipping the event when that fails, would drop events that export fine.
+$block = zm_non_flat_block($tokens);
+check('the export still branches on a non-flat structure', $block !== null);
+if ($block !== null) {
+  $inside = false;
+  foreach ($mkdirs as $mk) {
+    if (isset($mk['args'][0]) && $mk['args'][0] === '$event_dir'
+        && $mk['line'] > $block[0] && $mk['line'] < $block[1]) {
+      $inside = true;
+    }
+  }
+  check('the per-event directory is only created inside that branch', $inside,
+    sprintf('non-flat block spans lines %d-%d; mkdir($event_dir) at %s',
+      $block[0], $block[1],
+      implode(',', array_map(function($m) { return $m['line']; },
+        array_filter($mkdirs, function($m) { return ($m['args'][0] ?? '') === '$event_dir'; })))));
+}
 
 print $failures ? "\n$failures failed\n" : "\nall passed\n";
 exit($failures ? 1 : 0);

--- a/tests/php/test_export_dir_permissions.php
+++ b/tests/php/test_export_dir_permissions.php
@@ -1,0 +1,76 @@
+<?php
+// Exporting events created the per-event subdirectory with a bare mkdir(), so
+// its mode came from the PHP process umask. A strict umask leaves it with no
+// execute bit, and a directory with no execute bit cannot be traversed even by
+// root, because the search check is the one thing CAP_DAC_OVERRIDE does not
+// bypass. Every copy into it then failed with permission denied and the export
+// came out incomplete with nothing useful in the UI. Issue #5074, reported with
+// this diagnosis by techrockedge.
+// Run: php tests/php/test_export_dir_permissions.php   (from the repo root)
+
+$failures = 0;
+function check($label, $ok, $detail = '') {
+  global $failures;
+  if (!$ok) $failures++;
+  printf("[%s] %s%s\n", $ok ? 'PASS' : 'FAIL', $label, ($ok || $detail === '') ? '' : "\n        $detail");
+}
+
+$root = __DIR__.'/../..';
+$base = sys_get_temp_dir().'/zm_export_perm_'.getmypid();
+@mkdir($base);
+
+// The reporter's environment: a umask that strips the execute bits.
+$old_umask = umask(0117);
+
+// What the code used to do.
+$bare = $base.'/bare';
+@mkdir($bare);
+$bare_mode = fileperms($bare) & 0777;
+check('a bare mkdir under a strict umask loses the execute bits',
+  ($bare_mode & 0111) === 0,
+  sprintf('got mode %04o, so this platform does not reproduce the report', $bare_mode));
+
+// Writing through such a directory is what actually broke.
+$probe = @file_put_contents($bare.'/probe.txt', 'x');
+check('and the directory cannot be written through', $probe === false,
+  'expected the write to fail, so the export failure is reproduced');
+
+// What the code does now.
+$fixed = $base.'/fixed';
+@mkdir($fixed);
+chmod($fixed, 0700);
+$fixed_mode = fileperms($fixed) & 0777;
+check('an explicit chmod gives a predictable mode regardless of umask',
+  $fixed_mode === 0700, sprintf('got mode %04o, want 0700', $fixed_mode));
+check('and the directory can be written through',
+  @file_put_contents($fixed.'/probe.txt', 'x') !== false);
+
+umask($old_umask);
+@unlink($fixed.'/probe.txt');
+@chmod($bare, 0700);
+@rmdir($bare);
+@rmdir($fixed);
+@rmdir($base);
+
+// Guard the source itself: every mkdir in the export path must be followed by an
+// explicit chmod, since this was the one of three that was not.
+$src = file_get_contents($root.'/web/skins/classic/includes/export_functions.php');
+$lines = explode("\n", $src);
+$unchmodded = array();
+foreach ($lines as $i => $line) {
+  if (strpos($line, 'mkdir(') === false) continue;
+  // chmod follows within a few lines, past any error handling and comments.
+  $window = implode("\n", array_slice($lines, $i, 12));
+  if (strpos($window, 'chmod(') === false) $unchmodded[] = $i + 1;
+}
+check('every mkdir in the export path sets its mode explicitly',
+  count($unchmodded) === 0,
+  'mkdir with no following chmod at line(s): '.implode(', ', $unchmodded));
+
+// And a failed mkdir must skip the event rather than writing into a path that
+// does not exist, which is what made the failure silent.
+check('a failed export mkdir skips that event',
+  (bool)preg_match('/Can\'t mkdir \$event_dir"\);\s*\n\s*continue;/', $src));
+
+print $failures ? "\n$failures failed\n" : "\nall passed\n";
+exit($failures ? 1 : 0);

--- a/web/skins/classic/includes/export_functions.php
+++ b/web/skins/classic/includes/export_functions.php
@@ -943,7 +943,15 @@ function exportEvents(
     $event_dir = $export_dir.'/'.$event->Id();
     if (!(@mkdir($event_dir) or file_exists($event_dir))) {
       ZM\Error("Can't mkdir $event_dir");
+      continue;
     }
+    // mkdir() applies the process umask, so a strict enough one leaves this
+    // with no execute bit at all, and a directory with no execute bit is not
+    // traversable even by root: the search check is the one thing
+    // CAP_DAC_OVERRIDE does not bypass. Every copy into it then fails with
+    // permission denied and the export quietly comes out incomplete. Set the
+    // mode explicitly, the same as the two directories above. See #5074.
+    chmod($event_dir, 0700);
     $event_exportFileList = exportFileList($event, $exportDetail, $exportFrames, $exportImages, $exportVideo, $exportMisc);
     #$exportFileList = array_merge($exportFileList, $event_exportFileList);
     foreach ($event_exportFileList as $file) {

--- a/web/skins/classic/includes/export_functions.php
+++ b/web/skins/classic/includes/export_functions.php
@@ -912,7 +912,9 @@ function exportEvents(
   if (!(@mkdir(ZM_DIR_EXPORTS) or file_exists(ZM_DIR_EXPORTS))) {
     ZM\Fatal('Can\'t create exports dir at \''.ZM_DIR_EXPORTS.'\'');
   }
-  chmod(ZM_DIR_EXPORTS, 0700);
+  if (!chmod(ZM_DIR_EXPORTS, 0700)) {
+    ZM\Error('Can\'t chmod '.ZM_DIR_EXPORTS.' to 0700');
+  }
   $export_dir = ZM_DIR_EXPORTS.'/'.$export_root.($connkey?'_'.$connkey:'');
 
   # Ensure that we are going to be able to do this.
@@ -920,7 +922,9 @@ function exportEvents(
     ZM\Error("Can't create exports dir at '$export_dir'");
     return false;
   }
-  chmod($export_dir, 0700);
+  if (!chmod($export_dir, 0700)) {
+    ZM\Error("Can't chmod $export_dir to 0700");
+  }
   if (!chdir($export_dir)) {
     ZM\Error("Can't chdir to $export_dir");
     return;
@@ -940,18 +944,26 @@ function exportEvents(
       ZM\Warning('User '.($user?$user->Username():'').' cannot view event '.$event->Id());
       continue;
     }
-    $event_dir = $export_dir.'/'.$event->Id();
-    if (!(@mkdir($event_dir) or file_exists($event_dir))) {
-      ZM\Error("Can't mkdir $event_dir");
-      continue;
+    // Only the non-flat structure writes into a per-event directory. A flat
+    // export copies straight into $export_dir below, so creating this one, and
+    // skipping the event when that fails, would drop events that would have
+    // exported perfectly well.
+    if ($exportStructure != 'flat') {
+      $event_dir = $export_dir.'/'.$event->Id();
+      if (!(@mkdir($event_dir) or file_exists($event_dir))) {
+        ZM\Error("Can't mkdir $event_dir");
+        continue;
+      }
+      // Exports hold event footage, and this code keeps export directories to
+      // the owning user: ZM_DIR_EXPORTS and $export_dir above are both set to
+      // 0700, as are all three directories in download_functions.php. mkdir()
+      // takes its mode from the umask instead, which for the usual 0022 leaves
+      // this one 0755, so the footage is world readable and only the 0700
+      // parent is keeping anyone out. See #5074.
+      if (!chmod($event_dir, 0700)) {
+        ZM\Error("Can't chmod $event_dir to 0700");
+      }
     }
-    // mkdir() applies the process umask, so a strict enough one leaves this
-    // with no execute bit at all, and a directory with no execute bit is not
-    // traversable even by root: the search check is the one thing
-    // CAP_DAC_OVERRIDE does not bypass. Every copy into it then fails with
-    // permission denied and the export quietly comes out incomplete. Set the
-    // mode explicitly, the same as the two directories above. See #5074.
-    chmod($event_dir, 0700);
     $event_exportFileList = exportFileList($event, $exportDetail, $exportFrames, $exportImages, $exportVideo, $exportMisc);
     #$exportFileList = array_merge($exportFileList, $event_exportFileList);
     foreach ($event_exportFileList as $file) {


### PR DESCRIPTION
refs #5074 rather than fixes, since per your analysis this is not what causes the reported symptom.

The per-event export directory was the only mkdir in the export path with no chmod after it, so its mode came from the umask: 0755 under the usual 0022, leaving event footage world readable behind a 0700 parent. It is 0700 now like the other two here and all three in download_functions.php, and the three chmods report failure instead of failing silently. The mkdir and its continue moved inside the non-flat branch, since a flat export copies into $export_dir directly and never uses that directory.

Tests: `php tests/php/test_export_dir_permissions.php`.
