### PR TITLE
fix: use the interpolation syntax that survives PHP 9

### DIFF
--- a/web/api/app/Controller/EventsController.php
+++ b/web/api/app/Controller/EventsController.php
@@ -538,7 +538,7 @@ class EventsController extends AppController {
     // The $bw, $thumbs and unset() code is a workaround / temporary
     // until I have a better way of handing per-bandwidth config options
     $bw = (isset($_COOKIE['zmBandwidth']) ? strtoupper(substr($_COOKIE['zmBandwidth'], 0, 1)) : 'L');
-    $thumbs = "ZM_WEB_${bw}_SCALE_THUMBS";
+    $thumbs = "ZM_WEB_{$bw}_SCALE_THUMBS";
 
     $config = $this->Config->find('list', array(
       'conditions' => array('OR' => array(

--- a/web/skins/classic/views/monitorprobe.php
+++ b/web/skins/classic/views/monitorprobe.php
@@ -363,10 +363,10 @@ function probeNetwork() {
   foreach ( dbFetchAll("SELECT `Id`, `Name`, `Path` FROM `Monitors` WHERE `Type` = 'Ffmpeg' ORDER BY `Path`") as $monitor ) {
     $url_parts = parse_url($monitor['Path']);
     if ($url_parts !== false) {
-      ZM\Debug("Ffmpeg monitor ${url_parts['host']} = ${monitor['Id']} ${monitor['Name']}");
+      ZM\Debug("Ffmpeg monitor {$url_parts['host']} = {$monitor['Id']} {$monitor['Name']}");
       $monitors[gethostbyname($url_parts['host'])] = $monitor;
     } else {
-      ZM\Debug("Unable to parse ${monitor['Path']}");
+      ZM\Debug("Unable to parse {$monitor['Path']}");
     }
   }
 

--- a/web/skins/classic/views/onvifprobe.php
+++ b/web/skins/classic/views/onvifprobe.php
@@ -280,8 +280,8 @@ if (!isset($_REQUEST['step']) || ($_REQUEST['step'] == '1')) {
   foreach ($detprofiles as $profile) {
     $monitor = $camera['monitor'];
 
-    $sourceString = "${profile['Name']} : ${profile['Encoding']}" .
-      " (${profile['Width']}x${profile['Height']} @ ${profile['MaxFPS']}fps ${profile['Transport']})";
+    $sourceString = "{$profile['Name']} : {$profile['Encoding']}" .
+      " ({$profile['Width']}x{$profile['Height']} @ {$profile['MaxFPS']}fps {$profile['Transport']})";
     // copy technical details
     $monitor['Width']  = $profile['Width'];
     $monitor['Height'] = $profile['Height'];


### PR DESCRIPTION
`${var}` string interpolation was deprecated in PHP 8.2 and is removed in PHP 9. Three files still use it, eleven times: the profile summary in `onvifprobe.php`, two Debug calls in `monitorprobe.php`, and the per-bandwidth config name in `EventsController.php`. On PHP 8.2 or newer each one logs a deprecation notice every time the code runs, and on PHP 9 they stop parsing.

Running `php -l` on all three under PHP 8.4 reports 22 notices before and none after, with the same exit status. The two forms produce identical strings, which is easy to check side by side.
