### PR TITLE
fix: reconnect to db instead of bare ping in zmupdate and zmfilter loops

### DIFF
--- a/scripts/zmfilter.pl.in
+++ b/scripts/zmfilter.pl.in
@@ -294,7 +294,7 @@ sub checkFilter {
     last if $zm_terminate;
     my $Event = new ZoneMinder::Event($$event{Id}, $event);
 
-    $dbh->ping();
+    $dbh = zmDbConnect();
 
     # LockRows serialises this filter against the others one event at a time.
     # The lock is a row in Events_Lock rather than a lock on the event itself,

--- a/scripts/zmupdate.pl.in
+++ b/scripts/zmupdate.pl.in
@@ -182,7 +182,7 @@ if ($check) {
 
   while ( 1 ) {
     my $now = time();
-    $dbh->ping();
+    $dbh = zmDbConnect(undef, { mysql_multi_statements=>1 });
     if ( !$interactive and $lastVersion and $lastCheck and (($now-$lastCheck) <= CHECK_INTERVAL) ) {
       Debug("Not checking for updates since we already have less than " . CHECK_INTERVAL . " seconds ago.");
     } else {


### PR DESCRIPTION
## The bug

Logged repeatedly on a running server:

```
zmupdate[2889412]: ERR [Failed UPDATE Config SET Value = '1.38.4' WHERE Name = 'ZM_DYN_LAST_VERSION' :
The client was disconnected by the server because of inactivity.
See wait_timeout and interactive_timeout for configuring this behavior.]
```

`zmupdate.pl`'s update-check loop calls `$dbh->ping()` and discards the result. `ping()` only *tests* the connection - DBD::mysql does not reconnect on its own, `mysql_auto_reconnect` is off. The loop sleeps 3600s between iterations, so on a server whose `wait_timeout` is under an hour the handle is already closed on wake-up, the ping quietly returns false, and the next `zmDbDo` fails.

`zmfilter.pl` has the same bare ping in its per-event loop (`checkFilter`), where the gap between iterations is however long an event's work takes - an ffmpeg encode, an upload or an executed command.

## The fix

`zmDbConnect()` already does exactly the ping-and-reconnect these call sites were reaching for, and assigns the `ZoneMinder::Database` package global `$dbh` that `zmDbDo` and friends use, so call that instead of pinging in place.

`zmupdate` keeps passing `mysql_multi_statements` so a reconnected handle matches the one it originally opened.

## Not changed

`ZoneMinder::Event::delete` has the same bare ping at `Event.pm:394`, but it sits in a path that may run inside a caller-managed transaction, and `zmDbConnect()` resets `AutoCommit` to 1. That one wants a closer look than this fix; left alone deliberately.

Servers hitting this should also check their `wait_timeout` - an hourly ping would normally have kept the connection alive, so it is likely set well below the 28800 default. The reconnect makes it harmless either way.

## Testing

`perl -c` clean on both scripts with the `@ZM_*@` substitutions filled in. Runtime behaviour is the reconnect path in `zmDbConnect()`, which is already exercised by `zmdc`, `zmaudit`, `zmstats`, `zmtelemetry` and `zmwatch`, all of which use it in place of a bare ping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)