### PR TITLE
docs: correct what max-age=2147483647 actually means in setCookie

### DIFF
--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -960,10 +960,10 @@ function isJSON(str) {
 }
 
 // Cookies holding an absolute date range. They are shared between the events
-// list and montage review (refs #4976), but do not age well: kept until 2038, a
-// window picked months ago is restored on a bare page load and the view opens on
-// a range with no events. Session scope keeps the sharing and lets a new session
-// fall back to the last hour.
+// list and montage review (refs #4976), but do not age well: kept for decades by
+// the default below, a window picked months ago is restored on a bare page load
+// and the view opens on a range with no events. Session scope keeps the sharing
+// and lets a new session fall back to the last hour.
 const sessionCookies = ['zmFilter_StartDateTime', 'zmFilter_EndDateTime'];
 
 function setCookie(name, value, seconds) {
@@ -976,7 +976,10 @@ function setCookie(name, value, seconds) {
   } else if (sessionCookies.includes(name)) {
     expires = "";
   } else {
-    // 2147483647 is 2^31 - 1 which is January of 2038 to avoid the 32bit integer overflow bug.
+    // Max-Age is a duration in seconds counted from now, not an absolute date
+    // (RFC 6265 section 5.2.2), so this is roughly 68 years out rather than the
+    // January 2038 this comment used to claim. 2^31 - 1 is the largest value
+    // that cannot overflow a signed 32bit int in a client that converts it.
     expires = "; max-age=2147483647";
   }
   document.cookie = name + "=" + (newValue || "") + expires + "; path=/; samesite=strict";


### PR DESCRIPTION
Comment-only, no behaviour change.

`web/skins/classic/js/skin.js` said:

```js
// 2147483647 is 2^31 - 1 which is January of 2038 to avoid the 32bit integer overflow bug.
expires = "; max-age=2147483647";
```

`Max-Age` is a duration in seconds counted from now, not an absolute date (RFC 6265 §5.2.2), so the value is roughly 68 years out. January 2038 is what 2^31 − 1 means read as an epoch timestamp, which is how `Expires` works — a different attribute. The number itself is still the right choice, for the reason the comment half stated: it is the largest value that cannot overflow a signed 32bit int in a client that converts it.

The `sessionCookies` comment directly above repeated the claim as "kept until 2038". That one is worth correcting beyond pedantry, because the argument for scoping those two cookies to the session rests on how long the default actually keeps them — and it is decades, not twelve years.

Noticed while reviewing #5093, where Copilot raised the original comment as a suppressed note. Both lines are on master now, so this is separate from that PR.

ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkQwahn9pi1y4wJe9BTxjM
