### PR TITLE
fix: use the class the audit CSS styles on the missing files header

### DIFF
--- a/web/skins/classic/views/report_event_audit.php
+++ b/web/skins/classic/views/report_event_audit.php
@@ -143,7 +143,7 @@ echo $navbar;
             <th class="colLastEvent"><?php echo translate('LastEvent') ?></th>
             <th class="colMinGap"><?php echo translate('MinGap') ?></th> 
             <th class="colMaxGap"><?php echo translate('MaxGap') ?></th> 
-            <th class="colMissingFiles"><?php echo translate('MissingFiles') ?></th> 
+            <th class="colFileMissing"><?php echo translate('MissingFiles') ?></th> 
             <th class="colZeroSize"><?php echo translate('ZeroSize') ?></th> 
           </tr>
         </thead>


### PR DESCRIPTION
The missing files column header carries `colMissingFiles` while its cells and `report_event_audit.css` both use `colFileMissing`, so the `text-align: left` rule that covers every other column in that table misses this one header.

`colMissingFiles` appears nowhere else in the tree, so renaming the header class is enough.
