### PR TITLE
docs: correct the macOS guide against a real install

### DIFF
--- a/docs/installationguide/macos.rst
+++ b/docs/installationguide/macos.rst
@@ -6,9 +6,13 @@ macOS
 What this covers
 ----------------
 
-ZoneMinder builds, installs and runs on macOS from source. There is no package
-and no Homebrew formula yet, so everything here is manual, and there is no
-launchd job — you start the daemons yourself or write your own plist.
+ZoneMinder builds, installs and runs on macOS from source. There is no package,
+so everything here is manual.
+
+These steps have been run through on Apple Silicon to a working system: capture
+from a network source, motion detection, events recorded to disk, and the web
+interface serving its console. Treat it as a development and evaluation
+platform rather than something to put cameras behind — see the gaps at the end.
 
 Two prefixes are in play and it is worth keeping them apart. Homebrew's prefix
 is where the dependencies come from — ``/opt/homebrew`` on Apple Silicon,
@@ -182,7 +186,22 @@ you do it yourself, once:
                             /usr/local/var/lib/zoneminder
 
 ``_www`` is the account macOS runs its web server as, and is what configure
-detects. Mapped memory files live in ``/usr/local/var/run/zm`` rather than
+detects.
+
+Whatever account you choose, **ZoneMinder has to be started as that account**.
+``zmpkg.pl`` compares the current user against ``ZM_WEB_USER`` and, when they
+differ, tries ``sudo -u``, then two forms of ``su``, to become it. Run it as
+yourself against a configured user of ``_www`` and all three fail — ``su`` needs
+root and ``sudo`` wants a password — and it stops with ``Unable to find valid su
+syntax``. On Linux systemd sidesteps this by starting the unit as the web user;
+the launchd job below does the same.
+
+So either start it under launchd, or run everything as one account. For a
+workstation install the simpler option is to set ``ZM_WEB_USER`` and
+``ZM_WEB_GROUP`` in ``/usr/local/etc/zm/zm.conf`` to your own account and group,
+point a web server that runs as you at it, and own the directories above
+yourself. ``zms`` reads the mapped memory that ``zmc`` writes, so the capture
+daemons and the web server must agree on the account either way. Mapped memory files live in ``/usr/local/var/run/zm`` rather than
 ``/dev/shm``, which macOS does not have. That directory is on disk, not a RAM
 filesystem — macOS mounts no tmpfs — so expect more disk traffic than the same
 setup on Linux.
@@ -190,16 +209,31 @@ setup on Linux.
 Database
 --------
 
+A Homebrew MariaDB authenticates ``root`` with the ``unix_socket`` plugin, so
+``mysql -u root`` is refused — only the operating system's root user matches it.
+Your own account gets an administrative account instead, which is what ``mariadb``
+with no ``-u`` uses:
+
 ::
 
     brew services start mariadb
-    mysql -u root < /usr/local/share/zoneminder/db/zm_create.sql
-    mysql -u root -e "CREATE USER IF NOT EXISTS 'zmuser'@localhost IDENTIFIED BY 'zmpass';"
-    mysql -u root -e "GRANT LOCK TABLES, ALTER, SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON zm.* TO 'zmuser'@localhost;"
-    sudo zmupdate.pl --nointeractive
+    mariadb < /usr/local/share/zoneminder/db/zm_create.sql
+    mariadb -e "CREATE USER IF NOT EXISTS 'zmuser'@localhost IDENTIFIED BY 'zmpass';"
+    mariadb -e "GRANT LOCK TABLES, ALTER, SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX ON zm.* TO 'zmuser'@localhost;"
+    zmupdate.pl --nointeractive
 
 Change the user and password from the defaults, in the grant above and in
 ``/usr/local/etc/zm/zm.conf``, before putting this anywhere reachable.
+
+.. note::
+   ``zmupdate.pl`` does not use ``DBI`` for schema changes; it shells out to a
+   client binary, picking ``mariadb`` over ``mysql`` when one is on ``PATH``.
+   The Perl scripts run under ``-T`` and set a taint-safe
+   ``PATH`` of ``/bin:/usr/bin:/usr/local/bin``, so on Apple Silicon, where
+   Homebrew is ``/opt/homebrew``, neither client is found and the upgrade fails
+   with ``sh: mysql: command not found``. Until that path is configurable, add
+   the Homebrew prefix to the ``$ENV{PATH}`` line near the top of
+   ``zmupdate.pl``, or symlink ``mariadb`` into ``/usr/local/bin``.
 
 Web server
 ----------
@@ -211,6 +245,17 @@ neither is installed, and both need adapting to how your web server is set up.
 
 Whichever you choose, it needs PHP, CGI enabled for ``nph-zms``, and rewrite
 rules for the API. The sample files show all three.
+
+The CGI part decides which server is less work. ``zms`` is a CGI binary, and
+Apache runs those directly with ``mod_cgi``; nginx cannot, and needs a wrapper
+such as ``fcgiwrap``, which Homebrew does not package. With nginx and no wrapper
+the interface loads and the console works, but live streams and event playback
+do not.
+
+The samples are also written for the Linux layout and need editing here. The
+nginx one expects certificates under ``/etc/pki``, ``fastcgi_params`` under
+``/etc/nginx`` and an ``fcgiwrap`` socket at ``/run/fcgiwrap.sock``, none of
+which exist on macOS.
 
 Starting ZoneMinder
 -------------------
@@ -267,3 +312,10 @@ Known gaps
 - Configure warns that it cannot find ``arp-scan`` and ``ip``. Neither is fatal:
   ``brew install arp-scan`` covers the first, and ``ip`` is a Linux tool that
   macOS has no equivalent of, so monitor probing is a little less capable.
+- The taint-safe ``PATH`` the Perl scripts set is hardcoded to
+  ``/bin:/usr/bin:/usr/local/bin`` in seventeen files, so anything they shell out
+  to has to be in one of those. Apple Silicon's Homebrew prefix is not, which is
+  what breaks ``zmupdate.pl`` above. The same would affect a ``--prefix=/opt``
+  install on Linux.
+- ``Sys::CPU``, which ``zmtelemetry.pl`` uses, has been removed from CPAN and
+  cannot be installed at all. Telemetry is the only thing affected.


### PR DESCRIPTION
The macOS guide added in #5132 was written from a verified build and install. Everything past that point — database, web server, starting the daemons — was derived from the Debian packaging rather than run. I have now worked through it on Apple Silicon to a running system, and three things in it were wrong or missing.

### `mysql -u root` does not work

A Homebrew MariaDB authenticates `root` with the `unix_socket` plugin, so only the operating system's root user matches it:

```
ERROR 1698 (28000): Access denied for user 'root'@'localhost'
```

Your own account gets the administrative account instead, which is what plain `mariadb` uses. All four commands in that section corrected.

### Nothing said it has to be started as `ZM_WEB_USER`

`zmpkg.pl` compares the current user against `ZM_WEB_USER` and, when they differ, tries `sudo -u` then two forms of `su` to become it. Run as an ordinary user against a configured `_www`, all three fail — `su` needs root, `sudo` wants a password — and it stops with:

```
zmpkg[5922].ERR [ZoneMinder::General:238] [Unable to find valid su syntax]
```

systemd hides this on Linux by starting the unit as the web user, and the launchd job does the same, but the guide never said so. Now does, with the workstation alternative of running everything as one account and a note that `zms` and `zmc` must agree since one reads the mapped memory the other writes.

### `zms` is a CGI binary

The web server section listed the three things a server needs but not which server makes them easy. Apache runs CGI directly with `mod_cgi`; nginx cannot and needs a wrapper such as `fcgiwrap`, which Homebrew does not package — so with nginx alone the interface loads and the console works, but live streams and event playback do not. Verified both halves of that. Also noted the generated samples reference `/etc/pki`, `/etc/nginx` and `/run/fcgiwrap.sock`, none of which exist on macOS.

### Known gaps

Two additions, both hit while doing this:

**The taint-safe `PATH` is hardcoded.** `zmupdate.pl` does not use `DBI` for schema changes — it shells out to a client binary via `findDbCommand`, which prefers `mariadb` and falls back to `mysql`. The scripts run under `-T` and pin:

```perl
$ENV{PATH}  = '/bin:/usr/bin:/usr/local/bin';
```

Apple Silicon's Homebrew prefix is `/opt/homebrew`, which is not in that list, so neither client is found and the upgrade fails with `sh: mysql: command not found` even though both are on the caller's `PATH`. Seventeen files in `scripts/` pin the same string. This looks worth making configurable — it is the same shape as `FindGSOAP` only searching `/usr` and `/usr/local`, and would equally affect a `--prefix=/opt` install on Linux. I have not changed any of them here; this PR only documents the workaround. Happy to send that separately if you think it is worth doing.

**`Sys::CPU` is gone from CPAN.** It cannot be installed at all any more. Only `zmtelemetry.pl` uses it.

### Verification

Ran the corrected instructions end to end on macOS 26, Apple Silicon: schema loaded and `zmupdate.pl` reporting success, `zmdc`/`zmwatch`/`zmstats`/`zmfilter` running, a monitor reaching `Monitor_Status: Connected` with a 7.3 MB mapped memory file, events recorded to disk with their frame rows, and the web interface returning `<title>ZM - Console</title>` with the monitor listed and no PHP errors.

The opening section now says as much, and still points at the gaps rather than overselling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5KL9Xbi7K5aGsauLtd8tG