### PR TITLE
fix: give five labelled controls the id their label points at

### DIFF
--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -465,13 +465,13 @@ $interfaces = array('', 'select');
 
   echo htmlSelect('interface', $interfaces,
     (isset($_REQUEST['interface']) ? $_REQUEST['interface'] : $default_interface),
-    array('data-on-change-this'=>'changeInterface') );
+    array('id'=>'interface', 'data-on-change-this'=>'changeInterface') );
 
 ?>
         </p>
         <p>
           <label for="probe"><?php echo translate('DetectedCameras') ?></label>
-          <?php echo htmlSelect('probe', $cameras, null, array('data-on-change-this'=>'configureButtons')); ?>
+          <?php echo htmlSelect('probe', $cameras, null, array('id'=>'probe', 'data-on-change-this'=>'configureButtons')); ?>
         </p>
         <hr/>
         <p><?php echo translate('OnvifManualOr') ?></p>

--- a/web/skins/classic/views/monitors.php
+++ b/web/skins/classic/views/monitors.php
@@ -107,7 +107,7 @@ echo getNavBarHTML();
                 'Normal'=>translate('Normal'),
                 'Less'=>translate('Less important'),
                 'Not'=>translate('Not important')
-              ), $monitor->Importance());
+              ), $monitor->Importance(), array('id'=>'newMonitor[Importance]'));
 ?>
         </p>
         <div id="contentButtons">

--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -217,7 +217,7 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
 
   echo htmlSelect('interface', $interfaces,
     (isset($_REQUEST['interface']) ? $_REQUEST['interface'] : $default_interface),
-    array('data-on-change-this'=>'changeInterface', 'class'=>'chosen') );
+    array('id'=>'interface', 'data-on-change-this'=>'changeInterface', 'class'=>'chosen') );
 ?>
         </p>
         <div id="DetectedCameras">
@@ -242,7 +242,7 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
           </p>
           <p>
             <label for="Username"><?php echo translate('Username') ?></label>
-            <input type="text" name="Username" data-on-change-this="configureButtons"/>
+            <input type="text" id="Username" name="Username" data-on-change-this="configureButtons"/>
           </p>
           <p>
             <label for="Password"><?php echo translate('Password') ?></label>


### PR DESCRIPTION
Five controls are labelled with `<label for="X">` while the control itself has no id, so clicking the label does nothing: the Username input on the ONVIF probe, the Importance select on the monitors list, and the interface and detected-cameras selects on both probe views. `htmlSelect` emits only `name`, never an id, unless the caller passes one.

Passing it through the attributes argument is what `filter.php` already does with `['Id'=>'filter[UserId]', 'class'=>'chosen']`, so this follows that.

Left alone deliberately: the group captions over radio sets in the export and dnsmasq views, where the individual radios already carry their own ids and labels, and the second `probe` select on the ONVIF profiles step, which shares the name with the cameras select on the same page and so cannot take the same id.
