### PR TITLE
refactor: remove the FrameSkip control and its unread member

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -101,7 +101,7 @@ std::string load_monitor_sql =
   "`ImageBufferCount`, `MaxImageBufferCount`, `WarmupCount`, `PreEventCount`, "
   "`PostEventCount`, `StreamReplayBuffer`, `AlarmFrameCount`, "
   "`SectionLength`, `SectionLengthWarn`, `MinSectionLength`, `EventCloseMode`+0, "
-  "`FrameSkip`, `MotionFrameSkip`, "
+  "`MotionFrameSkip`, "
   "`FPSReportInterval`, `RefBlendPerc`, `AlarmRefBlendPerc`, `TrackMotion`, `Exif`, "
   "`Latitude`, `Longitude`, "
   "`RTSPServer`, `RTSPStreamName`, `SOAP_wsa_compl`, `ONVIF_Alarm_Text`,"
@@ -245,7 +245,6 @@ Monitor::Monitor() :
   min_section_length(0),
   startstop_on_section_length(false),
   adaptive_skip(false),
-  frame_skip(0),
   motion_frame_skip(0),
   analysis_fps_limit(0),
   analysis_update_delay(0),
@@ -618,7 +617,7 @@ void Monitor::Load(MYSQL_ROW dbrow, bool load_zones=true, Purpose p = QUERY) {
   packetqueue.setMaxVideoPackets(max_image_buffer_count);
   packetqueue.setKeepKeyframes((videowriter == PASSTHROUGH) && (recording != RECORDING_NONE));
 
-  /* "SectionLength, SectionLengthWarn, MinSectionLength, EventCloseMode, FrameSkip, MotionFrameSkip, " */
+  /* "SectionLength, SectionLengthWarn, MinSectionLength, EventCloseMode, MotionFrameSkip, " */
   section_length = Seconds(atoi(dbrow[col]));
   col++;
   section_length_warn = dbrow[col] ? atoi(dbrow[col]) : false;
@@ -661,8 +660,6 @@ void Monitor::Load(MYSQL_ROW dbrow, bool load_zones=true, Purpose p = QUERY) {
       event_close_mode = CLOSE_IDLE;
   }
 
-  frame_skip = atoi(dbrow[col]);
-  col++;
   motion_frame_skip = atoi(dbrow[col]);
   col++;
 

--- a/src/zm_monitor.h
+++ b/src/zm_monitor.h
@@ -625,7 +625,6 @@ class Monitor : public std::enable_shared_from_this<Monitor> {
   Seconds    min_section_length;   // Minimum event length when using event_close_mode == ALARM
   bool       startstop_on_section_length; // Whether to start/stop events on time % section_length
   bool       adaptive_skip;        // Whether to use the newer adaptive algorithm for this monitor
-  int        frame_skip;        // How many frames to skip in continuous modes
   int        motion_frame_skip;      // How many frames to skip in motion detection
   double     analysis_fps_limit;     // Target framerate for video analysis
   Microseconds analysis_update_delay;  //  How long we wait before updating analysis parameters

--- a/web/skins/classic/views/js/monitor.js.php
+++ b/web/skins/classic/views/js/monitor.js.php
@@ -162,8 +162,6 @@ function validateForm(form) {
       errors[errors.length] = "<?php echo translate('BadAnalysisUpdateDelay') ?>";
     if ( !form.elements['newMonitor[FPSReportInterval]'].value || !(parseInt(form.elements['newMonitor[FPSReportInterval]'].value) >= 0 ) )
       errors[errors.length] = "<?php echo translate('BadFPSReportInterval') ?>";
-    if ( !form.elements['newMonitor[FrameSkip]'].value || !(parseInt(form.elements['newMonitor[FrameSkip]'].value) >= 0 ) )
-      errors[errors.length] = "<?php echo translate('BadFrameSkip') ?>";
     if ( !form.elements['newMonitor[MotionFrameSkip]'].value || !(parseInt(form.elements['newMonitor[MotionFrameSkip]'].value) >= 0 ) )
       errors[errors.length] = "<?php echo translate('BadMotionFrameSkip') ?>";
     if ( form.elements['newMonitor[Type]'].value == 'Local' )

--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -1592,11 +1592,6 @@ echo htmlSelect('newMonitor[ReturnLocation]', $return_options, $monitor->ReturnL
           <span class="form-text form-control-sm">When continuous events are closed.&nbsp;(<a id="ZM_EVENT_CLOSE_MODE" class="optionhelp">?</a>)</span>
         </li>
         <li>
-          <label><?php echo translate('FrameSkip') ?></label>
-            <input type="number" name="newMonitor[FrameSkip]" value="<?php echo validHtmlStr($monitor->FrameSkip()) ?>" min="0"/>
-            <?php echo translate('frames')?>
-        </li>
-        <li>
           <label><?php echo translate('MotionFrameSkip') ?></label>
             <input type="number" name="newMonitor[MotionFrameSkip]" value="<?php echo validHtmlStr($monitor->MotionFrameSkip()) ?>" min="0"/>
             <?php echo translate('frames')?>


### PR DESCRIPTION
FrameSkip is written into `Monitor::frame_skip` and never read, so the Misc tab has been offering a control that does nothing. The analysis loop's use of it was commented out years ago and the remnant deleted in cb60b6c14. This removes the form control, the BadFrameSkip validator, the member and its initialiser.

`Monitor::Load` walks the columns positionally, so `FrameSkip` has to come out of `load_monitor_sql` in the same change: dropping the read on its own would shift every field after it by one column. That makes it four C++ edits rather than the three write-only sites. No schema change here, so the column, the model default, the Perl fields and the lang keys are left for the follow-up.

Checked the reader stays aligned by walking the column cursor over `Monitor::Load` before and after: 109 columns and 108 reads become 108 and 107, and every column except FrameSkip still maps to the same variable. The -Werror build and eslint are green on my fork.

Refs #3570.
