### PR TITLE
docs: note the render group for vaapi and qsv decoding

### DIFF
--- a/docs/installationguide/debian.rst
+++ b/docs/installationguide/debian.rst
@@ -101,6 +101,15 @@ but if you installed from source or the group was not added, run:
 
     sudo adduser www-data video
 
+If you plan to use hardware accelerated decoding (``DecoderHWAccelName`` set to
+``vaapi`` or ``qsv``), the web server user also needs the ``render`` group. The
+render node ``/dev/dri/renderD*`` belongs to ``render`` rather than ``video``,
+and without it ZoneMinder logs ``Failed to create hwaccel device``:
+
+::
+
+    sudo adduser www-data render
+
 **Step 7:** Tweak Apache configuration
 
 ::
@@ -210,6 +219,15 @@ but if you installed from source or the group was not added, run:
 ::
 
     sudo adduser www-data video
+
+If you plan to use hardware accelerated decoding (``DecoderHWAccelName`` set to
+``vaapi`` or ``qsv``), the web server user also needs the ``render`` group. The
+render node ``/dev/dri/renderD*`` belongs to ``render`` rather than ``video``,
+and without it ZoneMinder logs ``Failed to create hwaccel device``:
+
+::
+
+    sudo adduser www-data render
 
 **Step 7:** Tweak Apache configuration
 

--- a/docs/installationguide/ubuntu.rst
+++ b/docs/installationguide/ubuntu.rst
@@ -65,6 +65,15 @@ automatically, but if you installed from source or the group was not added, run:
 
         sudo adduser www-data video
 
+If you plan to use hardware accelerated decoding (``DecoderHWAccelName`` set to
+``vaapi`` or ``qsv``), the web server user also needs the ``render`` group. The
+render node ``/dev/dri/renderD*`` belongs to ``render`` rather than ``video``,
+and without it ZoneMinder logs ``Failed to create hwaccel device``:
+
+::
+
+        sudo adduser www-data render
+
 You will need to restart ZoneMinder (or reboot) for the group change to take effect.
 
 **Step 7:** Configure Apache correctly:
@@ -213,6 +222,15 @@ user to the ``video`` group:
 ::
 
         sudo adduser www-data video
+
+If you plan to use hardware accelerated decoding (``DecoderHWAccelName`` set to
+``vaapi`` or ``qsv``), the web server user also needs the ``render`` group. The
+render node ``/dev/dri/renderD*`` belongs to ``render`` rather than ``video``,
+and without it ZoneMinder logs ``Failed to create hwaccel device``:
+
+::
+
+        sudo adduser www-data render
 
 **Step 7:** Configure Apache correctly:
 


### PR DESCRIPTION
Fixes #4205.

@timrichardson hit "Failed to create hwaccel device" with vaapi until adding www-data to the render group. That checks out: the render node is root:render while only the card node is root:video, so the existing video-group instruction does not cover hardware decoding.

Added beside each of the four existing video-group notes in the Ubuntu and Debian guides. Docs only, no postinst change, since granting the web server user GPU access on every install is your call.
