### PR TITLE
ci: make package versions unique per build, and build once per branch

### DIFF
--- a/.github/workflows/build-deb-packages-aarch64.yml
+++ b/.github/workflows/build-deb-packages-aarch64.yml
@@ -5,6 +5,14 @@ on:
     branches: [ release-1.38, master ]
 permissions:
   contents: write
+
+# Several merges landing seconds apart used to start a run each, and every
+# one of them published. Keep one build per branch and cancel the ones that
+# a newer push has already superseded.
+concurrency:
+  group: deb-aarch64-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GPG_KEY_ID: ${{ secrets.ZMREPO_GPG_KEY_ID }}
   GPG_PASSPHRASE: ${{ secrets.ZMREPO_GPG_PASSPHRASE }}

--- a/.github/workflows/build-deb-packages.yml
+++ b/.github/workflows/build-deb-packages.yml
@@ -5,6 +5,14 @@ on:
     branches: [ release-1.38, master ]
 permissions:
   contents: write
+
+# Several merges landing seconds apart used to start a run each, and every
+# one of them published. Keep one build per branch and cancel the ones that
+# a newer push has already superseded.
+concurrency:
+  group: deb-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GPG_KEY_ID: ${{ secrets.ZMREPO_GPG_KEY_ID }}
   GPG_PASSPHRASE: ${{ secrets.ZMREPO_GPG_PASSPHRASE }}

--- a/.github/workflows/build-rpm-packages-aarch64.yml
+++ b/.github/workflows/build-rpm-packages-aarch64.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: write
 
+# Several merges landing seconds apart used to start a run each, and every
+# one of them published. Keep one build per branch and cancel the ones that
+# a newer push has already superseded.
+concurrency:
+  group: rpm-aarch64-${{ github.ref }}
+  cancel-in-progress: true
+
+
 env:
   GPG_KEY_ID: ${{ secrets.ZMREPO_GPG_KEY_ID }}
   GPG_PASSPHRASE: ${{ secrets.ZMREPO_GPG_PASSPHRASE }}
@@ -133,7 +141,11 @@ jobs:
           # Calculate snapshot version
           versionhash=$(git log -n1 --pretty=format:%h version.txt)
           numcommits=$(git rev-list ${versionhash}..HEAD --count)
-          SNAPSHOT="$(date +%Y%m%d).${numcommits}"
+          # date+numcommits is not unique per build: rebuilding the same commit
+          # on the same day reuses the version, and the repo then holds one
+          # version whose content changed underneath it. GITHUB_RUN_ID is unique
+          # and never reused.
+          SNAPSHOT="$(date +%Y%m%d).${numcommits}.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT:-1}"
           echo "snapshot=${SNAPSHOT}" >> $GITHUB_OUTPUT
 
           # Update version in spec file

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: write
 
+# Several merges landing seconds apart used to start a run each, and every
+# one of them published. Keep one build per branch and cancel the ones that
+# a newer push has already superseded.
+concurrency:
+  group: rpm-${{ github.ref }}
+  cancel-in-progress: true
+
+
 env:
   GPG_KEY_ID: ${{ secrets.ZMREPO_GPG_KEY_ID }}
   GPG_PASSPHRASE: ${{ secrets.ZMREPO_GPG_PASSPHRASE }}
@@ -129,7 +137,11 @@ jobs:
           # Calculate snapshot version
           versionhash=$(git log -n1 --pretty=format:%h version.txt)
           numcommits=$(git rev-list ${versionhash}..HEAD --count)
-          SNAPSHOT="$(date +%Y%m%d).${numcommits}"
+          # date+numcommits is not unique per build: rebuilding the same commit
+          # on the same day reuses the version, and the repo then holds one
+          # version whose content changed underneath it. GITHUB_RUN_ID is unique
+          # and never reused.
+          SNAPSHOT="$(date +%Y%m%d).${numcommits}.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT:-1}"
           echo "snapshot=${SNAPSHOT}" >> $GITHUB_OUTPUT
 
           # Update version in spec file

--- a/utils/do_debian_package.sh
+++ b/utils/do_debian_package.sh
@@ -181,7 +181,17 @@ else
 
       # Number of commits since the version file was last changed
       numcommits=$(git rev-list ${versionhash}..HEAD --count)
-      SNAPSHOT="`date +%Y%m%d.`$(git rev-list ${versionhash}..HEAD --count)"
+      SNAPSHOT="`date +%Y%m%d.`${numcommits}"
+
+      # date+numcommits is not unique per build: every build of the same tip on
+      # the same day produces the same string, and the repo then holds one
+      # version whose content changed underneath it. A client that read Packages
+      # before a republish and fetched the .deb after it gets a hash mismatch.
+      # GITHUB_RUN_ID is unique and never reused, and appending a component
+      # keeps the version strictly greater than the ones already published.
+      if [ -n "$GITHUB_RUN_ID" ]; then
+        SNAPSHOT="${SNAPSHOT}.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT:-1}"
+      fi
     fi;
   fi;
 fi;


### PR DESCRIPTION
The repo operator reports that 96% of version+dist pairs have been published more than once, and that `1.39.34~20260912.22-bookworm1` was installed six times in about thirty minutes, each upload overwriting the last with different content. No server-side setting fixes that: reindexing shrinks the window, but a client that read `Packages` before a republish and fetched the `.deb` after it still gets a hash mismatch. A version string has to identify content.

## It is not a retry loop

`utils/do_debian_package.sh` builds the snapshot component from the date and the number of commits since `version.txt` last changed:

```sh
versionhash=$(git log -n1 --pretty=format:%h version.txt)
SNAPSHOT="`date +%Y%m%d.`$(git rev-list ${versionhash}..HEAD --count)"
```

Nothing in it varies per build. Two things then multiply that into the observed pattern.

Three merges landed within 45 seconds on 2026-09-12 (`0a4194d5` at 14:24:06, `76002987` at 14:24:28, `0487e7fa` at 14:24:51), and each started its own run of both package workflows. That is three runs × two architecture workflows = six uploads per dist, which is the number the operator counted.

They all carried the same version because the script discards the commit that triggered the run. In CI the workflow symlinks the checkout as `ZoneMinder_ZoneMinder.git`, and the script then does `git pull` on it, clones it, and does `git checkout master && git pull` again in the clone. Every run started within that minute pulled the same tip, so all three computed the same commit count from the same HEAD and produced `~20260912.22` — while building whatever the tip happened to be when each one got there.

## What this changes

**Unique per build.** `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT` are appended to the snapshot. They are unique and never reused, including across re-runs. Outside Actions the variables are unset and the string is exactly what it was, so local builds are unaffected. The same one-line change goes into both RPM workflows, which compute the snapshot inline and have the same defect on rebuilds.

**One build per branch.** A `concurrency` group per workflow and branch with `cancel-in-progress`, so a newer push supersedes a build still in flight instead of racing it into the incoming directory. A burst of merges now publishes one package set rather than one per merge, and the matrix stops rebuilding fourteen containers for a commit that is already stale.

## Ordering

The longer string has to sort after everything already published and before the next `version.txt` bump. Verified both ways:

```
$ dpkg --compare-versions 1.39.34~20260912.22-bookworm1 lt 1.39.34~20260912.22.18234567890.1-bookworm1   # ok
$ dpkg --compare-versions 1.39.34~20260912.22.18234567890.1-bookworm1 lt 1.39.35~20260913.0.1.1-bookworm1 # ok
$ rpm --eval "%{lua:print(rpm.vercmp('0.20260912.22','0.20260912.22.18234567890.1'))}"                    # -1
```

`bash -n` on the script and a YAML parse of all four workflows pass.

## Two things this does not fix

**The architecture workflows now diverge.** `build-deb-packages` and `build-deb-packages-aarch64` are separate workflows with separate run IDs, so amd64 and arm64 packages for one commit no longer share a version string. Each architecture is self-consistent and installs fine; a multi-arch system with both enabled would see them as different versions. The alternative is to key uniqueness on `GITHUB_SHA`, which keeps the architectures aligned but republishes the same version on a deliberate re-run — the thing the operator asked to eliminate. I took the operator's requirement as stated; say the word and I will switch it.

**The version still describes the tip, not the commit that triggered the build.** The `git pull` in `do_debian_package.sh` means a run triggered by commit A can build and label commit B. With the concurrency group that mostly stops mattering, since superseded runs are cancelled rather than pulling ahead — but the script is still deriving a version from a tree it fetched rather than from the revision it was asked to build. Fixing it properly means using the checkout as-is (the `-l`/`LOCAL_SOURCE` path already skips the pull) and would want its own change, since the script is also run by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkQwahn9pi1y4wJe9BTxjM
