### PR TITLE
fix: escape names and paths written into html

### DIFF
--- a/web/ajax/modals/storage.php
+++ b/web/ajax/modals/storage.php
@@ -59,15 +59,15 @@
           <tbody>
             <tr>
               <th class="text-right " scope="row"><?php echo translate('Name') ?></th>
-              <td><input type="text" name="newStorage[Name]" value="<?php echo $newStorage->Name() ?>"/></td>
+              <td><input type="text" name="newStorage[Name]" value="<?php echo validHtmlStr($newStorage->Name()) ?>"/></td>
             </tr>
             <tr>
               <th class="text-right " scope="row"><?php echo translate('Path') ?></th>
-              <td><input type="text" name="newStorage[Path]" value="<?php echo $newStorage->Path() ?>"/></td>
+              <td><input type="text" name="newStorage[Path]" value="<?php echo validHtmlStr($newStorage->Path()) ?>"/></td>
             </tr>
             <tr>
               <th class="text-right " scope="row"><?php echo translate('Url') ?></th>
-              <td><input type="text" name="newStorage[Url]" value="<?php echo $newStorage->Url() ?>"/></td>
+              <td><input type="text" name="newStorage[Url]" value="<?php echo validHtmlStr($newStorage->Url()) ?>"/></td>
             </tr>
             <tr>
               <th class="text-right " scope="row"><?php echo translate('Server') ?></th>

--- a/web/skins/classic/views/_options_controlcaps.php
+++ b/web/skins/classic/views/_options_controlcaps.php
@@ -58,7 +58,7 @@ foreach( $controls as $control ) {
           <tr>
             <td class="colMark" data-checkbox="true"></td>
             <td class="colId"><?php echo $control['Id'] ?></td>
-            <td class="colName"><?php echo $control['Name'] ?></td>
+            <td class="colName"><?php echo validHtmlStr($control['Name']) ?></td>
             <td class="colType"><?php echo $control['Type'] ?></td>
             <td class="colProtocol"><?php echo validHtmlStr($control['Protocol']) ?></td>
             <td class="colCanMove"><?php echo $control['CanMove']?translate('Yes'):translate('No') ?></td>

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -492,7 +492,7 @@ if (defined('AUDIO_MOTION_ENABLED') && AUDIO_MOTION_ENABLED) echo '
 ' . PHP_EOL;
 ?>
                 <div class="monitorStatus">
-                  <span class="MonitorName"><?php echo $monitor->Name() . " (". translate('ID'). "=" . $monitor->Id() . ")"; ?>  </span>
+                  <span class="MonitorName"><?php echo validHtmlStr($monitor->Name()) . " (". translate('ID'). "=" . $monitor->Id() . ")"; ?>  </span>
                   <span class="stream-info-status-track"></span>
                 </div>
                 <p id="dvrControls">

--- a/web/skins/classic/views/report.php
+++ b/web/skins/classic/views/report.php
@@ -54,7 +54,7 @@ getBodyTopHTML();
           <tbody>
             <tr>
               <th class="text-right" scope="row"><?php echo translate('Name') ?></th>
-              <td><input type="text" name="Report[Name]" value="<?php echo $report->Name() ?>"/></td>
+              <td><input type="text" name="Report[Name]" value="<?php echo validHtmlStr($report->Name()) ?>"/></td>
             </tr>
             <tr>
               <th class="text-right " scope="row"><?php echo translate('Filter') ?></th>

--- a/web/skins/classic/views/timeline.php
+++ b/web/skins/classic/views/timeline.php
@@ -810,8 +810,8 @@ foreach ( array_keys($monEventSlots) as $monitorId ) {
 <?php
 foreach( array_keys($monEventSlots) as $monitorId ) {
 ?>
-          <span class="keyEntry"><?php echo $monitors[$monitorId]->Name() ?>
-          <div id="keyBox<?php echo $monitorId ?>" class="keyBox monitorColour<?php echo $monitorId ?>" title="<?php echo $monitors[$monitorId]->Name() ?>" style="background-color: <?php echo $monitors[$monitorId]->WebColour() ?>;"></div>
+          <span class="keyEntry"><?php echo validHtmlStr($monitors[$monitorId]->Name()) ?>
+          <div id="keyBox<?php echo $monitorId ?>" class="keyBox monitorColour<?php echo $monitorId ?>" title="<?php echo validHtmlStr($monitors[$monitorId]->Name()) ?>" style="background-color: <?php echo $monitors[$monitorId]->WebColour() ?>;"></div>
           </span>
 <?php
 }


### PR DESCRIPTION
Five places write a user-editable name or path into HTML without escaping: the monitor name in the event view and twice in the timeline key, the report name and the storage name, path and url inside `value="..."`, and the control name in the control caps table, whose next line already escapes Protocol.

A name containing a double quote closes the attribute, and the browser then parses what follows as further attributes. Fed `Front" onmouseover="alert(1)` to `DOMDocument`, the input tag today parses as two attributes; with `validHtmlStr` it parses as one whose value is the literal text.

Same helper and same shape as 47d7e0d37, which escaped Zone, Event and Server names.
