### PR TITLE
fix: stop installing vendored jwt-cpp headers into the prefix

### DIFF
--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Only build vendored jwt-cpp if not using system-installed version
 if(NOT HAVE_SYSTEM_JWT_CPP)
-  add_subdirectory(jwt-cpp)
+  # EXCLUDE_FROM_ALL so the vendored copy's own install() rules do not stage
+  # jwt-cpp headers, picojson.h and its cmake package files into our install
+  # prefix. It is a header-only INTERFACE target, so it still links. See #4590.
+  add_subdirectory(jwt-cpp EXCLUDE_FROM_ALL)
 endif()
 add_subdirectory(libbcrypt)
 add_subdirectory(RtspServer)


### PR DESCRIPTION
Fixes #4590.

The vendored jwt-cpp runs its own install() rules, so a build stages jwt-cpp's headers, picojson.h and three cmake package files into the install prefix. That is what @abishai was seeing in the FreeBSD staging directory. CxxUrl in the same file is already kept out of the install this way, via ENABLE_INSTALL; jwt-cpp has no equivalent option, so EXCLUDE_FROM_ALL does it.

Checked by installing to a scratch prefix before and after: 5 jwt-cpp and picojson files staged before, none after, and zmu still builds since it is a header-only INTERFACE target. The system-jwt path is untouched, this only applies when the vendored copy is used.
