### PR TITLE
fix: drop the line that assigns currentScale to itself

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -329,7 +329,6 @@ function changeScale() {
     newWidth = parseInt(w);
     newHeight = parseInt(h);
     currentScale = parseInt(w / eventData.Width * 100);
-    currentScale = currentScale;
   }
 
   console.log(`Real dimensions: ${eventData.Width} X ${eventData.Height}, Scale: ${currentScale}, deltaScale: ${deltaScale()}, New dimensions: ${newWidth} X ${newHeight}`);


### PR DESCRIPTION
`event.js:332` reads `currentScale = currentScale;`, immediately after the line above sets it, so it does nothing. eslint's `no-self-assign` flags it on master and is silent once the line is gone.
