### PR TITLE
fix: drop MonitorIds from User fields, the column went in 1.37.76

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/User.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/User.pm
@@ -48,7 +48,6 @@ Groups
 Devices
 System
 MaxBandwidth
-MonitorIds
 TokenMinExpiry
 APIEnabled
 );


### PR DESCRIPTION
`ZoneMinder::User` still lists `MonitorIds` in `%fields`, but `zm_update-1.37.76.sql` dropped that column from `Users`. `Object::save` builds its column list from `%fields`, so every insert or update through this class names a column that no longer exists.

Ran the insert that `save` produces against the current schema: with `MonitorIds` it fails with `ERROR 1054 Unknown column 'MonitorIds' in 'INSERT INTO'`, without it the insert succeeds.

Nothing in tree calls `User->save()` today, which is why it has gone unnoticed since 1.37.76.
