### PR TITLE
Fix timeline view SQL error when user cannot view all monitors

### DIFF
--- a/web/skins/classic/views/timeline.php
+++ b/web/skins/classic/views/timeline.php
@@ -156,7 +156,7 @@ WHERE NOT isnull(StartDateTime)';
 $eventsValues = array();
 
 if ( count($user->unviewableMonitorIds()) ) {
-  $monFilterSql = ' AND E.MonitorId IN ('.$user->viewableMonitorIds().')';
+  $monFilterSql = ' AND E.MonitorId IN (' . implode(',', $user->viewableMonitorIds()) . ')';
   $rangeSql .= $monFilterSql;
   $eventsSql .= $monFilterSql;
   $eventIdsSql .= $monFilterSql;


### PR DESCRIPTION
Fixes #5124

## Problem

Timeline view fails with `SQL-ERR 'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Array' in 'WHERE'` for any account that cannot view all monitors.

`web/skins/classic/views/timeline.php` concatenated the array returned by `$user->viewableMonitorIds()` directly into the SQL string, producing the literal text `Array`.

## Fix

`implode()` the id list, as every other view already does (`montagereview.php`, `events.php`, `report_event_audit.php`, `includes/functions.php`).

Verified working on ZoneMinder 1.37.75 (Debian package): timeline now renders with the monitor restriction applied.