### PR TITLE
fix: reach the montage review panel controls in sidebar filter mode

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -2507,10 +2507,16 @@ function insertControlModuleMenu() {
     filter = document.createElement('div');
     filter.setAttribute("id", "filterMontagereview");
 
-    const filterOne = document.querySelector('#mfbpanel .controlHeader');
+    // Named precisely: #fieldsTable also carries .controlHeader, so a looser
+    // '#mfbpanel .controlHeader' silently matches it instead when the monitor
+    // filter bar is absent, which hides the fact that the attribute filters
+    // never made it into the extruder.
+    const filterOne = document.querySelector('#monitorFilterBar .controlHeader');
     const filterTwo = document.querySelector('#fieldsTable');
-    filter.prepend(filterTwo);
-    filter.prepend(filterOne);
+    // Either can be absent - a filter with no terms renders no #fieldsTable -
+    // and prepend() stringifies null into a literal 'null' text node.
+    if (filterTwo) filter.prepend(filterTwo);
+    if (filterOne) filter.prepend(filterOne);
   } else if (currentView == 'watch') {
     destroyChosen();
     filter = document.querySelector('.controlHeader form');

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -1309,13 +1309,18 @@ function loadEventData(e) {
       const name = el.attr('name');
 
       if (name) {
-        const found = name.match(/filter\[Query\]\[terms\]\[(\d)+\]\[val\]/);
+        const found = name.match(/filter\[Query\]\[terms\]\[(\d+)\]\[val\]/);
         if (found) {
           const attr_name = 'filter[Query][terms]['+found[1]+'][attr]';
-          const attr = this.form.elements[attr_name];
           const op_name = 'filter[Query][terms]['+found[1]+'][op]';
-          const op = this.form.elements[op_name];
-          if (attr) {
+          // Looked up by name rather than through this.form: in sidebar filter
+          // mode insertControlModuleMenu() moves #fieldsTable out of
+          // #montagereview_form and into the extruder, leaving these inputs with
+          // no form owner. Scoped to #fieldsTable because term names are unique
+          // within a form, not within the document.
+          const attr = document.querySelector('#fieldsTable [name="'+attr_name+'"]');
+          const op = document.querySelector('#fieldsTable [name="'+op_name+'"]');
+          if (attr && op) {
             // Translate in a local rather than by writing back to attr.value:
             // the form is submitted when a filter changes, and
             // montagereview.php decides whether the range terms are already
@@ -1341,7 +1346,7 @@ function loadEventData(e) {
             }
             url += '/'+apiAttr+' '+op.value+':'+encodeURIComponent(urlVal);
           } else {
-            console.warn('No attr for '+attr_name);
+            console.warn('No attr/op for '+attr_name);
           }
         //} else {
           //console.log("No match for " + name);
@@ -1796,9 +1801,11 @@ function getMinMaxStartDateTimeElements() {
   $j('#fieldsTable input[value="StartDateTime"], #fieldsTable input[value="DateTime"]').each(function(index) {
     const matches = this.name.match(regexp);
     if (matches && matches.length) {
-      const val = this.form.elements['filter[Query][terms]['+matches[1]+'][val]'];
-      if (val) {
-        const op = this.form.elements['filter[Query][terms]['+matches[1]+'][op]'];
+      // Same reason as in loadEventData(): in sidebar filter mode these inputs have
+      // been moved out of the form, so this.form is null.
+      const val = document.querySelector('#fieldsTable [name="filter[Query][terms]['+matches[1]+'][val]"]');
+      const op = document.querySelector('#fieldsTable [name="filter[Query][terms]['+matches[1]+'][op]"]');
+      if (val && op) {
         if (op.value == '>=') {
           minStartDateTimeElement = val;
         } else if (op.value == '<=') {
@@ -1807,7 +1814,7 @@ function getMinMaxStartDateTimeElements() {
           console.warn('unknown op', op.value);
         }
       } else {
-        console.warn("no val ", matches);
+        console.warn("no val/op ", matches);
       }
     }
   });

--- a/web/skins/classic/views/montagereview.php
+++ b/web/skins/classic/views/montagereview.php
@@ -308,18 +308,17 @@ getBodyTopHTML();
     <div id="header">
 <?php
 $filter_inline = filterSettingsInline();
-$html = '';
-// In inline mode the filter panel sits at the top of the page and this flip
-// icon is what hides/shows it. In sidebar mode the panel lives in the sidebar
-// extruder, which has its own show/hide control, so the flip icon is omitted.
-if ($filter_inline) {
-  $html .= '<a class="flip" href="#"
-           data-flip-control-object="#mfbpanel"
-           data-flip-control-run-after-func="applyChosen drawGraph"
-           data-flip-control-run-after-complet-func="changeScale">
-             <i id="mfbflip" class="material-icons md-18" data-icon-visible="filter_alt_off" data-icon-hidden="filter_alt"></i>
-           </a>'.PHP_EOL;
-}
+// #mfbpanel holds more than the filter on this page. The scale and speed
+// sliders, the pan/zoom/period buttons, Live, Fit, Download Video and the
+// timeline are all inside it, and they stay behind when skin.js lifts the
+// filter out into the sidebar extruder. So this flip icon is the only way to
+// reach them in either mode and is rendered in both, as on montage and watch.
+$html = '<a class="flip" href="#"
+         data-flip-control-object="#mfbpanel"
+         data-flip-control-run-after-func="applyChosen drawGraph"
+         data-flip-control-run-after-complet-func="changeScale">
+           <i id="mfbflip" class="material-icons md-18" data-icon-visible="filter_alt_off" data-icon-hidden="filter_alt"></i>
+         </a>'.PHP_EOL;
 $html .= '<div id="mfbpanel" class="'.($filter_inline ? '' : 'hidden-shift ').'container-fluid">'.PHP_EOL;
 echo $html;
 // The monitor attribute filters pick which cameras are shown and are rarely
@@ -327,14 +326,26 @@ echo $html;
 // of the filter bar. skin.js applies hidden-shift from data-initial-state-icon,
 // which moves the block off screen while leaving it measurable so Chosen still
 // initialises the selects inside it.
-echo '<a class="flip" href="#"
-         data-flip-control-object="#monitorFilterBar"
-         data-initial-state-icon="hidden"
-         data-flip-control-run-after-func="applyChosen">
-        <i class="material-icons md-18" data-icon-visible="expand_less" data-icon-hidden="expand_more"></i>
-        '.translate('MonitorFilters').'
-      </a>'.PHP_EOL;
-echo '<div id="monitorFilterBar">'.$resultMonitorFilters['filterBarWithoutMonitor'].'</div>'.PHP_EOL;
+//
+// The toggle is inline-only: in sidebar mode insertControlModuleMenu() moves the
+// bar's contents into the extruder, which has its own control, so the toggle
+// would be left expanding an emptied container in a panel that is now reachable.
+if ($filter_inline) {
+  echo '<a class="flip" href="#"
+           data-flip-control-object="#monitorFilterBar"
+           data-initial-state-icon="hidden"
+           data-flip-control-run-after-func="applyChosen">
+          <i class="material-icons md-18" data-icon-visible="expand_less" data-icon-hidden="expand_more"></i>
+          '.translate('MonitorFilters').'
+        </a>'.PHP_EOL;
+}
+// The container itself is rendered in both modes: it is where
+// insertControlModuleMenu() collects the attribute filters from, so dropping it
+// in sidebar mode would not move them to the sidebar, it would lose them. With
+// no toggle there to do it, it carries the class that toggle would have applied,
+// keeping the emptied container out of the visible panel.
+echo '<div id="monitorFilterBar"'.($filter_inline ? '' : ' class="hidden-shift"').'>'.
+  $resultMonitorFilters['filterBarWithoutMonitor'].'</div>'.PHP_EOL;
 if (count($filter->terms())) {
   // The monitor selection is what those attribute filters produce, so it stays
   // on show with the event filter terms rather than collapsing with them. It is


### PR DESCRIPTION
Supersedes #5091, keeping its first hunk and reworking the second. Thanks @IgorA100 — the diagnosis there is right and the master code was mine to fix.

## The bug

`#mfbpanel` is not only the filter panel on montage review. It closes at `</div><!--flipMontageHeader-->`, so `#ScaleDiv`, `#SpeedDiv`, `#ButtonsDiv` (pan / zoom / 24h / 8h / 1h / All Events / **Live** / **Fit** / **Download Video**) and `#timelinediv` are all inside it, and they stay behind when `insertControlModuleMenu()` lifts the filter out into the sidebar extruder.

In sidebar mode (`ZM_WEB_FILTER_SETTINGS_POSITION` not `inline`, left navbar) the panel is rendered `hidden-shift` — `position:absolute; left:-999em` — with no flip icon, so every one of those controls was off screen with nothing to bring it back.

53f6a67fd flipped `if (!$filter_inline)` to `if ($filter_inline)` when the right answer was no condition at all; it verified inline mode regained its toggle and missed that the panel carries non-filter controls. #4999 had already settled this for montage.php and watch.php.

## Changes

**Render the `#mfbpanel` flip icon in both modes** — same as montage.php and watch.php. This is #5091's first hunk unchanged.

**Emit the MonitorFilters toggle inline only, but keep `#monitorFilterBar` in both modes.** With the panel now reachable in sidebar mode, that toggle would sit over a container whose contents have been moved to the extruder, so it is inline-only. The container itself has to stay: it is where `insertControlModuleMenu()` collects the attribute filters from, so omitting it does not move them to the sidebar, it drops the Group / Name / Source / Status / Server / Storage filters from montage review entirely. With no toggle in sidebar mode it carries the `hidden-shift` the toggle would otherwise have applied, keeping the emptied container out of the visible panel.

This is where this PR differs from #5091, which gates the container along with the toggle.

**Name the monitor filter bar directly in `insertControlModuleMenu()`.** `#fieldsTable` also carries `class="filterTable controlHeader"` (`Filter.php:1186`), so the previous `#mfbpanel .controlHeader` silently matches it when the bar is absent — `filterOne === filterTwo`, the double `prepend` is a no-op, and losing the attribute filters looks like it worked.

**Skip an absent node instead of passing it to `prepend()`**, which stringifies `null` into a literal `"null"` text node in the extruder. Reachable today: a request-supplied `filter` with no terms skips the default-term block and renders no `#fieldsTable`.

## Testing

`php -l` clean on the view; `npx eslint web/skins/classic/js/skin.js` clean. The rest is source reading — the local instance here serves an installed copy rather than this checkout, so **this still wants a look in the browser in both filter modes**: inline (panel visible, both toggles work) and sidebar (panel toggleable, scale/speed/buttons/timeline reachable, attribute filters present in the extruder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nr76CednxtDt2nPuq6WrbL
