### PR TITLE
test: read the bandwidth options the way the skin now derives them

### DIFF
--- a/tests/php/test_web_option_wiring.php
+++ b/tests/php/test_web_option_wiring.php
@@ -31,8 +31,18 @@ function skin_sources($root, $exclude) {
 }
 
 $config_src = file_get_contents($skin_config);
-preg_match_all("/define\(\s*'(ZM_WEB_[A-Z_]+)'/", $config_src, $m);
-$options = array_values(array_unique($m[1]));
+preg_match('/\$bandwidth_settings\s*=\s*array\((.*?)\);/s', $config_src, $required);
+preg_match('/\$bandwidth_optional_settings\s*=\s*array\((.*?)\);/s', $config_src, $optional);
+$names = array();
+if (!empty($required)) {
+  preg_match_all("/'([A-Z_]+)'/", $required[1], $m);
+  $names = array_merge($names, $m[1]);
+}
+if (!empty($optional)) {
+  preg_match_all("/'([A-Z_]+)'\s*=>/", $optional[1], $m);
+  $names = array_merge($names, $m[1]);
+}
+$options = array_values(array_unique(array_map(function($name) { return 'ZM_WEB_'.$name; }, $names)));
 check('the skin defines per-bandwidth web options', count($options) > 0);
 
 $sources = skin_sources($root, $skin_config);


### PR DESCRIPTION
`tests/php/test_web_option_wiring.php` collects the per-bandwidth options by grepping the skin config for `define('ZM_WEB_...')`. Since the aliases were changed to be derived from the profile prefix in a loop, there are no literal defines left, so the list comes back empty: the first check fails and the "every option is read somewhere" check silently passes over nothing, which is the exact protection the test was written to provide for #4850.

It now reads `$bandwidth_settings` and `$bandwidth_optional_settings`, the same two arrays the skin loops over, which gives it 18 options to check instead of 0.

`php tests/php/test_web_option_wiring.php` exits 1 with one FAIL on master and 0 with all five passing on this branch. All 18 are read somewhere today, so nothing else needed changing.
