### PR TITLE
fix: merge the duplicate OPTIONS_WHATTODISPLAY help in en_gb

### DIFF
--- a/web/lang/en_gb.php
+++ b/web/lang/en_gb.php
@@ -1082,7 +1082,11 @@ Always: A zmc process will run and immediately connect and stay connected.~~~~
     ),
   'OPTIONS_WHATTODISPLAY' => array(
      'Help' => '
-     On the Watch, Montage, Event page, you can display either a video stream, or an audio stream visualization, or both a video stream and an audio visualization.
+     On the Watch, Montage, Event page, you can display either a video stream, or an audio stream visualization, or both a video stream and an audio visualization.~~
+     To display the audio motion visualization, install the file "/skins/MySkin/assets/audioMotion-analyzer/src/audioMotion-analyzer.js".~~
+     This file can be downloaded from the following links:~~
+     https://cdn.jsdelivr.net/npm/audiomotion-analyzer@X.X.X where X.X.X is the version number~~
+     https://github.com/hvianna/audioMotion-analyzer/releases
      ',
     ),
   'FUNCTION_ANALYSIS_ENABLED' => array(
@@ -1179,15 +1183,6 @@ None: No frames will be decoded, live view and thumbnails will not be available~
      - SceneTemperature~~
      - Tamper~~
      For more details, see the instructions for your camera, as well as the specifications at the link:~~https://www.onvif.org/specs/core/ONVIF-Core-Specification.pdf
-    '
-   ),
-   'OPTIONS_WHATTODISPLAY' => array(
-    'Help' => '
-     Audio motion visualization can be displayed on the Montage, Watch, and Event pages.~~
-     To do this, install the file "/skins/MySkin/assets/audioMotion-analyzer/src/audioMotion-analyzer.js".~~
-     This file can be downloaded from the following links:~~
-     https://cdn.jsdelivr.net/npm/audiomotion-analyzer@X.X.X where X.X.X is the version number~~
-     https://github.com/hvianna/audioMotion-analyzer/releases
     '
    ),
   'ZM_OPT_TRAINING' => array(


### PR DESCRIPTION
`web/lang/en_gb.php` sets `OPTIONS_WHATTODISPLAY` twice in the same array, once around line 1083 and again around line 1184, with different help text. PHP keeps the last one, so the help that actually explains the option, video stream or audio visualization or both, has never reached the options page. What users see instead is only the audioMotion-analyzer install note that came in with #4393.

I merged the two texts into the first entry rather than picking one, since neither is wrong and together they answer both questions the option raises.

The translation files carry the same shape and I left them alone, because choosing between two translations is not my call: `ru_ru.php` has `Scale` three times and `None` twice, `es_la.php` has `Scale` three times, and in both the later value wins over the one that carries the `// Montage Review -> type button` comment. `ba_ba.php` and `zh_tw.php` repeat `Available` with the identical value, which is harmless.
