### PR TITLE
fix: initialize alarm_actions_fired in declaration order

### DIFF
--- a/src/zm_monitor.cpp
+++ b/src/zm_monitor.cpp
@@ -235,7 +235,6 @@ Monitor::Monitor() :
   audio_detection(false),
   audio_threshold(0),
   audio_alarm_score(0),
-  alarm_actions_fired(false),
   wallclock_timestamps(false),
 //event_prefix
 //label_format
@@ -331,6 +330,7 @@ Monitor::Monitor() :
   //linked_monitors_string
   n_linked_monitors(0),
   linked_monitors(nullptr),
+  alarm_actions_fired(false),
   RTSP2Web_Manager(nullptr),
   Go2RTC_Manager(nullptr),
   Janus_Manager(nullptr),


### PR DESCRIPTION
`ci-build-werror` has been red on master since ad70d5e80, and this is the only thing failing it:

```
src/zm_monitor.h:767:8: error: 'Monitor::alarm_actions_fired' will be initialized after [-Werror=reorder]
src/zm_monitor.h:621:19: error:   'bool Monitor::wallclock_timestamps' [-Werror=reorder]
src/zm_monitor.cpp:178:1: error:   when initialized here [-Werror=reorder]
```

That commit added `alarm_actions_fired(false)` to the `Monitor()` init list between `audio_alarm_score` and `wallclock_timestamps`, but declared the member much further down the class, after `linked_monitors`. Members initialize in declaration order whatever order the init list is written in, so gcc flags the mismatch.

Nothing observable changes — it's a `bool` with a constant initializer, so the only thing moving is where the entry sits in the list. Now placed after `linked_monitors(nullptr)`, which is where the member is declared.

### Verification

Reproduced with clang, which calls it `-Wreorder-ctor`:

```
$ c++ ... -Werror=reorder -c src/zm_monitor.cpp
src/zm_monitor.cpp:238:3: error: field 'alarm_actions_fired' will be initialized after field 'wallclock_timestamps' [-Werror,-Wreorder-ctor]
```

Clean with the change applied. I also swept all 124 non-vendored translation units in `compile_commands.json` with `-fsyntax-only -Wreorder` — no other reorder hits, so this should be the whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5KL9Xbi7K5aGsauLtd8tG