### PR TITLE
fix: stop orphaned zms processes accumulating, without killing streams on tab hide

### DIFF
--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -562,6 +562,10 @@ void MonitorStream::runStream() {
   Image *paused_image = nullptr;
   SystemTimePoint paused_timestamp;
 
+  // Same, for the stopped state. See the stopped branch in the loop below.
+  Image *stopped_image = nullptr;
+  SystemTimePoint stopped_timestamp;
+
   if (connkey && (playback_buffer > 0)) {
     // 15 is the max length for the swap path suffix, /zmswap-whatever, assuming max 6 digits for monitor id
     const int max_swap_len_suffix = 15;
@@ -668,10 +672,49 @@ void MonitorStream::runStream() {
       continue;
     }
     if (stopped) {
-      // In stopped state, do nothing except wait for a new command.
-      // Don't call setLastViewed() so we don't keep capture/decoding active unnecessarily.
+      // Stopped halts playback but keeps the connection, so that a later
+      // command can resume on the same process. Hold the last frame and
+      // re-send it every few seconds, as the paused state does.
+      //
+      // The write is the point: with nothing written, this branch never
+      // touches the socket, so a stream whose client has gone away is never
+      // told about it and never sees EPIPE. Since it also skipped the ttl
+      // check at the bottom of the loop, such a process had no way to exit at
+      // all and stayed until the machine was restarted. refs #4706
+      //
+      // setLastViewed is deliberately still not called: capture and decoding
+      // should not be held active for a stream that is not playing.
+      if (!stopped_image
+          && monitor->shared_data->valid
+          && (monitor->shared_data->last_write_index != monitor->image_buffer_count)) {
+        int index = monitor->shared_data->last_write_index % monitor->image_buffer_count;
+        Debug(1, "Saving stopped image from index %d", index);
+        stopped_image = new Image(*monitor->ReadShmFrame(index));
+        stopped_timestamp = SystemTimePoint(zm::chrono::duration_cast<Microseconds>(monitor->shared_timestamps[index]));
+      }
+      if (now - last_frame_sent > Seconds(5)) {
+        if (stopped_image) {
+          Debug(2, "Sending keepalive frame while stopped");
+          if (!sendFrame(stopped_image, stopped_timestamp)) zm_terminate = true;
+        } else if (sendTextFrame("Stopped") <= 0) {
+          // Nothing captured yet to hold, but we still have to write something
+          // to notice a client that is no longer there.
+          Debug(2, "Failed to send stopped keepalive text frame");
+          zm_terminate = true;
+        }
+      }
+      // The ttl check lives at the bottom of the loop, which this branch never
+      // reaches, so a stopped stream would otherwise outlive its own deadline.
+      if (ttl > Seconds(0) && (now - stream_start_time) > ttl) {
+        Debug(2, "Stopped and now - start > ttl. break");
+        break;
+      }
       std::this_thread::sleep_for(MAX_SLEEP);
       continue;
+    }
+    if (stopped_image) {
+      delete stopped_image;
+      stopped_image = nullptr;
     }
     monitor->setLastViewed();
     if (frame_type == FRAME_ANALYSIS)

--- a/src/zm_monitorstream.cpp
+++ b/src/zm_monitorstream.cpp
@@ -558,12 +558,14 @@ void MonitorStream::runStream() {
   std::string swap_path;
   bool buffered_playback = false;
 
-  // Last image and timestamp when paused, will be resent occasionally to prevent timeout
-  Image *paused_image = nullptr;
+  // Last image and timestamp when paused, will be resent occasionally to prevent timeout.
+  // unique_ptr because the loop below has break paths that leave the function
+  // while one of these is still held.
+  std::unique_ptr<Image> paused_image;
   SystemTimePoint paused_timestamp;
 
   // Same, for the stopped state. See the stopped branch in the loop below.
-  Image *stopped_image = nullptr;
+  std::unique_ptr<Image> stopped_image;
   SystemTimePoint stopped_timestamp;
 
   if (connkey && (playback_buffer > 0)) {
@@ -689,13 +691,13 @@ void MonitorStream::runStream() {
           && (monitor->shared_data->last_write_index != monitor->image_buffer_count)) {
         int index = monitor->shared_data->last_write_index % monitor->image_buffer_count;
         Debug(1, "Saving stopped image from index %d", index);
-        stopped_image = new Image(*monitor->ReadShmFrame(index));
+        stopped_image = zm::make_unique<Image>(*monitor->ReadShmFrame(index));
         stopped_timestamp = SystemTimePoint(zm::chrono::duration_cast<Microseconds>(monitor->shared_timestamps[index]));
       }
       if (now - last_frame_sent > Seconds(5)) {
         if (stopped_image) {
           Debug(2, "Sending keepalive frame while stopped");
-          if (!sendFrame(stopped_image, stopped_timestamp)) zm_terminate = true;
+          if (!sendFrame(stopped_image.get(), stopped_timestamp)) zm_terminate = true;
         } else if (sendTextFrame("Stopped") <= 0) {
           // Nothing captured yet to hold, but we still have to write something
           // to notice a client that is no longer there.
@@ -707,15 +709,16 @@ void MonitorStream::runStream() {
       // reaches, so a stopped stream would otherwise outlive its own deadline.
       if (ttl > Seconds(0) && (now - stream_start_time) > ttl) {
         Debug(2, "Stopped and now - start > ttl. break");
+        // checkCommandQueue() only returns when zm_terminate is set, and
+        // runStream() joins it below, so leaving the loop without setting it
+        // hangs in join() forever. See the two breaks at the bottom of the loop.
+        zm_terminate = true;
         break;
       }
       std::this_thread::sleep_for(MAX_SLEEP);
       continue;
     }
-    if (stopped_image) {
-      delete stopped_image;
-      stopped_image = nullptr;
-    }
+    stopped_image.reset();
     monitor->setLastViewed();
     if (frame_type == FRAME_ANALYSIS)
       monitor->setLastAnalysisViewed();
@@ -724,12 +727,11 @@ void MonitorStream::runStream() {
       if (!was_paused) {
         int index = monitor->shared_data->last_write_index % monitor->image_buffer_count;
         Debug(1, "Saving paused image from index %d",index);
-        paused_image = new Image(*monitor->ReadShmFrame(index));
+        paused_image = zm::make_unique<Image>(*monitor->ReadShmFrame(index));
         paused_timestamp = SystemTimePoint(zm::chrono::duration_cast<Microseconds>(monitor->shared_timestamps[index]));
       }
-    } else if (paused_image) {
-      delete paused_image;
-      paused_image = nullptr;
+    } else {
+      paused_image.reset();
     }
 
     if (buffered_playback && delayed) {
@@ -869,9 +871,9 @@ void MonitorStream::runStream() {
           }
           if (last_zoom != zoom) {
             Debug(2, "Sending 2 frames because change in zoom %d ?= %d", last_zoom, zoom.load());
-            if (!sendFrame(paused_image, paused_timestamp))
+            if (!sendFrame(paused_image.get(), paused_timestamp))
               zm_terminate = true;
-            if (!sendFrame(paused_image, paused_timestamp))
+            if (!sendFrame(paused_image.get(), paused_timestamp))
               zm_terminate = true;
             frame_count++;
             frame_count++;
@@ -883,7 +885,7 @@ void MonitorStream::runStream() {
                 Debug(2, "Sending keepalive frame because delta time %.2f s > 5 s",
                       FPSeconds(actual_delta_time).count());
                 // Send the next frame
-                if (!sendFrame(paused_image, paused_timestamp))
+                if (!sendFrame(paused_image.get(), paused_timestamp))
                   zm_terminate = true;
                 frame_count++;
               } else {
@@ -994,12 +996,18 @@ void MonitorStream::runStream() {
     if (!zm_terminate)
       std::this_thread::sleep_for(sleep_time);
 
+    // Both of these have to set zm_terminate, not just break: checkCommandQueue()
+    // loops until that flag is set and runStream() joins it below, so a stream
+    // that ended on its ttl or its frame count would sit in join() forever
+    // rather than exiting. That is a way for a zms to outlive its client. refs #4706
     if (ttl > Seconds(0) && (now - stream_start_time) > ttl) {
       Debug(2, "now - start > ttl (%" PRIi64 " us). break",
             static_cast<int64>(std::chrono::duration_cast<Microseconds>(ttl).count()));
+      zm_terminate = true;
       break;
     }
     if (frames_to_send > 0 && frame_count >= frames_to_send) {
+      zm_terminate = true;
       break;
     }
   } // end while ! zm_terminate

--- a/tests/js/monitorstream-resume.test.js
+++ b/tests/js/monitorstream-resume.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+// select_zms() has three ways out: resume an existing zms with CMD_PLAY, send
+// CMD_PLAY to the one the page was rendered with in mode=paused, or build a new
+// one. The first two send a stream command before the tail of the function sets
+// `started`, and streamCommand() silently drops anything sent while that is
+// false — so both could report success while sending nothing, leaving the
+// picture frozen on the last keepalive frame.
+//
+// These assert what actually reached the wire, not just which branch ran.
+// refs #4706
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const src = fs.readFileSync(
+    path.join(__dirname, '../../web/js/MonitorStream.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log('  ok ' + name);
+    passed++;
+  } catch (e) {
+    console.error('  FAIL ' + name);
+    console.error('    ' + (e.stack || e.message));
+    failed++;
+  }
+}
+
+function makeChainable() {
+  const proxy = new Proxy(function() {}, {
+    get: (target, prop) => (prop === 'then' ? undefined : proxy),
+    apply: () => proxy,
+  });
+  return proxy;
+}
+
+// MonitorStream.js is a browser file that leans on globals from skin.js and the
+// view templates. Resolve unknown globals to undefined and give real values only
+// to the handful these tests depend on.
+function loadMonitorStream(authHash) {
+  const globals = {
+    $j: makeChainable(),
+    $: makeChainable(),
+    console: {log() {}, warn() {}, error() {}, debug() {}},
+    currentView: 'watch',
+    getCookie: () => 'true',
+    setCookie: () => {},
+    document: {
+      getElementById: () => null,
+      querySelector: () => null,
+      createElement: () => ({}),
+    },
+    setTimeout: () => 0,
+    clearTimeout: () => 0,
+    setInterval: () => 0,
+    clearInterval: () => 0,
+    statusRefreshTimeout: 1000,
+    CMD_PLAY: 1,
+    CMD_QUIT: 17,
+    // '' is what an install with auth off, or under the plain/none relay forms,
+    // actually has here.
+    zmAuth: {hash: authHash, applyTo: (url) => url},
+    authHashFromRelay: () => authHash,
+    streamSessionActive: () => true,
+    generateUUID: () => 'uuid',
+    hideAudioMotion: () => {},
+    // select_zms() swaps the element first; hand back the one the test set up.
+    replaceDOMElement: (existing) => existing,
+    // The sandbox proxy answers every bare identifier, so the builtins the code
+    // uses have to be present on it explicitly.
+    Object: Object,
+    Array: Array,
+    JSON: JSON,
+  };
+  const sandbox = new Proxy(globals, {
+    has: () => true,
+    get: (target, prop) => (prop === Symbol.unscopables ? undefined : target[prop]),
+  });
+  globals.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(src, sandbox, {filename: 'MonitorStream.js'});
+  assert.strictEqual(typeof globals.MonitorStream, 'function',
+      'MonitorStream.js did not define MonitorStream');
+  return globals;
+}
+
+// select_zms() replaces the DOM element before anything else, so the monitor has
+// to hand back a stand-in <img> whose src the branch conditions can read.
+function makeMonitor(sandbox, {src: imgSrc, connKey, activePlayer, stoppedPlayer}) {
+  const monitor = new sandbox.MonitorStream({
+    id: 1, name: 'test', connKey: connKey || null,
+    url: '', url_to_zms: '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg',
+    width: 640, height: 480,
+  });
+  const element = {nodeName: 'IMG', src: imgSrc, srcObject: null,
+    getAttribute: () => 'eager', setAttribute: () => {}};
+
+  monitor.element = element;
+  monitor.getElement = () => element;
+  monitor.connKey = connKey || null;
+  monitor.streamCmdParms = {connkey: connKey || null};
+  monitor.statusCmdParms = {connkey: connKey || null};
+  monitor.activePlayer = activePlayer || '';
+  monitor.stoppedPlayer = stoppedPlayer || '';
+  monitor.started = false;
+  monitor.isActive = true;
+  monitor.scale = 100;
+
+  // Record what reaches the wire rather than which branch was taken.
+  monitor.sent = [];
+  monitor.streamCmdReq = (params) => monitor.sent.push(params);
+  monitor.quit = [];
+  monitor.quitConnKey = (key) => monitor.quit.push(key);
+
+  monitor.destroyVolumeSlider = () => {};
+  monitor.updateStreamInfo = () => {};
+  monitor.writeTextInfoBlock = () => {};
+  monitor.streamListenerBind = () => () => {};
+  monitor.streamCmdQuery = () => {};
+  monitor.resetCountStreamErrors = () => {};
+  monitor.img_onerror = () => {};
+  monitor.img_onload = () => {};
+  monitor.genConnKey = () => 999999;
+  monitor.kill = () => {};
+
+  return {monitor, element};
+}
+
+const playCommands = (monitor) =>
+  monitor.sent.filter((p) => p.command === 1); // CMD_PLAY
+
+console.log('MonitorStream.select_zms() resume and initial-paused paths');
+
+test('a stopped zms is resumed with CMD_PLAY on its existing connkey', () => {
+  // stop() clears activePlayer and started, so the resume branch is reached
+  // through stoppedPlayer with the connkey still held.
+  const sandbox = loadMonitorStream('');
+  const {monitor, element} = makeMonitor(sandbox, {
+    src: '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg&connkey=123456',
+    connKey: 123456, stoppedPlayer: 'zms',
+  });
+
+  monitor.select_zms();
+
+  const plays = playCommands(monitor);
+  assert.strictEqual(plays.length, 1,
+      'resume sent ' + plays.length + ' CMD_PLAY, expected exactly 1');
+  assert.strictEqual(plays[0].connkey, 123456,
+      'CMD_PLAY went to the wrong connkey');
+  assert.strictEqual(monitor.connKey, 123456,
+      'resume must not replace the connkey that addresses the running zms');
+  assert.strictEqual(element.src,
+      '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg&connkey=123456',
+      'resume must leave src untouched, or the browser tears the stream down');
+  assert.deepStrictEqual(monitor.quit, [],
+      'resume must not quit the process it is about to resume');
+});
+
+test('an initial mode=paused stream is played, not left paused', () => {
+  // The regression: streamCommand() drops commands while !started, and the tail
+  // of select_zms() sets started only after this branch has already run.
+  const sandbox = loadMonitorStream('');
+  const {monitor} = makeMonitor(sandbox, {
+    src: '/zm/cgi-bin/nph-zms?monitor=1&mode=paused&connkey=222222',
+    connKey: 222222,
+  });
+
+  monitor.select_zms();
+
+  const plays = playCommands(monitor);
+  assert.strictEqual(plays.length, 1,
+      'initial mode=paused sent ' + plays.length + ' CMD_PLAY, expected exactly 1');
+  assert.strictEqual(plays[0].connkey, 222222,
+      'CMD_PLAY went to the wrong connkey');
+});
+
+test('with auth off the resume path is taken rather than a rebuild', () => {
+  // srcAuthCurrent used to require a non-empty zmAuth.hash, so installs with
+  // auth off always rebuilt, abandoning a perfectly good zms every cycle.
+  const sandbox = loadMonitorStream('');
+  const {monitor, element} = makeMonitor(sandbox, {
+    src: '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg&connkey=333333',
+    connKey: 333333, activePlayer: 'zms',
+  });
+
+  monitor.select_zms();
+
+  assert.strictEqual(monitor.connKey, 333333, 'auth-off install rebuilt the stream');
+  assert.strictEqual(element.src,
+      '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg&connkey=333333',
+      'auth-off install replaced src instead of resuming');
+});
+
+test('a stale auth hash still rebuilds, and quits the old zms first', () => {
+  // The counterpart: when there is a hash and it no longer matches, the stream
+  // has to be rebuilt — and the process the old connkey addressed told to quit,
+  // because nothing can reach it once the key is replaced.
+  const sandbox = loadMonitorStream('freshhash');
+  const {monitor} = makeMonitor(sandbox, {
+    src: '/zm/cgi-bin/nph-zms?monitor=1&mode=jpeg&auth=stalehash',
+    connKey: 444444, activePlayer: 'zms',
+  });
+  sandbox.authHashFromRelay = () => 'stalehash';
+
+  monitor.select_zms();
+
+  assert.deepStrictEqual(monitor.quit, [444444],
+      'the replaced zms was not told to quit');
+  assert.strictEqual(monitor.connKey, 999999, 'rebuild should mint a new connkey');
+});
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed ? 1 : 0);

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -2201,7 +2201,14 @@ function MonitorStream(monitorData) {
       // in fact resumed looks frozen. refs #4706
       this.writeTextInfoBlock("");
     } else if (srcAuthCurrent && (-1 != stream.src.indexOf('mode=paused'))) {
-      // Initial page load has zms with mode=paused, auth is still valid
+      // Initial page load has zms with mode=paused, auth is still valid.
+      // started has to be set first here for the same reason as the resume
+      // branch above: streamCommand() drops anything sent while !started, and
+      // the tail of this function does not set it until after this runs, so the
+      // CMD_PLAY went nowhere and the stream stayed paused. With auth on this
+      // needed a still-valid hash to reach; with auth off, where there is no
+      // hash to go stale, it is reached on every initial load. refs #4706
+      this.started = true;
       this.streamCmdTimer = setInterval(this.streamCmdQuery.bind(this), statusRefreshTimeout);
       this.streamCommand(CMD_PLAY);
     } else {

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -2177,6 +2177,12 @@ function MonitorStream(monitorData) {
     } else {
       let src = zmAuth.applyTo(this.url_to_zms.replace(/mode=single/i, 'mode=jpeg'));
       if (-1 == src.search('connkey')) {
+        /* Quit the previous zms before the connkey that addresses it is
+         * replaced, exactly as the reload path in getStreamCmdResponse() does.
+         * Nothing can reach that process afterwards, so one that missed its
+         * SIGPIPE would sit in its stopped state forever. refs #4706
+         */
+        if (this.connKey) this.quitConnKey(this.connKey);
         this.streamCmdParms.connkey = this.statusCmdParms.connkey = this.connKey = this.genConnKey(); // The "connkey" needs to be replaced, because on the Watch page, when switching the player to ZMS, then to any other player, and then returning to ZMS, playback will not occur, because the socket="previous connkey" will be closed.
         src += '&connkey='+this.connKey;
       }

--- a/web/js/MonitorStream.js
+++ b/web/js/MonitorStream.js
@@ -222,6 +222,7 @@ function MonitorStream(monitorData) {
   this.player = monitorData.DefaultPlayer;
   this.defaultPlayer = (this.player) ? this.player : this.playerPriority[1]['name'];
   this.activePlayer = ''; // Variants: go2rtc, janus, rtsp2web_hls, rtsp2web_mse, rtsp2web_webrtc, zms. Relevant for this.player = ''/Auto
+  this.stoppedPlayer = ''; // What stop() shut down, so a zms it left running can be resumed rather than replaced.
   this.selectedPlayer = ''; // Selected player in the browser
   this.setPlayer = function(p) {
     if (-1 != p.indexOf('go2rtc')) {
@@ -877,6 +878,9 @@ function MonitorStream(monitorData) {
     if (!isZms && !isMse) stream.removeAttribute('src');
     if (!isMse) stream.load?.();
 
+    // Remembered before it is cleared: stop() leaves a zms running, and
+    // select_zms() needs to know that in order to resume it. refs #4706
+    this.stoppedPlayer = this.activePlayer;
     this.activePlayer = '';
     this.started = false;
   };
@@ -980,6 +984,10 @@ function MonitorStream(monitorData) {
 
   this.restart = function(channelStream = "default", delay = 200) {
     this.stop();
+    // Restart is the error path. Whatever went wrong may well be the zms that
+    // stop() just left running, and the img is likely broken, which no
+    // CMD_PLAY repairs - so rebuild the stream rather than resuming it. refs #4706
+    this.stoppedPlayer = '';
     const countErrors = this.getCountStreamErrors(this.player);
     if (countErrors < this.limitCountErrors) {
       const playbackSessionId = this.playbackSessionId;
@@ -2157,19 +2165,41 @@ function MonitorStream(monitorData) {
     // Check if the auth hash in the current img src is still valid.
     // On long-running pages the hash from page load may have expired.
     // zmAuth.hash is '' when authentication is off or under the plain/none relay
-    // forms; there is no hash to compare then, so fall through and rebuild as
-    // this has always done.
-    const srcAuthCurrent = stream.src && zmAuth.hash && authHashFromRelay(stream.src) === zmAuth.hash;
+    // forms. There is no hash to compare then, and equally nothing that can go
+    // stale, so the src is as current as it will ever be - treating that as
+    // "not current" sent every install with auth off down the rebuild path and
+    // gave up the resume below for no reason. refs #4706
+    const srcAuthCurrent = stream.src &&
+        (!zmAuth.hash || authHashFromRelay(stream.src) === zmAuth.hash);
 
     if (!this.isActive) {
       this.kill();
       return;
     }
 
-    if (srcAuthCurrent && this.activePlayer == 'zms') {
-      // Auth is current and zms was already the active player — just resume
+    // stop() clears activePlayer, which is what made this branch unreachable
+    // after one: a stream stopped for a hidden tab could only ever be replaced,
+    // never resumed, so every hide/show cycle abandoned a live zms. The process
+    // stop() left running is still addressable while we hold its connkey, so
+    // ask it to play again instead of building a second one. refs #4706
+    const resumableZms = (this.activePlayer == 'zms') ||
+        ((this.stoppedPlayer == 'zms') && this.connKey);
+
+    if (srcAuthCurrent && resumableZms) {
+      // Auth is current and zms was already the active player — just resume.
+      // started has to be set before the command rather than at the end of this
+      // function with the other players: streamCommand() drops anything sent
+      // while !started, so resuming after a stop - which clears it - silently
+      // sent nothing and left the stream frozen on its keepalive frame.
+      // Resuming after a pause worked only because pause() leaves it set. refs #4706
+      this.started = true;
       this.streamCmdTimer = setInterval(this.streamCmdQuery.bind(this), statusRefreshTimeout);
       this.streamCommand(CMD_PLAY);
+      // img_onload does this on the rebuild path, but resuming leaves src
+      // untouched so no load event fires. Without it the "Loading..." block and
+      // the still image behind it stay over the picture, and a stream that has
+      // in fact resumed looks frozen. refs #4706
+      this.writeTextInfoBlock("");
     } else if (srcAuthCurrent && (-1 != stream.src.indexOf('mode=paused'))) {
       // Initial page load has zms with mode=paused, auth is still valid
       this.streamCmdTimer = setInterval(this.streamCmdQuery.bind(this), statusRefreshTimeout);
@@ -2220,6 +2250,7 @@ function MonitorStream(monitorData) {
     this.started = true;
     this.handlerEventListener['killStream'] = this.streamListenerBind();
     this.activePlayer = 'zms';
+    this.stoppedPlayer = '';
     this.updateStreamInfo('ZMS MJPEG');
     hideAudioMotion(this.id);
   };


### PR DESCRIPTION
Fixes the orphaned `zms` accumulation reported in #4706, without killing streams on tab hide — which @connortechnology ruled out there, since killing takes the status polling and alarm sounds down with it.

**Reproduced and verified on a live instance.** Two monitors on a montage page, one simulated tab hide/show cycle each time:

| | before | after 1 cycle | after 2 cycles | processes |
| --- | --- | --- | --- | --- |
| stock `zms` + stock `MonitorStream.js` | 2 | **4** | **6** | replaced each cycle, old ones orphaned |
| with this branch | 2 | **2** | **2** | **the same two, resumed** |

The pre-fix run is exactly the accumulation #4706 describes. With the branch the process ids do not change at all across the cycles, and both pictures are live afterwards.

## The two defects

**A stopped `zms` could never exit** (`src/zm_monitorstream.cpp:670`). The stopped branch slept and `continue`d without writing anything, so the socket was never touched and a client that had gone away was never discovered: no write, no `EPIPE`, no `SIGPIPE`. The `continue` also skipped the `ttl` check at the bottom of the loop, so even a caller's deadline did not apply. The only way out was an explicit `CMD_QUIT`, and a stream that missed one stayed until the machine was restarted. This is why they accumulate rather than merely appear.

The last captured frame is now held on entering the stopped state and re-sent every five seconds, as the paused state already does, and `ttl` applies here too. Confirmed in the logs of a running stream:

```
DB1 [Got STOP command]
DB1 [Saving stopped image from index 0]
DB2 [Sending keepalive frame while stopped]      <- every 5s thereafter
```

`setLastViewed` is deliberately still not called: capture and decoding should not be held active for a stream that is not playing.

**`select_zms()` replaced the connkey without quitting the process it addressed** (`web/js/MonitorStream.js`). Once the key is gone nothing can reach that `zms` again, so no `CMD_QUIT` can ever be delivered to it. `getStreamCmdResponse()` already learned this — its reload path calls `quitConnKey()` first, with a comment saying exactly why — but the path every ordinary `start()` takes did not. `quitConnKey` had precisely two references in the file: its own definition and that one use.

## Resuming instead of rebuilding

The third commit makes the hide/show path *resume* the stopped `zms` with `CMD_PLAY` rather than build a new one — what `CMD_STOP` is designed for, and what the discussion on #4706 assumed should work. It did not, for three separate reasons, none of which were visible from reading:

1. `stop()` clears `activePlayer`, which is the only thing the resume branch tests, so after a stop it was unreachable.
2. `srcAuthCurrent` required a non-empty `zmAuth.hash`, which is `''` whenever auth is off — so those installs always rebuilt, for no reason, since there is no hash that can go stale.
3. `streamCommand()` drops anything sent while `!started`, and `started` is not set until the end of `select_zms()`. The resume issued its `CMD_PLAY` into nothing. Resuming after a *pause* worked only because `pause()` leaves `started` set.

With those fixed the `zms` status reports `stopped: 0` and ~15 fps — and the picture still looked frozen, because the rebuild path clears the `"Loading..."` info block from `img_onload`, which cannot fire when `src` never changes. The resumed stream was playing underneath its own overlay. Clearing the block on the resume path is the last piece.

@IgorA100 reported on #4706 that a `CMD_PLAY` after `CMD_STOP` does not restart the video. That was correct, and points 3 and 4 above are why.

## Testing

- `zms` builds clean, no new warnings; full C++ suite **138/138 pass**; ESLint clean on `MonitorStream.js`.
- Live before/after process counts as tabled above, on a 2-monitor montage page.
- Keepalive behaviour confirmed in `zms` debug logs.
- Resume confirmed end to end: same pids across two cycles, `stopped: 0` and ~15 fps from the stream status query, and the burnt-in camera timestamp advancing in the browser afterwards.

## Relationship to #4706

Supersedes it. Same diagnosis of the symptom, different mechanism: nothing is killed on tab hide, and the process that does get replaced is now told to quit rather than left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
