### PR TITLE
fix: stop the Events_Lock comment from closing early in zm_create.sql

### DIFF
--- a/db/zm_create.sql.in
+++ b/db/zm_create.sql.in
@@ -371,7 +371,7 @@ CREATE TABLE `Events_Archived` (
  * event before working on it. Deliberately NOT a row lock: claiming is a single
  * autocommitted INSERT touching one row here, so no lock is held while the
  * filter works, and nothing in this table can deadlock against, or block, the
- * writers that touch Events/Events_*/Event_Summaries.
+ * writers that touch Events, the Events_* tables and Event_Summaries.
  * No foreign key to Events for the same reason - it would make every event
  * delete take a lock in here. Rows for deleted events are harmless and expire.
  */


### PR DESCRIPTION
The Events_Lock comment added in ad1c01a50 contains `Events/Events_*/Event_Summaries.`, and the `*/` inside that path closes the comment block, so the following lines are parsed as SQL and the file stops at line 374.

Loading unmodified master into MariaDB 11 gives `ERROR 1064` there and creates 11 of the 48 tables, leaving a database with no Monitors. With the path reworded the same load creates all 55 tables and reports nothing.

Comment text only, no schema change.
