### PR TITLE
fix: give the AI options views keys that read as English

### DIFF
--- a/web/ajax/modals/ai_class.php
+++ b/web/ajax/modals/ai_class.php
@@ -39,7 +39,7 @@ if ($result) {
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><?php echo translate('AIObjectClass') .' - '. validHtmlStr($class['ClassName']) ?></h5>
+        <h5 class="modal-title"><?php echo translate('AI Object Class') .' - '. validHtmlStr($class['ClassName']) ?></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -59,11 +59,11 @@ if ($result) {
                 <td><?php echo htmlSelect('newClass[DatasetId]', $datasets, $class['DatasetId']) ?></td>
               </tr>
               <tr class="ClassName">
-                <th scope="row"><?php echo translate('ClassName') ?></th>
+                <th scope="row"><?php echo translate('Class Name') ?></th>
                 <td><input type="text" name="newClass[ClassName]" value="<?php echo validHtmlStr($class['ClassName']) ?>" required/></td>
               </tr>
               <tr class="ClassIndex">
-                <th scope="row"><?php echo translate('ClassIndex') ?></th>
+                <th scope="row"><?php echo translate('Class Index') ?></th>
                 <td><input type="number" name="newClass[ClassIndex]" value="<?php echo validCardinal($class['ClassIndex']) ?>" step="1" min="0" required/></td>
               </tr>
               <tr class="Description">

--- a/web/ajax/modals/ai_dataset.php
+++ b/web/ajax/modals/ai_dataset.php
@@ -30,7 +30,7 @@ if ( $did ) {
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><?php echo translate('AIDataset') .' - '. validHtmlStr($dataset['Name']) ?></h5>
+        <h5 class="modal-title"><?php echo translate('AI Dataset') .' - '. validHtmlStr($dataset['Name']) ?></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -54,7 +54,7 @@ if ( $did ) {
                 <td><input type="text" name="newDataset[Version]" value="<?php echo validHtmlStr($dataset['Version']) ?>"/></td>
               </tr>
               <tr class="NumClasses">
-                <th scope="row"><?php echo translate('NumClasses') ?></th>
+                <th scope="row"><?php echo translate('Number of Classes') ?></th>
                 <td><input type="number" name="newDataset[NumClasses]" value="<?php echo validCardinal($dataset['NumClasses']) ?>" step="1" min="0" required/></td>
               </tr>
               <tr class="Description">

--- a/web/ajax/modals/ai_model.php
+++ b/web/ajax/modals/ai_model.php
@@ -51,7 +51,7 @@ $framework_options = array(
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><?php echo translate('AIModel') .' - '. validHtmlStr($model['Name']) ?></h5>
+        <h5 class="modal-title"><?php echo translate('AI Model') .' - '. validHtmlStr($model['Name']) ?></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -83,7 +83,7 @@ $framework_options = array(
                 <td><?php echo htmlSelect('newModel[DatasetId]', $datasets, $model['DatasetId']) ?></td>
               </tr>
               <tr class="ModelPath">
-                <th scope="row"><?php echo translate('ModelPath') ?></th>
+                <th scope="row"><?php echo translate('Model Path') ?></th>
                 <td><input type="text" name="newModel[ModelPath]" value="<?php echo validHtmlStr($model['ModelPath']) ?>"/></td>
               </tr>
               <tr class="Enabled">

--- a/web/skins/classic/views/_options_ai_classes.php
+++ b/web/skins/classic/views/_options_ai_classes.php
@@ -20,9 +20,9 @@
     </div> <!-- .row -->
     <div class="row mb-3">
       <div class="col-md-4">
-        <label for="datasetFilter"><?php echo translate('FilterByDataset') ?>:</label>
+        <label for="datasetFilter"><?php echo translate('Filter by Dataset') ?>:</label>
         <select id="datasetFilter" class="form-control">
-          <option value=""><?php echo translate('AllDatasets') ?></option>
+          <option value=""><?php echo translate('All Datasets') ?></option>
 <?php
 $datasets_result = dbQuery('SELECT Id, Name FROM AI_Datasets ORDER BY Name');
 if ($datasets_result) {
@@ -43,8 +43,8 @@ if ($datasets_result) {
                 <th class="colMark"><?php echo translate('Mark') ?></th>
                 <th data-sortable="true" class="colId"><?php echo translate('Id') ?></th>
                 <th data-sortable="true" class="colDataset"><?php echo translate('Dataset') ?></th>
-                <th data-sortable="true" class="colClassName"><?php echo translate('ClassName') ?></th>
-                <th data-sortable="true" class="colClassIndex"><?php echo translate('ClassIndex') ?></th>
+                <th data-sortable="true" class="colClassName"><?php echo translate('Class Name') ?></th>
+                <th data-sortable="true" class="colClassIndex"><?php echo translate('Class Index') ?></th>
                 <th data-sortable="true" class="colDescription"><?php echo translate('Description') ?></th>
               </tr>
             </thead>

--- a/web/skins/classic/views/_options_ai_datasets.php
+++ b/web/skins/classic/views/_options_ai_datasets.php
@@ -28,7 +28,7 @@
                 <th data-sortable="true" class="colId"><?php echo translate('Id') ?></th>
                 <th data-sortable="true" class="colName"><?php echo translate('Name') ?></th>
                 <th data-sortable="true" class="colVersion"><?php echo translate('Version') ?></th>
-                <th data-sortable="true" class="colNumClasses"><?php echo translate('NumClasses') ?></th>
+                <th data-sortable="true" class="colNumClasses"><?php echo translate('Number of Classes') ?></th>
                 <th data-sortable="true" class="colDescription"><?php echo translate('Description') ?></th>
               </tr>
             </thead>

--- a/web/skins/classic/views/_options_ai_models.php
+++ b/web/skins/classic/views/_options_ai_models.php
@@ -30,7 +30,7 @@
                 <th data-sortable="true" class="colFramework"><?php echo translate('Framework') ?></th>
                 <th data-sortable="true" class="colVersion"><?php echo translate('Version') ?></th>
                 <th data-sortable="true" class="colDataset"><?php echo translate('Dataset') ?></th>
-                <th data-sortable="true" class="colModelPath"><?php echo translate('ModelPath') ?></th>
+                <th data-sortable="true" class="colModelPath"><?php echo translate('Model Path') ?></th>
                 <th data-sortable="true" class="colEnabled"><?php echo translate('Enabled') ?></th>
                 <th data-sortable="true" class="colDescription"><?php echo translate('Description') ?></th>
               </tr>


### PR DESCRIPTION
The AI classes, datasets and models views and their three modals label thirteen controls with keys no lang file carries, so the tables show `AIObjectClass`, `AllDatasets`, `ClassIndex`, `ClassName`, `FilterByDataset`, `ModelPath`, `NumClasses`, `AIDataset` and `AIModel`.

No language translates any of them, so this takes the route you suggested on #5098 and gives them spaced keys that read correctly in English with no lang entry. `Filter by Dataset` matches the existing `FilterByEncoder` wording.
