### PR TITLE
build: notice new migrations and fonts without a manual reconfigure

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file(zm_update-1.39.26.sql.in "${CMAKE_CURRENT_BINARY_DIR}/zm_update-1
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zm_create.sql" DESTINATION "${CMAKE_INSTALL_DATADIR}/zoneminder/db")
 
 # Glob all database upgrade scripts
-file(GLOB dbfileslist RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.sql")
+file(GLOB dbfileslist CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.sql")
 
 # install zm_update-1.31.30.sql
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zm_update-1.31.30.sql" DESTINATION "${CMAKE_INSTALL_DATADIR}/zoneminder/db")

--- a/fonts/CMakeLists.txt
+++ b/fonts/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Glob all database upgrade scripts
-file(GLOB fontfileslist RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.zmfnt")
+file(GLOB fontfileslist CONFIGURE_DEPENDS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.zmfnt")
 # Install the fonts
 install(FILES ${fontfileslist} DESTINATION "${ZM_FONTDIR}")


### PR DESCRIPTION
`file(GLOB)` runs at configure time, so a migration added after the build tree exists is not installed until someone reruns cmake. That is the failure mode behind c0865336f and eae2df6b4 last week, and it will bite again each time a `zm_update-*.sql` lands.

Checked it in a throwaway project on cmake 4.1: with a plain glob, adding `b.sql` and running build plus install again leaves only `a.sql` installed. With `CONFIGURE_DEPENDS` the same sequence installs `a.sql`, `b.sql` and `c.sql`. The option has been available since cmake 3.12, which is the minimum this project already requires.

The fonts glob has the same shape so it gets the same treatment. The one in `scripts/CMakeLists.txt` is left alone: it globs the build directory for files `configure_file` has just generated, where a configure-time snapshot is the correct behaviour.
