### PR TITLE
fix: draw monitor names in montage review, not html entities

### DIFF
--- a/web/skins/classic/views/js/montagereview.js.php
+++ b/web/skins/classic/views/js/montagereview.js.php
@@ -156,7 +156,7 @@ foreach ( $monitors as $m ) {
   echo "  monitorHeight["          . $m->Id() . "]=" . validHtmlStr($m->ViewHeight()) . ";\n";
   echo "  monitorIndex["           . $m->Id() . "]=" . $numMonitors . ";\n";
   echo "  monitorServerId["        . $m->Id() . "]='" .($m->ServerId() ?  $m->ServerId() : '0'). "';\n";
-  echo "  monitorName["            . $m->Id() . "]=\"" . validHtmlStr($m->Name()) . "\";\n";
+  echo "  monitorName["            . $m->Id() . "]=\"" . validJsStr($m->Name()) . "\";\n";
   echo "  monitorLoadStartTimems[" . $m->Id() . "]=0;\n";
   echo "  monitorLoadEndTimems["   . $m->Id() . "]=0;\n";
   echo "  monitorNormalizeScale["  . $m->Id() . "]=" . sqrt($avgArea / ($m->Width() * $m->Height() )) . ";\n";


### PR DESCRIPTION
`montagereview.js.php` escapes the monitor name with `validHtmlStr`, so `monitorName[7]` ends up holding `Bob &amp; Sons`, and that array goes to `ctx.fillText` at `montagereview.js:720` and `:1413`. Canvas draws the string as given, so the timeline labels show the entities.

`validJsStr` is the right helper for a value going into a JS string, and it is what `watch.js.php` already uses for Path. As with #5107, the monitor form filters those characters out, so a name like that has to come from the API.
