### PR TITLE
fix: qualify Approx as Catch::Approx in audio detector tests

### DIFF
--- a/tests/zm_audio_detector.cpp
+++ b/tests/zm_audio_detector.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Audio RMS of signed 16-bit samples") {
 
   SECTION("a full scale square wave is full scale") {
     const auto samples = SquareS16(32767, 64);
-    REQUIRE(AudioDetector::RmsS16(samples.data(), samples.size()) == Approx(1.0).margin(0.001));
+    REQUIRE(AudioDetector::RmsS16(samples.data(), samples.size()) == Catch::Approx(1.0).margin(0.001));
   }
 
   SECTION("the most negative sample does not exceed full scale") {
@@ -58,7 +58,7 @@ TEST_CASE("Audio RMS of signed 16-bit samples") {
     const auto loud = SquareS16(16384, 64);
     const auto quiet = SquareS16(8192, 64);
     REQUIRE(AudioDetector::RmsS16(loud.data(), loud.size()) ==
-            Approx(2.0 * AudioDetector::RmsS16(quiet.data(), quiet.size())));
+            Catch::Approx(2.0 * AudioDetector::RmsS16(quiet.data(), quiet.size())));
   }
 
   SECTION("no samples is zero, not a division by zero") {
@@ -76,14 +76,14 @@ TEST_CASE("Audio RMS of float samples") {
 
   SECTION("full scale is one") {
     const std::vector<float> samples(64, 1.0f);
-    REQUIRE(AudioDetector::RmsFloat(samples.data(), samples.size()) == Approx(1.0));
+    REQUIRE(AudioDetector::RmsFloat(samples.data(), samples.size()) == Catch::Approx(1.0));
   }
 
   SECTION("decoder overshoot is clamped rather than scoring above full scale") {
     // Float decoders are allowed to emit values outside -1..1; without the
     // clamp a hot AAC stream would report a level above 100.
     const std::vector<float> samples(64, 4.0f);
-    REQUIRE(AudioDetector::RmsFloat(samples.data(), samples.size()) == Approx(1.0));
+    REQUIRE(AudioDetector::RmsFloat(samples.data(), samples.size()) == Catch::Approx(1.0));
   }
 }
 


### PR DESCRIPTION
`tests/zm_audio_detector.cpp`, added in c7deb3faa, uses the bare `Approx(...)` matcher. That is the Catch2 v2 spelling — v3 moved it into the `Catch` namespace — so the file does not compile against Catch2 3.x:

```
tests/zm_audio_detector.cpp:47:70: error: use of undeclared identifier 'Approx'; did you mean 'Catch::Approx'?
```

Four call sites, all in that one file. The rest of `tests/` is already on v3 idiom — `zm_config.cpp` writes `Catch::Approx`, and `zm_catch2.h` includes `catch2/catch_all.hpp` — so this was the only holdout.

### Why CI missed it

No workflow passes `-DBUILD_TEST_SUITE=ON`, so `tests/` is never configured or compiled in CI. `ci-build-werror.yml` builds with `ENABLE_WERROR=ON` but leaves the test suite off, which means a test file can stop compiling without anything going red. Worth considering as a separate change — adding the test suite to one CI job would have caught this at the source.

### Verification

Built against Catch2 3.15.2 on macOS (arm64, Homebrew). Before the change the object fails to compile; after it, it builds clean and the full suite passes:

```
./tests/tests "~[notCI]"
All tests passed (12480 assertions in 144 test cases)
```

Note the suite has to be run from the build's `tests/` directory — the font tests load `data/fonts/*` by relative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5KL9Xbi7K5aGsauLtd8tG