### PR TITLE
fix: free the event start iterator when openEvent cannot lock its packet

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -3824,6 +3824,11 @@ Event * Monitor::openEvent(
 
     if (!starting_packet.packet_) {
       Warning("Unable to get starting packet lock");
+      // Every other path out of here hands start_it to the Event, which frees
+      // it in ~Event. Leaking it leaves a registered iterator pinned to the
+      // front of the queue, which stops clearPackets() removing anything for
+      // the life of the process.
+      packetqueue.free_it(start_it);
       return nullptr;
     }
     packet_lock->unlock();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
   zm_font.cpp
   zm_image.cpp
   zm_monitorstream.cpp
+  zm_packetqueue.cpp
   zm_monitor_action.cpp
   zm_onvif_auth_error.cpp
   zm_onvif_renewal.cpp

--- a/tests/zm_packetqueue.cpp
+++ b/tests/zm_packetqueue.cpp
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the ZoneMinder Project. See AUTHORS file for contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "zm_catch2.h"
+
+#include "zm_packet.h"
+#include "zm_packetqueue.h"
+
+#include <memory>
+
+namespace {
+
+std::shared_ptr<ZMPacket> video_packet(int keyframe) {
+  auto packet = std::make_shared<ZMPacket>();
+  packet->packet->stream_index = 0;
+  packet->keyframe = keyframe;
+  packet->codec_type = AVMEDIA_TYPE_VIDEO;
+  packet->timestamp = std::chrono::system_clock::now();
+  return packet;
+}
+
+}  // namespace
+
+// Monitor::openEvent() takes an iterator from get_event_start_packet_it() and
+// normally hands it to the Event, which frees it in ~Event. The error path that
+// fails to lock the starting packet used to return without freeing it. This
+// covers what that leak does to the queue: a registered iterator sitting on the
+// front packet stops clearPackets() removing anything, permanently, because
+// deletePacket() drags registered iterators onto each new front packet.
+TEST_CASE("PacketQueue: an abandoned iterator blocks trimming until it is freed") {
+  PacketQueue queue;
+  queue.addStream();
+  queue.setKeepKeyframes(false);
+  queue.setMaxVideoPackets(10);
+  queue.setPreEventVideoPackets(2);
+
+  // queuePacket() drops everything when no iterator is registered, so stand in
+  // for the analysis thread and keep one registered for the whole test.
+  packetqueue_iterator *analysis_it = queue.get_video_it(false);
+  REQUIRE(analysis_it != nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    REQUIRE(queue.queuePacket(video_packet(i == 0 ? 1 : 0)));
+  }
+  REQUIRE(queue.size() == 6);
+
+  SECTION("the queue trims once nothing points at the front") {
+    // Analysis has consumed the queue, so its iterator sits at the tail.
+    while (queue.increment_it(analysis_it, false)) {}
+
+    auto trigger = video_packet(1);
+    REQUIRE(queue.queuePacket(trigger));
+    REQUIRE(queue.clearPackets(trigger));
+
+    REQUIRE(queue.size() < 7);
+  }
+
+  SECTION("an abandoned iterator on the front packet stops every removal") {
+    // What openEvent() used to leave behind: a registered iterator that nothing
+    // owns any more, pointing at the front of the queue.
+    packetqueue_iterator *leaked_it = queue.get_video_it(false);
+    REQUIRE(leaked_it != nullptr);
+    while (queue.increment_it(analysis_it, false)) {}
+
+    auto trigger = video_packet(1);
+    REQUIRE(queue.queuePacket(trigger));
+    queue.clearPackets(trigger);
+
+    REQUIRE(queue.size() == 7);
+
+    // Freeing it is all the fix does, and the queue drains on the next attempt.
+    queue.free_it(leaked_it);
+
+    auto next = video_packet(1);
+    REQUIRE(queue.queuePacket(next));
+    REQUIRE(queue.clearPackets(next));
+
+    REQUIRE(queue.size() < 8);
+  }
+
+  queue.stop();
+  queue.clear();
+}
+
+// The pair of calls the fix in Monitor::openEvent() now makes on its error path:
+// an iterator from get_event_start_packet_it() is registered with the queue, and
+// free_it() is what takes it back out again.
+TEST_CASE("PacketQueue: free_it unregisters an event start iterator") {
+  PacketQueue queue;
+  queue.addStream();
+  queue.setKeepKeyframes(false);
+  queue.setMaxVideoPackets(0);
+  queue.setPreEventVideoPackets(2);
+
+  packetqueue_iterator *analysis_it = queue.get_video_it(false);
+  REQUIRE(analysis_it != nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    REQUIRE(queue.queuePacket(video_packet(i == 0 ? 1 : 0)));
+  }
+
+  std::shared_ptr<ZMPacket> front = *queue.begin();
+  while (queue.increment_it(analysis_it, false)) {}
+  REQUIRE_FALSE(queue.is_there_an_iterator_pointing_to_packet(front));
+
+  packetqueue_iterator *start_it = queue.get_event_start_packet_it(*analysis_it, 10);
+  REQUIRE(start_it != nullptr);
+  REQUIRE(queue.is_there_an_iterator_pointing_to_packet(front));
+
+  queue.free_it(start_it);
+  REQUIRE_FALSE(queue.is_there_an_iterator_pointing_to_packet(front));
+
+  queue.stop();
+  queue.clear();
+}


### PR DESCRIPTION
Fixes #5127.

```diff
     if (!starting_packet.packet_) {
       Warning("Unable to get starting packet lock");
+      packetqueue.free_it(start_it);
       return nullptr;
     }
```

`PacketQueue::get_event_start_packet_it()` allocates a `packetqueue_iterator` and registers it in `PacketQueue::iterators`. Every path out of `Monitor::openEvent()` hands that pointer to `new Event(...)`, which releases it in `~Event` via `free_it` (src/zm_event.cpp:201) — except the one that fails to lock the starting packet, which returned `nullptr` and left it registered for the life of the process.

## What the leak does

`clearPackets()` takes `min_iterator_queue_index` across all registered iterators (src/zm_packetqueue.cpp:283) and stops removing at the first packet whose `queue_index` reaches it. An abandoned iterator pins that to the front packet, so the trimmer removes nothing on every invocation — and `deletePacket()` advances registered iterators onto the packet after the one it removed, dragging the orphan onto each new front packet so it can never age out. `clear_packets_pending_` then latches true (line 321), downgrading the gate at line 254 so the futile scan re-runs on every video packet rather than only on keyframes.

The only removal path left is the emergency one-GOP eviction in `queuePacket()`. The queue settles into: refill a GOP, exceed `max_video_packet_count`, warn, evict a GOP, repeat. It is pinned at its cap by construction, which is why an affected monitor warns once per GOP at a constant rate for as long as `zmc` runs, and no amount of idle time or extra headroom recovers it. Restarting that monitor clears it instantly.

`free_it()` takes the queue mutex itself; only `ZMPacketLock`s are held at that point, so there is no deadlock risk.

## Tests

`tests/zm_packetqueue.cpp`, two cases:

- `free_it` takes an event start iterator back out of the queue — the exact call pair the error path now makes, asserted through `is_there_an_iterator_pointing_to_packet()`.
- An abandoned iterator on the front packet stops every removal, and trimming resumes once it is freed — the mechanism that turns the leak into the permanent warning loop.

```
$ ./tests/tests "PacketQueue*"
All tests passed (36 assertions in 2 test cases)
```

Note for whoever runs the full suite: `tests/zm_audio_detector.cpp` does not compile here (`'Approx' was not declared in this scope` — Catch2 v3 removed it), which is pre-existing on master and unrelated to this change. I ran the suite with that one file excluded and left it untouched. CI does not catch it because it builds with `BUILD_TEST_SUITE=0`.

## Not addressed

The `// FIXME this iterator is not protected from invalidation` at src/zm_monitor.cpp:3816 is the same iterator and a separate hazard. The warning text in `queuePacket()` also offers only capacity explanations, neither of which applies in this state; logging `iterators.size()` and `min_iterator_queue_index` alongside the depth would tell a stuck iterator from real congestion at a glance. Both left for separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
