### PR TITLE
fix: escape monitor names emitted into javascript

### DIFF
--- a/web/skins/classic/views/js/cycle.js.php
+++ b/web/skins/classic/views/js/cycle.js.php
@@ -16,7 +16,7 @@ foreach ( $monitors as $monitor ) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
-  'name': '<?php echo $monitor->Name() ?>',
+  'name': '<?php echo validJsStr($monitor->Name()) ?>',
   'connKey': '<?php echo $monitor->connKey() ?>',
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,

--- a/web/skins/classic/views/js/montage.js.php
+++ b/web/skins/classic/views/js/montage.js.php
@@ -22,7 +22,7 @@ foreach ( $monitors as $monitor ) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
-  'name': '<?php echo $monitor->Name() ?>',
+  'name': '<?php echo validJsStr($monitor->Name()) ?>',
   'server_id': '<?php echo $monitor->ServerId() ?>',
   'connKey': '<?php echo $monitor->connKey() ?>',
   'width': <?php echo $monitor->ViewWidth() ?>,
@@ -55,7 +55,7 @@ global $layouts;
 foreach ( $layouts as $layout ) {
 ?>
 layouts[<?php echo $layout->Id() ?>] = {
-  "Name":"<?php echo $layout->Name()?>",
+  "Name":"<?php echo validJsStr($layout->Name()) ?>",
   "UserId":"<?php echo $layout->UserId()?>",
   "Positions":<?php echo ($layout->Positions() and json_decode($layout->Positions()))?$layout->Positions():'{}' ?>};
 <?php

--- a/web/skins/classic/views/js/montagereview.js.php
+++ b/web/skins/classic/views/js/montagereview.js.php
@@ -100,7 +100,7 @@ foreach ( $monitors as $monitor ) {
 
 monitorData[monitorData.length] = {
   'Id': <?php echo $monitor->Id() ?>,
-  'Name': '<?php echo $monitor->Name() ?>',
+  'Name': '<?php echo validJsStr($monitor->Name()) ?>',
   'connKey': '<?php echo $monitor->connKey() ?>',
   'Width': <?php echo $monitor->ViewWidth() ?>,
   'Height':<?php echo $monitor->ViewHeight() ?>,

--- a/web/skins/classic/views/js/user.js.php
+++ b/web/skins/classic/views/js/user.js.php
@@ -8,7 +8,7 @@ foreach ($monitors as $m) {
 ?>
 monitors[monitors.length] = {
   'id': <?php echo $m->Id() ?>,
-  'name': '<?php echo $m->Name() ?>'  
+  'name': '<?php echo validJsStr($m->Name()) ?>'  
 };
 <?php
 } // end foreach monitor

--- a/web/skins/classic/views/js/watch.js.php
+++ b/web/skins/classic/views/js/watch.js.php
@@ -36,7 +36,7 @@ foreach ($monitors as $m) {
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $m->Id() ?>,
-  'name': '<?php echo $m->Name() ?>',
+  'name': '<?php echo validJsStr($m->Name()) ?>',
   'server_id': '<?php echo $m->ServerId() ?>',
   'connKey': <?php echo $m->connKey() ?>,
   'width': <?php echo $m->ViewWidth() ?>,

--- a/web/skins/classic/views/js/zone.js.php
+++ b/web/skins/classic/views/js/zone.js.php
@@ -65,7 +65,7 @@ var monitorPixelArea = <?php echo $monitor->ViewWidth() * $monitor->ViewHeight()
 var monitorData = new Array();
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
-  'name': '<?php echo $monitor->Name() ?>',
+  'name': '<?php echo validJsStr($monitor->Name()) ?>',
   'connKey': <?php echo $monitor->connKey() ?>,
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,

--- a/web/skins/classic/views/js/zones.js.php
+++ b/web/skins/classic/views/js/zones.js.php
@@ -9,7 +9,7 @@ var monitorData = new Array();
 ?>
 monitorData[monitorData.length] = {
   'id': <?php echo $monitor->Id() ?>,
-  'name': '<?php echo $monitor->Name() ?>',
+  'name': '<?php echo validJsStr($monitor->Name()) ?>',
   'connKey': <?php echo $monitor->connKey() ?>,
   'width': <?php echo $monitor->ViewWidth() ?>,
   'height':<?php echo $monitor->ViewHeight() ?>,


### PR DESCRIPTION
Seven of the per-view JavaScript files interpolate the monitor name straight into a quoted JS string, so a name containing an apostrophe emits `'name': 'Bob's Garage',` and the file stops parsing. Montage, watch, cycle, zone, zones, montagereview and user all build their monitor object that way, and montage does the same for saved layout names.

Such a name cannot come from the monitor form, which strips the apostrophe through the `filter_regexp` in `Monitor.php`, but the API applies no character rule, and layout names have no filter at all.

These files already escape their neighbours, `validJsStr` on Path and SecondPath in `watch.js.php` and `validHtmlStr` on the name at `montagereview.js.php:159`, so this uses `validJsStr` to match. The emitted snippet fails `node --check` today and parses once escaped.
